### PR TITLE
Select arch-specific paths by globs

### DIFF
--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -3,28 +3,28 @@ package: libc6
 slices:
   config:
     contents:
-      /etc/ld.so.conf.d/x86_64-linux-gnu.conf:
+      /etc/ld.so.conf.d/*-linux-*.conf:
 
   libs:
     contents:
-      /lib/x86_64-linux-gnu/ld-linux-x86-64.so.*:
-      /lib/x86_64-linux-gnu/libBrokenLocale.so.*:
-      /lib/x86_64-linux-gnu/libanl.so.*:
-      /lib/x86_64-linux-gnu/libc.so.*:
-      /lib/x86_64-linux-gnu/libc_malloc_debug.so.*:
-      /lib/x86_64-linux-gnu/libdl.so.*:
-      /lib/x86_64-linux-gnu/libm.so.*:
-      /lib/x86_64-linux-gnu/libmemusage.so:
-      /lib/x86_64-linux-gnu/libmvec.so.*:
-      /lib/x86_64-linux-gnu/libnsl.so.*:
-      /lib/x86_64-linux-gnu/libnss_compat.so.*:
-      /lib/x86_64-linux-gnu/libnss_dns.so.*:
-      /lib/x86_64-linux-gnu/libnss_files.so.*:
-      /lib/x86_64-linux-gnu/libnss_hesiod.so.*:
-      /lib/x86_64-linux-gnu/libpcprofile.so:
-      /lib/x86_64-linux-gnu/libpthread.so.*:
-      /lib/x86_64-linux-gnu/libresolv.so.*:
-      /lib/x86_64-linux-gnu/librt.so.*:
-      /lib/x86_64-linux-gnu/libthread_db.so.*:
-      /lib/x86_64-linux-gnu/libutil.so.*:
-      /lib64/ld-linux-x86-64.so.*:
+      /lib/*-linux-*/ld*.so.*:
+      /lib/*-linux-*/libBrokenLocale.so.*:
+      /lib/*-linux-*/libanl.so.*:
+      /lib/*-linux-*/libc.so.*:
+      /lib/*-linux-*/libc_malloc_debug.so.*:
+      /lib/*-linux-*/libdl.so.*:
+      /lib/*-linux-*/libm.so.*:
+      /lib/*-linux-*/libmemusage.so:
+      /lib/*-linux-*/libmvec.so.*: {arch: amd64}
+      /lib/*-linux-*/libnsl.so.*:
+      /lib/*-linux-*/libnss_compat.so.*:
+      /lib/*-linux-*/libnss_dns.so.*:
+      /lib/*-linux-*/libnss_files.so.*:
+      /lib/*-linux-*/libnss_hesiod.so.*:
+      /lib/*-linux-*/libpcprofile.so:
+      /lib/*-linux-*/libpthread.so.*:
+      /lib/*-linux-*/libresolv.so.*:
+      /lib/*-linux-*/librt.so.*:
+      /lib/*-linux-*/libthread_db.so.*:
+      /lib/*-linux-*/libutil.so.*:
+      /lib*/ld*.so.*:

--- a/slices/libcom-err2.yaml
+++ b/slices/libcom-err2.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/x86_64-linux-gnu/libcom_err.so.*:
+      /lib/*-linux-*/libcom_err.so.*:

--- a/slices/libcrypt1.yaml
+++ b/slices/libcrypt1.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/x86_64-linux-gnu/libcrypt.so.*:
+      /lib/*-linux-*/libcrypt.so.*:

--- a/slices/libgcc-s1.yaml
+++ b/slices/libgcc-s1.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/x86_64-linux-gnu/libgcc_s.so.*:
+      /lib/*-linux-*/libgcc_s.so.*:

--- a/slices/libgssapi-krb5-2.yaml
+++ b/slices/libgssapi-krb5-2.yaml
@@ -10,4 +10,4 @@ slices:
       - libkrb5support0_libs
     contents:
       /etc/gss/mech.d/:
-      /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.*:
+      /usr/lib/*-linux-*/libgssapi_krb5.so.*:

--- a/slices/libicu70.yaml
+++ b/slices/libicu70.yaml
@@ -7,9 +7,9 @@ slices:
       - libgcc-s1_libs
       - libstdc++6_libs
     contents:
