### PR TITLE
[22.04] add slice definition file for libc-bin, with nsswitch slice only

### DIFF
--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -1,0 +1,6 @@
+package: libc-bin
+
+slices:
+  nsswitch:
+    contents:
+      /etc/nsswitch.conf: {copy: /usr/share/libc-bin/nsswitch.conf}


### PR DESCRIPTION
This new slice definition file encompasses only the `nsswitch.conf` file of the libc-bin package.