### PR TITLE
feat: libapr1 - Apache Tomcat dependency

### DIFF
--- a/slices/libapr1.yaml
+++ b/slices/libapr1.yaml
@@ -1,0 +1,9 @@
+package: libapr1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libuuid1_libs
+    contents:
+      /usr/lib/*-linux-*/libapr-1.so.0*:


### PR DESCRIPTION
This is a draft PR that adds Apache Portable library slice for Apache Tomcat native extensions. It is required to run OpenSSL TLS backend in Apache Tomcat.

Sample docker [file](https://github.com/vpa1977/chiselled-jre/blob/samples-for-17/benchmark/acmeair-tomcat/Dockerfile.distroless)

Testing:

```
$ docker build -t tomcat . -f Dockerfile.distroless 
[+] Building 2.5s (29/29) FINISHED                                              
 => [internal] load build definition from Dockerfile.distroless            0.0s
 => => transferring dockerfile: 2.68kB                                     0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [internal] load metadata for docker.io/ubuntu/jre:17_edge              0.0s
 => [internal] load metadata for public.ecr.aws/ubuntu/ubuntu:22.04@sha25  1.9s
 => [internal] load metadata for docker.io/library/golang:1.18             1.9s
 => [chisel 1/4] FROM docker.io/library/golang:1.18@sha256:50c889275d26f8  0.0s
 => [builder 1/8] FROM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:5f6d7e4d  0.0s
 => [stage-3 1/6] FROM docker.io/ubuntu/jre:17_edge                        0.0s
 => [internal] load build context                                          0.0s
 => => transferring context: 153B                                          0.0s
 => CACHED [stage-3 2/6] WORKDIR /usr/local/tomcat                         0.0s
 => CACHED [builder 2/8] RUN apt-get update     && DEBIAN_FRONTEND=nonint  0.0s
 => CACHED [chisel 2/4] RUN git clone -b tomcat-dependencies https://gith  0.0s
 => CACHED [chisel 3/4] WORKDIR /opt/chisel                                0.0s
 => CACHED [chisel 4/4] RUN go generate internal/deb/version.go     && go  0.0s
 => CACHED [builder 3/8] COPY --from=chisel /opt/chisel/chisel /usr/bin/   0.0s
 => CACHED [builder 4/8] RUN mkdir -p "/usr/local/tomcat"                  0.0s
 => CACHED [builder 5/8] WORKDIR /usr/local/tomcat                         0.0s
 => CACHED [builder 6/8] ADD build-tomcat.sh /                             0.0s
 => CACHED [builder 7/8] RUN /build-tomcat.sh                              0.0s
 => CACHED [builder 8/8] RUN rm /build-tomcat.sh                           0.0s
 => CACHED [sliced-deps 1/4] COPY --from=chisel /opt/chisel-releases /opt  0.0s
 => CACHED [sliced-deps 2/4] RUN mkdir -p /rootfs     && chisel cut --rel  0.0s
 => CACHED [sliced-deps 3/4] RUN cd /rootfs/bin && for applet in $(busybo  0.0s
 => CACHED [sliced-deps 4/4] RUN mkdir -p /rootfs/usr/local/tomcat     &&  0.0s
 => CACHED [stage-3 3/6] COPY --from=sliced-deps /rootfs /                 0.0s
 => CACHED [stage-3 4/6] RUN set -eux;     nativeLines="$(catalina.sh con  0.0s
 => CACHED [stage-3 5/6] ADD config/server.xml /usr/local/tomcat/conf/ser  0.0s
 => [stage-3 6/6] ADD acmeair-java-2.0.0-SNAPSHOT.war /usr/local/tomcat/w  0.1s
 => exporting to image                                                     0.3s
 => => exporting layers                                                    0.3s
 => => writing image sha256:264bba104a45c10e6ea9f48a951c521e5dd982970d5f9  0.0s
 => => naming to docker.io/library/tomcat                                  0.0s

$ docker run tomcat
23-Jun-2023 02:07:20.815 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server version name:   Apache Tomcat/10.1.9
23-Jun-2023 02:07:20.816 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server built:          May 9 2023 14:30:05 UTC
23-Jun-2023 02:07:20.816 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server version number: 10.1.9.0
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log OS Name:               Linux
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log OS Version:            6.2.0-23-generic
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Architecture:          amd64
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Java Home:             /opt/java
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log JVM Version:           17.0.7+7-Ubuntu-0ubuntu122.04.2
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log JVM Vendor:            Private Build
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log CATALINA_BASE:         /usr/local/tomcat
23-Jun-2023 02:07:20.817 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log CATALINA_HOME:         /usr/local/tomcat
23-Jun-2023 02:07:20.821 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
23-Jun-2023 02:07:20.821 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
23-Jun-2023 02:07:20.821 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djdk.tls.ephemeralDHKeySize=2048
23-Jun-2023 02:07:20.821 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.lang=ALL-UNNAMED
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.io=ALL-UNNAMED
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.util=ALL-UNNAMED
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Dcatalina.base=/usr/local/tomcat
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Dcatalina.home=/usr/local/tomcat
23-Jun-2023 02:07:20.822 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.io.tmpdir=/usr/local/tomcat/temp
23-Jun-2023 02:07:20.823 INFO [main] org.apache.catalina.core.AprLifecycleListener.lifecycleEvent Loaded Apache Tomcat Native library [2.0.3] using APR version [1.7.0].
23-Jun-2023 02:07:20.825 INFO [main] org.apache.catalina.core.AprLifecycleListener.initializeSSL OpenSSL successfully initialized [OpenSSL 3.0.2 15 Mar 2022]
23-Jun-2023 02:07:20.914 INFO [main] org.apache.coyote.AbstractProtocol.init Initializing ProtocolHandler ["http-nio-8080"]
23-Jun-2023 02:07:20.922 INFO [main] org.apache.catalina.startup.Catalina.load Server initialization in [183] milliseconds
23-Jun-2023 02:07:20.933 INFO [main] org.apache.catalina.core.StandardService.startInternal Starting service [Catalina]
23-Jun-2023 02:07:20.933 INFO [main] org.apache.catalina.core.StandardEngine.startInternal Starting Servlet engine: [Apache Tomcat/10.1.9]
```