### PR TITLE
add .NET slice definition files and dependencies

### DIFF
--- a/slices/aspnetcore-runtime-6.0.yaml
+++ b/slices/aspnetcore-runtime-6.0.yaml
@@ -1,0 +1,7 @@
+package: aspnetcore-runtime-6.0
+slices:
+  libs:
+    essential:
+      - dotnet-runtime-6.0_libs
+    contents:
+      /usr/lib/dotnet/dotnet6-*/shared/Microsoft.AspNetCore.App/**:

--- a/slices/dotnet-host.yaml
+++ b/slices/dotnet-host.yaml
@@ -1,0 +1,9 @@
+package: dotnet-host
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/dotnet/dotnet6-*/dotnet:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -1,0 +1,10 @@
+package: dotnet-hostfxr-6.0
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - dotnet-host_bins
+    contents:
+      /usr/lib/dotnet/dotnet6-*/host/fxr/*/libhostfxr.so:

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -1,0 +1,16 @@
+package: dotnet-runtime-6.0
+slices:
+  libs:
+    essential:
+      - dotnet-hostfxr-6.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libicu70_libs
+      - liblttng-ust1_libs
+      - libssl3_libs
+      - libstdc++6_libs
+      - libunwind-13_libs
+      - libunwind8_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/dotnet/dotnet6-*/shared/Microsoft.NETCore.App/**:

--- a/slices/liblttng-ust-common1.yaml
+++ b/slices/liblttng-ust-common1.yaml
@@ -1,0 +1,7 @@
+package: liblttng-ust-common1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-common.so.*:

--- a/slices/liblttng-ust-ctl5.yaml
+++ b/slices/liblttng-ust-ctl5.yaml
@@ -1,0 +1,9 @@
+package: liblttng-ust-ctl5
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblttng-ust-common1_libs
+      - libnuma1_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-ctl.so.*:

--- a/slices/liblttng-ust1.yaml
+++ b/slices/liblttng-ust1.yaml
@@ -1,0 +1,18 @@
+package: liblttng-ust1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblttng-ust-common1_libs
+      - liblttng-ust-ctl5_libs
+      - libnuma1_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-cyg-profile-fast.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-cyg-profile.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-dl.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-fd.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-fork.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-libc-wrapper.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-pthread-wrapper.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-tracepoint.so.*:
+      /usr/lib/*-linux-*/liblttng-ust.so.*:

--- a/slices/liblzma5.yaml
+++ b/slices/liblzma5.yaml
@@ -1,0 +1,7 @@
+package: liblzma5
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/liblzma.so.*:

--- a/slices/libnuma1.yaml
+++ b/slices/libnuma1.yaml
@@ -1,0 +1,7 @@
+package: libnuma1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnuma.so.*:

--- a/slices/libunwind-13.yaml
+++ b/slices/libunwind-13.yaml
@@ -1,0 +1,10 @@
+package: libunwind-13
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/llvm-13/lib/libunwind.so.1.*:
+      /usr/lib/llvm-13/lib/libunwind.so.1:
+      /usr/lib/*-linux-*/libunwind.so.1.*:
+      /usr/lib/*-linux-*/libunwind.so.1:

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -1,0 +1,10 @@
+package: libunwind8
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblzma5_libs
+    contents:
+      /usr/lib/*-linux-*/libunwind-*.so.*:
+      /usr/lib/*-linux-*/libunwind.so.8.*:
+      /usr/lib/*-linux-*/libunwind.so.8:


### PR DESCRIPTION
The .NET packages are now in `jammy-updates`, so this PR includes the SDFs (very similar to the ones in `ubuntu-22.10`'s chisel release) for the .NET family (ASP.NET included) and all their dependencies.

Tested with a modified version of Chisel capable of fetching from `<animal>-security` and `<animal>-updates`.