### PR TITLE
feat: Add Java 17 runtime dependencies

### DIFF
--- a/slices/libglib2.0-0.yaml
+++ b/slices/libglib2.0-0.yaml
@@ -1,7 +1,7 @@
 package: libglib2.0-0
 
 slices:
-  glib:
+  core:
     essential:
       - libc6_libs
       - libpcre3_libs
@@ -10,7 +10,7 @@ slices:
 
   libs:
     essential:
-      - libglib2.0-0_glib
+      - libglib2.0-0_core
       - libffi8_libs
       - libmount1_libs
       - libselinux1_libs

--- a/slices/libglib2.0-0.yaml
+++ b/slices/libglib2.0-0.yaml
@@ -1,17 +1,22 @@
 package: libglib2.0-0
 
 slices:
-  libs:
+  glib:
     essential:
       - libc6_libs
+      - libpcre3_libs
+    contents:
+      /usr/lib/*-linux-*/libglib-2.0.so.0*:
+
+  libs:
+    essential:
+      - libglib2.0-0_glib
       - libffi8_libs
       - libmount1_libs
-      - libpcre3_libs
       - libselinux1_libs
       - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/libgio-2.0.so.0*:
-      /usr/lib/*-linux-*/libglib-2.0.so.0*:
       /usr/lib/*-linux-*/libgmodule-2.0.so.0*:
       /usr/lib/*-linux-*/libgobject-2.0.so.0*:
       /usr/lib/*-linux-*/libgthread-2.0.so.0*:

--- a/slices/libgraphite2-3.yaml
+++ b/slices/libgraphite2-3.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/*-linux-gnu/libgraphite2.so*:
+      /usr/lib/*-linux-*/libgraphite2.so*:

--- a/slices/libgraphite2-3.yaml
+++ b/slices/libgraphite2-3.yaml
@@ -1,0 +1,8 @@
+package: libgraphite2-3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-gnu/libgraphite2.so*:


### PR DESCRIPTION
This PR adds libraries that Java 17 links against:  a separate slice of `libglib2` and `libgraphite2-3`

Sample docker [file](https://github.com/vpa1977/chiselled-jre/blob/mandatory-slices-demo/jre/Dockerfile.22.04).

Testing:
```
$ docker build -t jre . -f Dockerfile.22.04 --no-cache
[+] Building 152.8s (21/21) FINISHED                                                                                                                                                                    
 => [internal] load build definition from Dockerfile.22.04                                                                                                                                         0.0s
 => => transferring dockerfile: 38B                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                  0.0s
 => => transferring context: 32B                                                                                                                                                                   0.0s
 => [internal] load metadata for public.ecr.aws/ubuntu/ubuntu:22.04@sha256:2c1168b31e636c7ab22598bfaefa6de63d1806a908d0c39bd402277881356fab                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.18                                                                                                                                     1.7s
 => CACHED [chisel 1/4] FROM docker.io/library/golang:1.18@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da                                                                 0.0s
 => CACHED [builder 1/6] FROM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:2c1168b31e636c7ab22598bfaefa6de63d1806a908d0c39bd402277881356fab                                                           0.0s
 => [builder 2/6] RUN apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates         ca-certificates-java         binutils         openjdk-17-jdk     && apt-g  126.8s
 => [chisel 2/4] RUN git clone -b jre17-mandatory https://github.com/vpa1977/chisel-releases /opt/chisel-releases     && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chi  3.5s
 => [chisel 3/4] WORKDIR /opt/chisel                                                                                                                                                               1.1s
 => [chisel 4/4] RUN go generate internal/deb/version.go     && go build ./cmd/chisel                                                                                                              5.2s
 => [builder 3/6] COPY --from=chisel /opt/chisel/chisel /usr/bin/                                                                                                                                  0.8s 
 => [builder 4/6] RUN jlink --no-header-files --no-man-pages --strip-debug     --add-modules java.base,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.managemen  3.2s 
 => [builder 5/6] WORKDIR /opt/java                                                                                                                                                                0.9s 
 => [builder 6/6] RUN tar zcvf legal.tar.gz legal && rm -r legal                                                                                                                                   1.2s 
 => [sliced-deps 1/4] COPY --from=chisel /opt/chisel-releases /opt/chisel-releases                                                                                                                 0.9s 
 => [sliced-deps 2/4] RUN mkdir -p /rootfs     && chisel cut --release /opt/chisel-releases --root /rootfs         libc6_libs         libgcc-s1_libs         libstdc++6_libs         zlib1g_libs  13.4s
 => [sliced-deps 3/4] RUN install -d -m 0755 -o 101 -g 101 /rootfs/home/app     && mkdir -p /rootfs/etc     && echo -e "root:x:0:\napp:x:101:" >/rootfs/etc/group     && echo -e "root:x:0:0:root  1.2s
 => [sliced-deps 4/4] COPY --from=builder /opt/java/ /rootfs/opt/java/                                                                                                                             1.0s
 => [stage-3 1/2] COPY --from=sliced-deps /rootfs /                                                                                                                                                0.3s
 => [stage-3 2/2] COPY --from=sliced-deps --chown=101:101 /rootfs/home/app /home/app                                                                                                               0.1s
 => exporting to image                                                                                                                                                                             0.9s
 => => exporting layers                                                                                                                                                                            0.9s
 => => writing image sha256:5fc0f737f3013f30999a5592306b372ffda1b36d2cf29b1632747a57e04f850c                                                                                                       0.0s
 => => naming to docker.io/library/jre                                                                                                                                                             0.0s
$ docker run jre17 -version
openjdk version "17.0.7" 2023-04-18
OpenJDK Runtime Environment (build 17.0.7+7-Ubuntu-0ubuntu122.04.2)
OpenJDK 64-Bit Server VM (build 17.0.7+7-Ubuntu-0ubuntu122.04.2, mixed mode)
```

Note, Java 17 docker uses `jlink` as opposed to slices installation as it is required to supply 'lib/modules' file that only contains modules relevant for the runtime. 


