### PR TITLE
Dotnet runtime slices

### DIFF
--- a/slices/dotnet-host.yaml
+++ b/slices/dotnet-host.yaml
@@ -1,0 +1,15 @@
+package: dotnet-host
+
+slices:
+    bins:
+        essential:
+            - libc6_config
+            - libc6_libs
+            - libgcc-s1_libs
+            - libstdc++6_libs
+        contents:
+            /usr/lib/dotnet/dotnet6-*/dotnet:
+           
+    config:
+        contents:
+            /etc/profile.d/dotnet.sh:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -1,0 +1,15 @@
+package: dotnet-hostfxr-6.0
+
+slices:
+    libs:
+        essential:
+            - dotnet-host_bins
+            - dotnet-host_config
+            - libc6_config
+            - libc6_libs
+            - libgcc-s1_libs
+            - libstdc++6_libs
+
+        contents:
+           /usr/lib/dotnet/dotnet6-*/host/fxr/*/libhostfxr.so:
+           

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -1,0 +1,23 @@
+package: dotnet-runtime-6.0
+
+slices:
+    bins:
+        essential:
+            - dotnet-hostfxr-6.0_libs
+            - libc6_config
+            - libc6_libs
+            - libgcc-s1_libs
+            - libicu70_libs
+            - liblttng-ust1_libs
+            - libssl3_libs
+            - libstdc++6_libs
+            - libunwind-13_libs
+            - zlib1g_libs
+
+        contents:
+           /usr/lib/dotnet/dotnet6-*/shared/Microsoft.NETCore.App/*/*.dll:
+           /usr/lib/dotnet/dotnet6-*/shared/Microsoft.NETCore.App/*/*.so:
+
+    config:
+        contents:
+           /usr/lib/dotnet/dotnet6-*/shared/Microsoft.NETCore.App/*/*.json:

--- a/slices/liblttng-ust-common1.yaml
+++ b/slices/liblttng-ust-common1.yaml
@@ -1,0 +1,11 @@
+package: liblttng-ust-common1
+
+slices:
+    libs:
+        essential:
+            - libc6_config
+            - libc6_libs
+
+        contents:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-common.so.*:
+

--- a/slices/liblttng-ust-ctl5.yaml
+++ b/slices/liblttng-ust-ctl5.yaml
@@ -1,0 +1,13 @@
+package: liblttng-ust-ctl5
+
+slices:
+    libs:
+        essential:
+            - libc6_config
+            - libc6_libs
+            - liblttng-ust-common1_libs
+            - libnuma1_libs
+
+        contents:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-ctl.so.*:
+

--- a/slices/liblttng-ust1.yaml
+++ b/slices/liblttng-ust1.yaml
@@ -1,0 +1,21 @@
+package: liblttng-ust1
+
+slices:
+    libs:
+        essential:
+            - libc6_config
+            - libc6_libs
+            - liblttng-ust-common1_libs
+            - liblttng-ust-ctl5_libs
+            - libnuma1_libs
+
+        contents:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-cyg-profile-fast.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-cyg-profile.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-dl.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-fd.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-fork.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-libc-wrapper.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-pthread-wrapper.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust-tracepoint.so.*:
+           /usr/lib/x86_64-linux-gnu/liblttng-ust.so.*:

--- a/slices/libnuma1.yaml
+++ b/slices/libnuma1.yaml
@@ -1,0 +1,11 @@
+package: libnuma1
+
+slices:
+    libs:
+        essential:
+            - libc6_config
+            - libc6_libs
+
+        contents:
+           /usr/lib/x86_64-linux-gnu/libnuma.so.*:
+

--- a/slices/libunwind-13.yaml
+++ b/slices/libunwind-13.yaml
@@ -1,0 +1,13 @@
+package: libunwind-13
+
+slices:
+    libs:
+        essential:
+            - libc6_config
+            - libc6_libs
+
+        contents:
+            /usr/lib/llvm-13/lib/libunwind.so.*:
+            /usr/lib/x86_64-linux-gnu/libunwind.so.*:
+
+


### PR DESCRIPTION
These slices are the same as the ones proposed for the dotnet rocks repo.
Now using globs to avoid dotnet version dependencies in paths.
Still waiting on the dotnet package publishing to universe so it can find the packages in the archive.