### PR TITLE
fix: dotnet* pkgs new content structure (22.04)

### DIFF
--- a/slices/dotnet-host.yaml
+++ b/slices/dotnet-host.yaml
@@ -6,4 +6,4 @@ slices:
       - libgcc-s1_libs
       - libstdc++6_libs
     contents:
-      /usr/lib/dotnet/dotnet6-*/dotnet:
+      /usr/lib/dotnet/dotnet:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -7,4 +7,4 @@ slices:
       - libstdc++6_libs
       - dotnet-host_bins
     contents:
-      /usr/lib/dotnet/dotnet6-*/host/fxr/*/libhostfxr.so:
+      /usr/lib/dotnet/host/fxr/*/libhostfxr.so:

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -13,4 +13,4 @@ slices:
       - libunwind8_libs
       - zlib1g_libs
     contents:
-      /usr/lib/dotnet/dotnet6-*/shared/Microsoft.NETCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/**:


### PR DESCRIPTION
At the moment, due to an update of the .NET debs, Chisel will complain about:

```bash
$ chisel cut --root output dotnet-runtime-6.0_libs
(...)
2022/11/29 08:52:27 Extracting files from package "dotnet-host"...
error: cannot extract from package "dotnet-host": no content at /usr/lib/dotnet/dotnet6-*/dotnet
```

After the upgrade from .NET 6.0.110 to 6.0.111, some the of DEB content paths have eliminated intermediate folders, causing Chisel to fail to locate certain contents. This commit is fixing those paths for the affected .NET* slices.

This PR is updating the .NET* slice definitions according to the new DEBs' structures.

---
Additional info regarding the underlying .NET change: https://bugs.launchpad.net/ubuntu/+source/dotnet6/+bug/1996499

> 
> [Original Report]
> ------------------------------------------------------------------
> Now that dotnet7 is coming to Ubuntu (https://bugs.launchpad.net/ubuntu/+bug/1995478), the actual support of several versions through update-alternatives system doesn't allow future SDKs to see previous ones.
> 
> To use only a muxer (dotnet binary provided by dotnet-host package nowadays) that can see all the SDKs, shared, templates, etc... the new layout has to be like this: https://learn.microsoft.com/en-us/dotnet/core/distribution-packaging.
> 
> To finish, remove the use of update-alternatives.