### PR TITLE
[22.10] add slice definition file for libc-bin, with nsswitch slice only

### DIFF
--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -1,0 +1,7 @@
+package: libc-bin
+
+slices:
+  nsswitch:
+    contents:
+      /usr/share/libc-bin/nsswitch.conf:
+      /etc/nsswitch.conf: {copy: /usr/share/libc-bin/nsswitch.conf}


### PR DESCRIPTION
same as https://github.com/canonical/chisel-releases/pull/18