### PR TITLE
fix: aspnetcore-runtime-6.0 new content structure (22.10)

### DIFF
--- a/slices/aspnetcore-runtime-6.0.yaml
+++ b/slices/aspnetcore-runtime-6.0.yaml
@@ -4,4 +4,4 @@ slices:
     essential:
       - dotnet-runtime-6.0_libs
     contents:
-      /usr/lib/dotnet/dotnet6-*/shared/Microsoft.AspNetCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/**:


### PR DESCRIPTION
analogous to https://github.com/canonical/chisel-releases/pull/26