### PR TITLE
feat: add stunnel slices for jammy

### DIFF
--- a/slices/libcap2.yaml
+++ b/slices/libcap2.yaml
@@ -1,0 +1,8 @@
+package: libcap2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libcap.so.2*:

--- a/slices/libgcrypt20.yaml
+++ b/slices/libgcrypt20.yaml
@@ -1,0 +1,9 @@
+package: libgcrypt20
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgpg-error0_libs
+    contents:
+      /usr/lib/*-linux-*/libgcrypt.so.20*:

--- a/slices/libgpg-error0.yaml
+++ b/slices/libgpg-error0.yaml
@@ -1,0 +1,8 @@
+package: libgpg-error0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libgpg-error.so.0*:

--- a/slices/liblz4-1.yaml
+++ b/slices/liblz4-1.yaml
@@ -1,0 +1,8 @@
+package: liblz4-1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblz4.so.1*:

--- a/slices/libnsl2.yaml
+++ b/slices/libnsl2.yaml
@@ -1,0 +1,9 @@
+package: libnsl2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libtirpc3_libs
+    contents:
+      /usr/lib/*-linux-*/libnsl.so.2*:

--- a/slices/libsystemd0.yaml
+++ b/slices/libsystemd0.yaml
@@ -1,0 +1,13 @@
+package: libsystemd0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcap2_libs
+      - libgcrypt20_libs
+      - liblz4-1_libs
+      - liblzma5_libs
+      - libzstd1_libs
+    contents:
+      /usr/lib/*-linux-*/libsystemd.so.0*:

--- a/slices/libtirpc-common.yaml
+++ b/slices/libtirpc-common.yaml
@@ -1,0 +1,6 @@
+package: libtirpc-common
+
+slices:
+  common:
+    contents:
+      /etc/netconfig:

--- a/slices/libtirpc3.yaml
+++ b/slices/libtirpc3.yaml
@@ -1,0 +1,10 @@
+package: libtirpc3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgssapi-krb5-2_libs
+      - libtirpc-common_common
+    contents:
+      /lib/*-linux-*/libtirpc.so.3*:

--- a/slices/libwrap0.yaml
+++ b/slices/libwrap0.yaml
@@ -1,0 +1,9 @@
+package: libwrap0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnsl2_libs
+    contents:
+      /usr/lib/*-linux-*/libwrap.so.0*:

--- a/slices/libzstd1.yaml
+++ b/slices/libzstd1.yaml
@@ -1,0 +1,8 @@
+package: libzstd1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libzstd.so.1*:

--- a/slices/stunnel4.yaml
+++ b/slices/stunnel4.yaml
@@ -1,0 +1,17 @@
+package: stunnel4
+
+slices:
+  bins:
+    essential:
+      - libc6_config
+      - libc6_libs
+      - libssl3_libs
+      - libsystemd0_libs
+      - libwrap0_libs
+      - openssl_config
+      - stunnel4_libs
+    contents:
+      /usr/bin/stunnel*:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/stunnel/libstunnel.so:


### PR DESCRIPTION
This PR adds a bunch of slices which are required for the `stunnel` slice (also included) to run.

Execution of the `stunnel` slice:

```
$ docker run -it base_image_debug:22.04
[ ] Initializing inetd mode configuration
[ ] Clients allowed=512000
[.] stunnel 5.63 on x86_64-pc-linux-gnu platform
[.] Compiled/running with OpenSSL 3.0.2 15 Mar 2022
[.] Threading:PTHREAD Sockets:POLL,IPv6,SYSTEMD TLS:ENGINE,OCSP,PSK,SNI Auth:LIBWRAP
```

Example Dockerfile:

```
ARG UBUNTU_RELEASE=22.04
ARG USER=app
ARG UID=101
ARG GROUP=app
ARG GID=101

FROM golang:1.20 AS chisel
ARG UBUNTU_RELEASE
RUN git clone -b stunnel-slices https://github.com/kholia/chisel-releases /opt/chisel-releases \
    && git clone --depth 1 -b main https://github.com/kholia/chisel /opt/chisel
WORKDIR /opt/chisel
RUN go generate internal/deb/version.go \
    && go build ./cmd/chisel

FROM public.ecr.aws/ubuntu/ubuntu:$UBUNTU_RELEASE AS builder
SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
RUN apt-get update \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates busybox-static \
    && apt-get clean -y \
    && rm -rf /var/lib/apt/lists/*
COPY --from=chisel /opt/chisel/chisel /usr/bin/

### BOILERPLATE END ###

FROM builder AS sliced-deps
ARG USER
ARG UID
ARG GROUP
ARG GID
SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
RUN mkdir -p /rootfs \
      && chisel cut --release /opt/chisel-releases --root /rootfs \
        base-files_base \
        base-files_release-info \
        ca-certificates_data \
        libc6_libs \
        stunnel4_bins

RUN find /rootfs

RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd

FROM scratch
ARG USER
ARG UID
ARG GID
USER $UID:$GID
COPY --from=sliced-deps /rootfs /
COPY --from=sliced-deps /bin/busybox /bin
COPY --from=sliced-deps /tmp/urls.txt /root/packages.txt
# Workaround for https://github.com/moby/moby/issues/38710
COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
ENTRYPOINT ["/usr/bin/stunnel4"]
```

```
$ docker images | grep base             
base_image_debug                            22.04     66dae527e735   About a minute ago   18.7MB
```

Thanks for considering this pull request - cheers!