### PR TITLE
fix: dotnet* pkgs new content structure (22.10)

### DIFF
--- a/slices/dotnet-host.yaml
+++ b/slices/dotnet-host.yaml
@@ -6,4 +6,4 @@ slices:
       - libgcc-s1_libs
       - libstdc++6_libs
     contents:
-      /usr/lib/dotnet/dotnet6-*/dotnet:
+      /usr/lib/dotnet/dotnet:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -7,4 +7,4 @@ slices:
       - libstdc++6_libs
       - dotnet-host_bins
     contents:
-      /usr/lib/dotnet/dotnet6-*/host/fxr/*/libhostfxr.so:
+      /usr/lib/dotnet/host/fxr/*/libhostfxr.so:

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -13,4 +13,4 @@ slices:
       - libunwind8_libs
       - zlib1g_libs
     contents:
-      /usr/lib/dotnet/dotnet6-*/shared/Microsoft.NETCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/**:


### PR DESCRIPTION
(same as https://github.com/canonical/chisel-releases/pull/23, but for Kinetic)