### PR TITLE
feat: add basic slice definitions files for Focal

### DIFF
--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -1,0 +1,61 @@
+package: base-files
+
+slices:
+  base:
+    essential:
+      - base-files_etc
+      - base-files_bin
+      - base-files_lib
+      - base-files_tmp
+      - base-files_var
+      - base-files_home
+
+  etc:
+    contents:
+      /etc/:
+
+  bin:
+    contents:
+      /bin/:
+      /sbin/:
+      /usr/bin/:
+      /usr/sbin/:
+
+  lib:
+    contents:
+      /lib/:
+      /usr/lib/:
+
+  tmp:
+    contents:
+      /tmp/:
+
+  var:
+    contents:
+      /run/:
+      /var/cache/:
+      /var/lib/:
+      /var/log/:
+      /var/run/:
+      /var/tmp/:
+
+  home:
+    contents:
+      /home/:
+      /root/:
+
+  release-info:
+    essential:
+      - base-files_etc
+      - base-files_lib
+    contents:
+      /etc/debian_version:
+      /etc/dpkg/origins/debian:
+      /etc/dpkg/origins/ubuntu:
+      /etc/dpkg/origins/default: {symlink: /etc/dpkg/origins/ubuntu}
+      /etc/host.conf:
+      /etc/issue:
+      /etc/issue.net:
+      /etc/lsb-release:
+      /etc/os-release:
+      /usr/lib/os-release:

--- a/slices/base-passwd.yaml
+++ b/slices/base-passwd.yaml
@@ -1,0 +1,14 @@
+package: base-passwd
+
+slices:
+  data:
+    contents:
+      /usr/share/base-passwd/group.master:  {until: mutate}
+      /usr/share/base-passwd/passwd.master: {until: mutate}
+      /etc/group:  {text: FIXME, mutable: true}
+      /etc/passwd: {text: FIXME, mutable: true}
+    mutate: |
+      gr = content.read("/usr/share/base-passwd/group.master")
+      content.write("/etc/group", gr)
+      pw = content.read("/usr/share/base-passwd/passwd.master")
+      content.write("/etc/passwd", pw)

--- a/slices/ca-certificates.yaml
+++ b/slices/ca-certificates.yaml
@@ -1,0 +1,12 @@
+package: ca-certificates
+
+slices:
+  data:
+    contents:
+      /etc/ssl/certs/ca-certificates.crt: {text: FIXME, mutable: true}
+      /usr/share/ca-certificates/mozilla/: {until: mutate}
+      /usr/share/ca-certificates/mozilla/*: {until: mutate}
+    mutate: |
+      certs_dir = "/usr/share/ca-certificates/mozilla/"
+      certs = [content.read(certs_dir + path) for path in content.list(certs_dir)]
+      content.write("/etc/ssl/certs/ca-certificates.crt", "".join(certs))

--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -1,0 +1,51 @@
+package: libc6
+
+slices:
+  config:
+    contents:
+      /etc/ld.so.conf.d/*-linux-*.conf:
+
+  libs:
+    contents:
+      /lib/*-linux-*/ld-*.*.so:
+      /lib/*-linux-*/ld-*.so.*:
+      /lib/*-linux-*/libBrokenLocale-*.*.so:
+      /lib/*-linux-*/libBrokenLocale.so.*:
+      /lib/*-linux-*/libSegFault.so:
+      /lib/*-linux-*/libanl-*.*.so:
+      /lib/*-linux-*/libanl.so.*:
+      /lib/*-linux-*/libc-*.*.so:
+      /lib/*-linux-*/libc.so.*:
+      /lib/*-linux-*/libdl-*.*.so:
+      /lib/*-linux-*/libdl.so.*:
+      /lib/*-linux-*/libm-*.*.so:
+      /lib/*-linux-*/libm.so.*:
+      /lib/*-linux-*/libmemusage.so:
+      /lib/*-linux-*/libmvec-*.*.so: {arch: amd64}
+      /lib/*-linux-*/libmvec.so.*: {arch: amd64}
+      /lib/*-linux-*/libnsl-*.*.so:
+      /lib/*-linux-*/libnsl.so.*:
+      /lib/*-linux-*/libnss_compat-*.*.so:
+      /lib/*-linux-*/libnss_compat.so.*:
+      /lib/*-linux-*/libnss_dns-*.*.so:
+      /lib/*-linux-*/libnss_dns.so.*:
+      /lib/*-linux-*/libnss_files-*.*.so:
+      /lib/*-linux-*/libnss_files.so.*:
+      /lib/*-linux-*/libnss_hesiod-*.*.so:
+      /lib/*-linux-*/libnss_hesiod.so.*:
+      /lib/*-linux-*/libnss_nis-*.*.so:
+      /lib/*-linux-*/libnss_nis.so.*:
+      /lib/*-linux-*/libnss_nisplus-*.*.so:
+      /lib/*-linux-*/libnss_nisplus.so.*:
+      /lib/*-linux-*/libpcprofile.so:
+      /lib/*-linux-*/libpthread-*.*.so:
+      /lib/*-linux-*/libpthread.so.*:
+      /lib/*-linux-*/libresolv-*.*.so:
+      /lib/*-linux-*/libresolv.so.*:
+      /lib/*-linux-*/librt-*.*.so:
+      /lib/*-linux-*/librt.so.*:
+      /lib/*-linux-*/libthread_db-*.*.so:
+      /lib/*-linux-*/libthread_db*.so.*:
+      /lib/*-linux-*/libutil-*.*.so:
+      /lib/*-linux-*/libutil.so.*:
+      /lib*/ld*.so.*:

--- a/slices/libgcc-s1.yaml
+++ b/slices/libgcc-s1.yaml
@@ -1,0 +1,8 @@
+package: libgcc-s1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libgcc_s.so.*:


### PR DESCRIPTION
This PR backports (from 22.04) and fits a few (the most basic and essential) slice definitions files into the new Focal Chisel release.

The affected packages are:
 - base-files
 - base-passwd
 - ca-certificates
 - libc6
 - libgcc-s1

The choice of packages was driven by our [Chiselled Ubuntu base image](https://ubuntu.com/blog/craft-custom-chiselled-ubuntu-distroless).
