### PR TITLE
focal: add python3.8 slices

### DIFF
--- a/slices/libbz2-1.0.yaml
+++ b/slices/libbz2-1.0.yaml
@@ -1,0 +1,8 @@
+package: libbz2-1.0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libbz2.so.1*:

--- a/slices/libdb5.3.yaml
+++ b/slices/libdb5.3.yaml
@@ -1,0 +1,8 @@
+package: libdb5.3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libdb-5.3.so:

--- a/slices/libmpdec2.yaml
+++ b/slices/libmpdec2.yaml
@@ -1,0 +1,8 @@
+package: libmpdec2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libmpdec.so.2*:

--- a/slices/libncursesw6.yaml
+++ b/slices/libncursesw6.yaml
@@ -1,0 +1,12 @@
+package: libncursesw6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libtinfo6_libs
+    contents:
+      /lib/*-linux-*/libncursesw.so.6*:
+      /usr/lib/*-linux-*/libformw.so.6*:
+      /usr/lib/*-linux-*/libmenuw.so.6*:
+      /usr/lib/*-linux-*/libpanelw.so.6*:

--- a/slices/libpython3.8-minimal.yaml
+++ b/slices/libpython3.8-minimal.yaml
@@ -1,0 +1,113 @@
+package: libpython3.8-minimal
+
+# Most of the Python3.8 standard libraries are split into
+# two major packages:
+# - libpython3.8-minimal (this one)
+# - libpython3.8-stdlib
+# While the libpython3.8-stdlib package has been chiselled logically
+# into granular slices, the same hasn't been done for this package.
+# The reason is simple, the libraries in this package are tightly
+# dependent upon each other.
+slices:
+  config:
+    contents:
+      /etc/python3.8/sitecustomize.py:
+
+  libs:
+    essential:
+      - libc6_libs
+      - libssl1.1_libs
+      - libpython3.8-minimal_config
+    contents:
+      /usr/lib/python3.8/__future__.py:
+      /usr/lib/python3.8/_bootlocale.py:
+      /usr/lib/python3.8/_collections_abc.py:
+      /usr/lib/python3.8/_compat_pickle.py:
+      /usr/lib/python3.8/_py_abc.py:
+      /usr/lib/python3.8/_sitebuiltins.py:
+      /usr/lib/python3.8/_strptime.py:
+      /usr/lib/python3.8/_sysconfigdata_*-linux-*.py:
+      /usr/lib/python3.8/_threading_local.py:
+      /usr/lib/python3.8/_weakrefset.py:
+      /usr/lib/python3.8/abc.py:
+      /usr/lib/python3.8/argparse.py:
+      /usr/lib/python3.8/ast.py:
+      /usr/lib/python3.8/base64.py:
+      /usr/lib/python3.8/bisect.py:
+      /usr/lib/python3.8/calendar.py:
+      /usr/lib/python3.8/codecs.py:
+      /usr/lib/python3.8/collections/**:
+      /usr/lib/python3.8/compileall.py:
+      /usr/lib/python3.8/configparser.py:
+      /usr/lib/python3.8/contextlib.py:
+      /usr/lib/python3.8/copy.py:
+      /usr/lib/python3.8/copyreg.py:
+      /usr/lib/python3.8/csv.py:
+      /usr/lib/python3.8/datetime.py:
+      /usr/lib/python3.8/dis.py:
+      /usr/lib/python3.8/email/**:
+      /usr/lib/python3.8/encodings/**:
+      /usr/lib/python3.8/enum.py:
+      /usr/lib/python3.8/fnmatch.py:
+      /usr/lib/python3.8/functools.py:
+      /usr/lib/python3.8/genericpath.py:
+      /usr/lib/python3.8/getopt.py:
+      /usr/lib/python3.8/glob.py:
+      /usr/lib/python3.8/hashlib.py:
+      /usr/lib/python3.8/heapq.py:
+      /usr/lib/python3.8/imp.py:
+      /usr/lib/python3.8/importlib/**:
+      /usr/lib/python3.8/inspect.py:
+      /usr/lib/python3.8/io.py:
+      /usr/lib/python3.8/ipaddress.py:
+      /usr/lib/python3.8/keyword.py:
+      /usr/lib/python3.8/lib-dynload/_hashlib.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_opcode.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_ssl.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/linecache.py:
+      /usr/lib/python3.8/locale.py:
+      /usr/lib/python3.8/logging/**:
+      /usr/lib/python3.8/opcode.py:
+      /usr/lib/python3.8/operator.py:
+      /usr/lib/python3.8/optparse.py:
+      /usr/lib/python3.8/os.py:
+      /usr/lib/python3.8/pathlib.py:
+      /usr/lib/python3.8/pickle.py:
+      /usr/lib/python3.8/pkgutil.py:
+      /usr/lib/python3.8/platform.py:
+      /usr/lib/python3.8/posixpath.py:
+      /usr/lib/python3.8/py_compile.py:
+      /usr/lib/python3.8/quopri.py:
+      /usr/lib/python3.8/random.py:
+      /usr/lib/python3.8/re.py:
+      /usr/lib/python3.8/reprlib.py:
+      /usr/lib/python3.8/runpy.py:
+      /usr/lib/python3.8/selectors.py:
+      /usr/lib/python3.8/signal.py:
+      /usr/lib/python3.8/site.py:
+      /usr/lib/python3.8/sitecustomize.py:
+      /usr/lib/python3.8/socket.py:
+      /usr/lib/python3.8/sre_compile.py:
+      /usr/lib/python3.8/sre_constants.py:
+      /usr/lib/python3.8/sre_parse.py:
+      /usr/lib/python3.8/ssl.py:
+      /usr/lib/python3.8/stat.py:
+      /usr/lib/python3.8/string.py:
+      /usr/lib/python3.8/stringprep.py:
+      /usr/lib/python3.8/struct.py:
+      /usr/lib/python3.8/subprocess.py:
+      /usr/lib/python3.8/sysconfig.py:
+      /usr/lib/python3.8/tempfile.py:
+      /usr/lib/python3.8/textwrap.py:
+      /usr/lib/python3.8/threading.py:
+      /usr/lib/python3.8/token.py:
+      /usr/lib/python3.8/tokenize.py:
+      /usr/lib/python3.8/traceback.py:
+      /usr/lib/python3.8/tracemalloc.py:
+      /usr/lib/python3.8/types.py:
+      /usr/lib/python3.8/urllib/**:
+      /usr/lib/python3.8/uu.py:
+      /usr/lib/python3.8/warnings.py:
+      /usr/lib/python3.8/weakref.py:
+      /usr/lib/python3.8/zipfile.py:
+      /usr/lib/python3.8/zipimport.py:

--- a/slices/libpython3.8-stdlib.yaml
+++ b/slices/libpython3.8-stdlib.yaml
@@ -1,0 +1,383 @@
+package: libpython3.8-stdlib
+
+# The slices in this package have been grouped with inspiration
+# from the Python 3.8 Standard Library (https://docs.python.org/3.8/library/index.html).
+# Aside from the "core" slice which contains the minimal libraries that
+# should come from this package and the "extra" slice which contains
+# miscellaneous libraries, all the other slice definitions are sorted
+# by their names. The "core" slice is placed at the very beginning and
+# the "extra" slice at the very end.
+slices:
+  # The "core" slice provides a very minimal libpython3.8-stdlib
+  core:
+    essential:
+      - libpython3.8-minimal_libs
+      - libc6_libs
+      - libbz2-1.0_libs
+      - liblzma5_libs
+      - mime-support_mime-types
+    contents:
+      /usr/lib/python3.8/_compression.py:
+      /usr/lib/python3.8/bz2.py:
+      /usr/lib/python3.8/contextvars.py:
+      /usr/lib/python3.8/dataclasses.py:
+      /usr/lib/python3.8/gettext.py:
+      /usr/lib/python3.8/gzip.py:
+      /usr/lib/python3.8/http/__init__.py:
+      /usr/lib/python3.8/http/client.py:
+      /usr/lib/python3.8/lib-dynload/_bz2.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_codecs_*.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_contextvars.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_lzma.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_multibytecodec.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_queue.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/mmap.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lzma.py:
+      /usr/lib/python3.8/mimetypes.py:
+      /usr/lib/python3.8/ntpath.py:
+      /usr/lib/python3.8/queue.py:
+      /usr/lib/python3.8/shutil.py:
+      /usr/lib/python3.8/socketserver.py:
+      /usr/lib/python3.8/tarfile.py:
+      /usr/lib/python3.8/typing.py:
+
+  # Generic Operating System Services
+  # https://docs.python.org/3.8/library/allos.html
+  all-os:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_unix
+      - libncursesw6_libs
+      - libffi7_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.8/_pyio.py:
+      /usr/lib/python3.8/ctypes/**:
+      /usr/lib/python3.8/curses/**:
+      /usr/lib/python3.8/getpass.py:
+      /usr/lib/python3.8/lib-dynload/_ctypes*.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_curses*.cpython-38-*-linux-*.so:
+
+  # Concurrent Execution
+  # https://docs.python.org/3.8/library/concurrency.html
+  concurrency:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_crypto
+      - libpython3.8-stdlib_all-os
+    contents:
+      /usr/lib/python3.8/_dummy_thread.py:
+      /usr/lib/python3.8/concurrent/**:
+      /usr/lib/python3.8/dummy_threading.py:
+      /usr/lib/python3.8/lib-dynload/_multiprocessing.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_posixshmem.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/multiprocessing/**:
+      /usr/lib/python3.8/sched.py:
+
+  # Cryptographic Services
+  # https://docs.python.org/3.8/library/crypto.html
+  crypto:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/hmac.py:
+      /usr/lib/python3.8/secrets.py:
+
+  # Custom Python Interpreters
+  # https://docs.python.org/3.8/library/custominterp.html
+  custom-interpreters:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_text
+    contents:
+      /usr/lib/python3.8/code.py:
+      /usr/lib/python3.8/codeop.py:
+
+  # Data Types
+  # https://docs.python.org/3.8/library/datatypes.html
+  data-types:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/pprint.py:
+
+  # Debugging and Profiling
+  # https://docs.python.org/3.8/library/debug.html
+  debug:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_custom-interpreters
+      - libpython3.8-stdlib_data-types
+      - libpython3.8-stdlib_frameworks
+      - libpython3.8-stdlib_text
+    contents:
+      /usr/lib/python3.8/bdb.py:
+      /usr/lib/python3.8/cProfile.py:
+      /usr/lib/python3.8/lib-dynload/_lsprof.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/pdb.py:
+      /usr/lib/python3.8/profile.py:
+      /usr/lib/python3.8/pstats.py:
+      /usr/lib/python3.8/timeit.py:
+      /usr/lib/python3.8/trace.py:
+
+  # Development Tools
+  # https://docs.python.org/3.8/library/development.html
+  development-tools:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_all-os
+      - libpython3.8-stdlib_concurrency
+      - libpython3.8-stdlib_data-types
+      - libpython3.8-stdlib_debug
+      - libpython3.8-stdlib_distribution
+      - libpython3.8-stdlib_internet
+      - libpython3.8-stdlib_ipc
+      - libpython3.8-stdlib_markup-tools
+      - libpython3.8-stdlib_net-data
+      - libpython3.8-stdlib_numeric
+      - libpython3.8-stdlib_text
+      - libpython3.8-stdlib_unix
+    contents:
+      /usr/lib/python3.8/__phello__.foo.py:
+      /usr/lib/python3.8/doctest.py:
+      /usr/lib/python3.8/lib-dynload/_testbuffer.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_testcapi.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_testimportmultiple.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_testinternalcapi.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_testmultiphase.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_xxsubinterpreters.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_xxtestfuzz.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/xxlimited.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/test/**:
+      /usr/lib/python3.8/unittest/**:
+
+  # Software Packaging and Distribution
+  # https://docs.python.org/3.8/library/distribution.html
+  distribution:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_osx-support
+    contents:
+      /usr/lib/python3.8/distutils/**:
+      /usr/lib/python3.8/venv/**:
+      /usr/lib/python3.8/zipapp.py:
+
+  # File Formats
+  # https://docs.python.org/3.8/library/fileformats.html
+  file-formats:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_frameworks
+      - libpython3.8-stdlib_markup-tools
+    contents:
+      /usr/lib/python3.8/netrc.py:
+      /usr/lib/python3.8/plistlib.py:
+      /usr/lib/python3.8/xdrlib.py:
+
+  # File and Directory Access
+  # https://docs.python.org/3.8/library/filesys.html
+  filesys:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/filecmp.py:
+      /usr/lib/python3.8/fileinput.py:
+
+  # Program Frameworks
+  # https://docs.python.org/3.8/library/frameworks.html
+  frameworks:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_text
+    contents:
+      /usr/lib/python3.8/cmd.py:
+      /usr/lib/python3.8/shlex.py:
+      /usr/lib/python3.8/turtle.py:
+
+  # Importing Modules
+  # https://docs.python.org/3.8/library/modules.html
+  importing:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/modulefinder.py:
+
+  # Internet Protocols and Support
+  # https://docs.python.org/3.8/library/internet.html
+  internet:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_crypto
+      - libpython3.8-stdlib_file-formats
+      - libpython3.8-stdlib_frameworks
+      - libpython3.8-stdlib_ipc
+      - libpython3.8-stdlib_markup-tools
+      - libpython3.8-stdlib_numeric
+      - libpython3.8-stdlib_pydoc
+      - libuuid1_libs
+    contents:
+      /usr/lib/python3.8/cgi.py:
+      /usr/lib/python3.8/cgitb.py:
+      /usr/lib/python3.8/ftplib.py:
+      /usr/lib/python3.8/http/cookiejar.py:
+      /usr/lib/python3.8/http/cookies.py:
+      /usr/lib/python3.8/http/server.py:
+      /usr/lib/python3.8/imaplib.py:
+      /usr/lib/python3.8/lib-dynload/_uuid.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/nntplib.py:
+      /usr/lib/python3.8/nturl2path.py:
+      /usr/lib/python3.8/poplib.py:
+      /usr/lib/python3.8/smtpd.py:
+      /usr/lib/python3.8/smtplib.py:
+      /usr/lib/python3.8/telnetlib.py:
+      /usr/lib/python3.8/uuid.py:
+      /usr/lib/python3.8/webbrowser.py:
+      /usr/lib/python3.8/wsgiref/**:
+      /usr/lib/python3.8/xmlrpc/**:
+
+  # Networking and Interprocess Communication
+  # https://docs.python.org/3.8/library/ipc.html
+  ipc:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_concurrency
+    contents:
+      /usr/lib/python3.8/asynchat.py:
+      /usr/lib/python3.8/asyncio/**:
+      /usr/lib/python3.8/asyncore.py:
+      /usr/lib/python3.8/lib-dynload/_asyncio.cpython-38-*-linux-*.so:
+
+  # Python Language Services
+  # https://docs.python.org/3.8/library/language.html
+  language:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/lib-dynload/parser.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/pickletools.py:
+      /usr/lib/python3.8/pyclbr.py:
+      /usr/lib/python3.8/symbol.py:
+      /usr/lib/python3.8/symtable.py:
+      /usr/lib/python3.8/tabnanny.py:
+
+  # Structured Markup Processing Tools (HTML, XML)
+  # https://docs.python.org/3.8/library/markup.html
+  markup-tools:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/_markupbase.py:
+      /usr/lib/python3.8/html/**:
+      /usr/lib/python3.8/xml/**:
+
+  # Multimedia Services
+  # https://docs.python.org/3.8/library/mm.html
+  multimedia:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/aifc.py:
+      /usr/lib/python3.8/chunk.py:
+      /usr/lib/python3.8/colorsys.py:
+      /usr/lib/python3.8/imghdr.py:
+      /usr/lib/python3.8/lib-dynload/audioop.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/ossaudiodev.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/sndhdr.py:
+      /usr/lib/python3.8/sunau.py:
+      /usr/lib/python3.8/wave.py:
+
+  # Internet Data Handling
+  # https://docs.python.org/3.8/library/netdata.html
+  net-data:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/binhex.py:
+      /usr/lib/python3.8/json/**:
+      /usr/lib/python3.8/lib-dynload/_json.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/mailbox.py:
+      /usr/lib/python3.8/mailcap.py:
+
+  # Numeric and Mathematical Modules
+  # https://docs.python.org/3.8/library/numeric.html
+  numeric:
+    essential:
+      - libpython3.8-stdlib_core
+      - libmpdec2_libs
+    contents:
+      /usr/lib/python3.8/_pydecimal.py:
+      /usr/lib/python3.8/decimal.py:
+      /usr/lib/python3.8/fractions.py:
+      /usr/lib/python3.8/lib-dynload/_decimal.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/numbers.py:
+      /usr/lib/python3.8/statistics.py:
+
+  # Shared OS X support functions
+  osx-support:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/_osx_support.py:
+
+  # Data Persistence
+  # https://docs.python.org/3.8/library/persistence.html
+  data-persistence:
+    essential:
+      - libpython3.8-stdlib_core
+      - libdb5.3_libs
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/python3.8/dbm/**:
+      /usr/lib/python3.8/lib-dynload/_dbm.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/_sqlite3.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/shelve.py:
+      /usr/lib/python3.8/sqlite3/**:
+
+  # pydoc - Documentation generator and online help system
+  # https://docs.python.org/3.8/library/pydoc.html
+  pydoc:
+    essential:
+      - libpython3.8-stdlib_core
+    contents:
+      /usr/lib/python3.8/pydoc_data/**:
+      /usr/lib/python3.8/pydoc.py:
+
+  # Text Processing Services
+  # https://docs.python.org/3.8/library/text.html
+  text:
+    essential:
+      - libpython3.8-stdlib_core
+      - libreadline8_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.8/difflib.py:
+      /usr/lib/python3.8/lib-dynload/readline.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/rlcompleter.py:
+
+  # Unix Specific Services
+  # https://docs.python.org/3.8/library/unix.html
+  unix:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_frameworks
+      - libcrypt1_libs
+    contents:
+      /usr/lib/python3.8/crypt.py:
+      /usr/lib/python3.8/lib-dynload/_crypt.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/nis.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/resource.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/lib-dynload/termios.cpython-38-*-linux-*.so:
+      /usr/lib/python3.8/pipes.py:
+      /usr/lib/python3.8/pty.py:
+      /usr/lib/python3.8/tty.py:
+
+  # Outliers and Deprecated Modules
+  # The "extra" slice consists of easter-eggs and deprecated modules
+  extras:
+    essential:
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_internet
+    contents:
+      /usr/lib/python3.8/antigravity.py:
+      /usr/lib/python3.8/formatter.py:
+      /usr/lib/python3.8/this.py:

--- a/slices/libreadline8.yaml
+++ b/slices/libreadline8.yaml
@@ -1,0 +1,11 @@
+package: libreadline8
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libtinfo6_libs
+      - readline-common_config
+    contents:
+      /lib/*-linux-*/libreadline.so.8*:
+      /lib/*-linux-*/libhistory.so.8*:

