### PR TITLE
fix: aspnetcore-runtime-6.0 new content structure (22.04)

### DIFF
--- a/slices/aspnetcore-runtime-6.0.yaml
+++ b/slices/aspnetcore-runtime-6.0.yaml
@@ -4,4 +4,4 @@ slices:
     essential:
       - dotnet-runtime-6.0_libs
     contents:
-      /usr/lib/dotnet/dotnet6-*/shared/Microsoft.AspNetCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/**:


### PR DESCRIPTION
Same reason as for https://github.com/canonical/chisel-releases/pull/23. In that PR, ASPNET was forgotten, but apparently, it has also suffered the same restructuring as all other .NET runtime packages.