### PR TITLE
feat: .NET7 in Kinetic

### DIFF
--- a/slices/aspnetcore-runtime-6.0.yaml
+++ b/slices/aspnetcore-runtime-6.0.yaml
@@ -4,4 +4,4 @@ slices:
     essential:
       - dotnet-runtime-6.0_libs
     contents:
-      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/6*/**:

--- a/slices/aspnetcore-runtime-7.0.yaml
+++ b/slices/aspnetcore-runtime-7.0.yaml
@@ -1,0 +1,7 @@
+package: aspnetcore-runtime-7.0
+slices:
+  libs:
+    essential:
+      - dotnet-runtime-7.0_libs
+    contents:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/7*/**:

--- a/slices/dotnet-host-7.0.yaml
+++ b/slices/dotnet-host-7.0.yaml
@@ -1,0 +1,14 @@
+package: dotnet-host-7.0
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      # This copy is done to avoid Chisel's current handling of conflicts, as
+      # it flags a conflict between this slice and .NET6's, even if the two
+      # are not being installed at the same time.
+      # TODO: once Chisel can cope with duplicate contents within the same
+      # release, this copy can be suppressed
+      /usr/lib/dotnet/dotnet7:  {copy: /usr/lib/dotnet/dotnet}

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -7,4 +7,4 @@ slices:
       - libstdc++6_libs
       - dotnet-host_bins
     contents:
-      /usr/lib/dotnet/host/fxr/*/libhostfxr.so:
+      /usr/lib/dotnet/host/fxr/6*/libhostfxr.so:

--- a/slices/dotnet-hostfxr-7.0.yaml
+++ b/slices/dotnet-hostfxr-7.0.yaml
@@ -1,0 +1,10 @@
+package: dotnet-hostfxr-7.0
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - dotnet-host-7.0_bins
+    contents:
+      /usr/lib/dotnet/host/fxr/7*/libhostfxr.so:

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -13,4 +13,4 @@ slices:
       - libunwind8_libs
       - zlib1g_libs
     contents:
-      /usr/lib/dotnet/shared/Microsoft.NETCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/6*/**:

--- a/slices/dotnet-runtime-7.0.yaml
+++ b/slices/dotnet-runtime-7.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-runtime-7.0
+slices:
+  libs:
+    essential:
+      - dotnet-hostfxr-7.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - liblttng-ust1_libs
+      - libssl3_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/7*/**:


### PR DESCRIPTION
needs https://github.com/canonical/chisel/issues/50

### Changes

 - add new slice definitions files for .NET7
 - modify globs in .NET6 slice definitions files, to avoid path conflicts in Chisel

### Definition of Ready

 - atm, `dotnet-host-7.0` is avoiding Chiselling conflicts by [copying](https://github.com/canonical/chisel-releases/compare/ubuntu-23.04...cjdcordeiro:chisel-releases:ROCKS-358_dotnet7-lunar?expand=1#diff-9f0a818a394029a5f24e7f27fd58bf32639e2e1249f744f48d141979f25689a9R14) the `dotnet` binary instead of inheriting its full name and path. If we merge it now and later fix the `dotnet` path, we will create a regression for those already chiselling .net7. Once https://github.com/canonical/chisel/issues/50 is done, this PR can be updated and then merged