--- a/slices/libtinfo6.yaml
+++ b/slices/libtinfo6.yaml
@@ -1,0 +1,9 @@
+package: libtinfo6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libtinfo.so.6*:
+      /usr/lib/*-linux-*/libtic.so.6*:

--- a/slices/mime-support.yaml
+++ b/slices/mime-support.yaml
@@ -1,0 +1,6 @@
+package: mime-support
+
+slices:
+  mime-types:
+    contents:
+      /etc/mime.types:

--- a/slices/python3.8-minimal.yaml
+++ b/slices/python3.8-minimal.yaml
@@ -1,0 +1,13 @@
+package: python3.8-minimal
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libpython3.8-minimal_libs
+      - libexpat1_libs
+      - zlib1g_libs
+    contents:
+      /usr/bin/python3.8:
+      /usr/local/lib/python3.8/: {make: true, mode: 02775}
+      /usr/local/lib/python3.8/dist-packages/: {make: true, mode: 02775}

--- a/slices/python3.8.yaml
+++ b/slices/python3.8.yaml
@@ -1,0 +1,53 @@
+package: python3.8
+
+slices:
+  # The "core" slice provides a very minimal, yet functioning Python3.8.
+  # It includes very few modules from the libpython3.8-stdlib package.
+  core:
+    essential:
+      - python3.8-minimal_bins
+      - libpython3.8-stdlib_core
+      - mime-support_mime-types
+
+  # The "standard" slice extends "core" with all the Python
+  # modules from the libpython3.8-stdlib package.
+  standard:
+    essential:
+      - python3.8_core
+      - libpython3.8-stdlib_core
+      - libpython3.8-stdlib_all-os
+      - libpython3.8-stdlib_concurrency
+      - libpython3.8-stdlib_crypto
+      - libpython3.8-stdlib_custom-interpreters
+      - libpython3.8-stdlib_data-types
+      - libpython3.8-stdlib_debug
+      - libpython3.8-stdlib_development-tools
+      - libpython3.8-stdlib_distribution
+      - libpython3.8-stdlib_file-formats
+      - libpython3.8-stdlib_filesys
+      - libpython3.8-stdlib_frameworks
+      - libpython3.8-stdlib_importing
+      - libpython3.8-stdlib_internet
+      - libpython3.8-stdlib_ipc
+      - libpython3.8-stdlib_language
+      - libpython3.8-stdlib_markup-tools
+      - libpython3.8-stdlib_multimedia
+      - libpython3.8-stdlib_net-data
+      - libpython3.8-stdlib_numeric
+      - libpython3.8-stdlib_osx-support
+      - libpython3.8-stdlib_data-persistence
+      - libpython3.8-stdlib_pydoc
+      - libpython3.8-stdlib_text
+      - libpython3.8-stdlib_unix
+      - libpython3.8-stdlib_extras
+
+  # The "utlis" slice extends "core" with various tools.
+  utils:
+    essential:
+      - python3.8_core
+      - libpython3.8-stdlib_pydoc
+      - libpython3.8-stdlib_debug
+    contents:
+      /usr/bin/pdb3.8:
+      /usr/bin/pydoc3.8:
+      /usr/bin/pygettext3.8:

--- a/slices/readline-common.yaml
+++ b/slices/readline-common.yaml
@@ -1,0 +1,6 @@
+package: readline-common
+
+slices:
+  config:
+    contents:
+      /etc/inputrc: { copy: /usr/share/readline/inputrc }


### PR DESCRIPTION
This PR adds the necessary slices for a chiselled python3.8.

The slices should support almost all of the python3.8 standard library, except for the following modules:
- `ensurepip` (will need the `python3-pip` package)
- `tkinter`, `tkinter.*` (will need the `python3-tk` package)
   * `turtle` (although this module is included, it directly depends on `tkinter`)
- `msilib`, `msvcrt`, `winreg`, `winsound` (These are MS Windows specific services and only available on MS Windows platforms)

Additionally, I intentionally did not create any `/usr/bin/python3` symlink for any possible conflicts with other future versions. Let me know if you think I should have that pointing to `/usr/bin/python3.8` anyway. Cheers!

---

<details>
  <summary>python3.8 package dependencies</summary>
  
  Here goes a trimmed-down, relevant dependency of the `python3.8` package on Focal. The full list can be found [here as a GitHub Gist](https://gist.github.com/rebornplusplus/683b4010870a70db918051f1e14afc4b).
  
```
python3.8
  Depends: python3.8-minimal (= 3.8.10-0ubuntu1~20.04.8)
  Depends: libpython3.8-stdlib (= 3.8.10-0ubuntu1~20.04.8)
  Depends: mime-support
python3.8-minimal
  PreDepends: libc6 (>= 2.29)
  Depends: libpython3.8-minimal (= 3.8.10-0ubuntu1~20.04.8)
  Depends: libexpat1 (>= 2.1~beta3)
  Depends: zlib1g (>= 1:1.2.0)
libpython3.8-stdlib
  Depends: libpython3.8-minimal (= 3.8.10-0ubuntu1~20.04.8)
  Depends: mime-support
  Depends: libbz2-1.0
  Depends: libc6 (>= 2.28)
  Depends: libcrypt1 (>= 1:4.1.0)
  Depends: libdb5.3
  Depends: libffi7 (>= 3.3~20180313)
  Depends: liblzma5 (>= 5.1.1alpha+20120614)
  Depends: libmpdec2
  Depends: libncursesw6 (>= 6)
  Depends: libreadline8 (>= 7.0~beta)
  Depends: libsqlite3-0 (>= 3.7.15)
  Depends: libtinfo6 (>= 6)
  Depends: libuuid1 (>= 2.20.1)
mime-support
libc6
  Depends: libgcc-s1
  Depends: libcrypt1 (>= 1:4.4.10-10ubuntu4)
libpython3.8-minimal
  Depends: libc6 (>= 2.4)
  Depends: libssl1.1 (>= 1.1.1)
libexpat1
  Depends: libc6 (>= 2.25)
zlib1g
  Depends: libc6 (>= 2.14)
libbz2-1.0
  Depends: libc6 (>= 2.4)
libcrypt1
  Depends: libc6 (>= 2.25)
libdb5.3
  Depends: libc6 (>= 2.17)
libffi7
  Depends: libc6 (>= 2.14)
liblzma5
  Depends: libc6 (>= 2.17)
libmpdec2
  Depends: libc6 (>= 2.14)
libncursesw6
  Depends: libtinfo6 (= 6.2-0ubuntu2.1)
  Depends: libc6 (>= 2.14)
libreadline8
  Depends: readline-common
  Depends: libc6 (>= 2.15)
  Depends: libtinfo6 (>= 6)
libsqlite3-0
  Depends: libc6 (>= 2.29)
libtinfo6
  Depends: libc6 (>= 2.16)
libuuid1
  Depends: libc6 (>= 2.25)
libgcc-s1
  Depends: libc6 (>= 2.14)
libssl1.1
  Depends: libc6 (>= 2.25)
```
  
</details>