-      /usr/lib/x86_64-linux-gnu/libicudata.so.*:
-      /usr/lib/x86_64-linux-gnu/libicui18n.so.*:
-      /usr/lib/x86_64-linux-gnu/libicuio.so.*:
-      /usr/lib/x86_64-linux-gnu/libicutest.so.*:
-      /usr/lib/x86_64-linux-gnu/libicutu.so.*:
-      /usr/lib/x86_64-linux-gnu/libicuuc.so.*:
+      /usr/lib/*-linux-*/libicudata.so.*:
+      /usr/lib/*-linux-*/libicui18n.so.*:
+      /usr/lib/*-linux-*/libicuio.so.*:
+      /usr/lib/*-linux-*/libicutest.so.*:
+      /usr/lib/*-linux-*/libicutu.so.*:
+      /usr/lib/*-linux-*/libicuuc.so.*:

--- a/slices/libk5crypto3.yaml
+++ b/slices/libk5crypto3.yaml
@@ -6,4 +6,4 @@ slices:
       - libc6_libs
       - libkrb5support0_libs
     contents:
-      /usr/lib/x86_64-linux-gnu/libk5crypto.so.*:
+      /usr/lib/*-linux-*/libk5crypto.so.*:

--- a/slices/libkeyutils1.yaml
+++ b/slices/libkeyutils1.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/x86_64-linux-gnu/libkeyutils.so.*:
+      /lib/*-linux-*/libkeyutils.so.*:

--- a/slices/libkrb5-3.yaml
+++ b/slices/libkrb5-3.yaml
@@ -10,6 +10,6 @@ slices:
       - libkrb5support0_libs
       - libssl3_libs
     contents:
-      /usr/lib/x86_64-linux-gnu/krb5/plugins/libkrb5/:
-      /usr/lib/x86_64-linux-gnu/krb5/plugins/preauth/spake.so:
-      /usr/lib/x86_64-linux-gnu/libkrb5.so.*:
+      /usr/lib/*-linux-*/krb5/plugins/libkrb5/:
+      /usr/lib/*-linux-*/krb5/plugins/preauth/spake.so:
+      /usr/lib/*-linux-*/libkrb5.so.*:

--- a/slices/libkrb5support0.yaml
+++ b/slices/libkrb5support0.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/x86_64-linux-gnu/libkrb5support.so.*:
+      /usr/lib/*-linux-*/libkrb5support.so.*:

--- a/slices/libssl3.yaml
+++ b/slices/libssl3.yaml
@@ -5,9 +5,9 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/x86_64-linux-gnu/engines-3/afalg.so:
-      /usr/lib/x86_64-linux-gnu/engines-3/loader_attic.so:
-      /usr/lib/x86_64-linux-gnu/engines-3/padlock.so:
-      /usr/lib/x86_64-linux-gnu/libcrypto.so.*:
-      /usr/lib/x86_64-linux-gnu/libssl.so.*:
-      /usr/lib/x86_64-linux-gnu/ossl-modules/legacy.so:
+      /usr/lib/*-linux-*/engines-3/afalg.so:
+      /usr/lib/*-linux-*/engines-3/loader_attic.so:
+      /usr/lib/*-linux-*/engines-3/padlock.so:
+      /usr/lib/*-linux-*/libcrypto.so.*:
+      /usr/lib/*-linux-*/libssl.so.*:
+      /usr/lib/*-linux-*/ossl-modules/legacy.so:

--- a/slices/libstdc++6.yaml
+++ b/slices/libstdc++6.yaml
@@ -6,4 +6,4 @@ slices:
       - libc6_libs
       - libgcc-s1_libs
     contents:
-      /usr/lib/x86_64-linux-gnu/libstdc++.so.*:
+      /usr/lib/*-linux-*/libstdc++.so.*:

--- a/slices/zlib1g.yaml
+++ b/slices/zlib1g.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/x86_64-linux-gnu/libz.so.*:
+      /lib/*-linux-*/libz.so.*:


### PR DESCRIPTION
Tested with chisel with commits from PR
https://github.com/canonical/chisel/pull/12 applied:

    slices="base-files_base libc6_libs libgcc-s1_libs libssl3_libs libstdc++6_libs zlib1g_libs ca-certificates_data"
    for a in amd64 arm64 armhf i386 ppc64el riscv64 s390x; do
        mkdir output-$a
        chisel cut --release ~/devel/chisel-releases/ --root $PWD/output-$a --arch $a $slices
    done