### PR TITLE
feat: add security and updates suites to 22.10

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -4,3 +4,4 @@ archives:
     ubuntu:
         version: 22.10
         components: [main, universe]
+        suites: [kinetic, kinetic-security, kinetic-updates]


### PR DESCRIPTION
add the security and updates suites to 22.10

This was motivated by the recent release of OpenSSL, which has fixed a critical vulnerability affecting Jammy and Kinetic.