### PR TITLE
[22.04] Add slice for libxml2

### DIFF
--- a/slices/libxml2.yaml
+++ b/slices/libxml2.yaml
@@ -8,4 +8,4 @@ slices:
       - liblzma5_libs
       - zlib1g_libs
     contents:
-      /usr/lib/*-linux-*/libxml2.so.*:
+      /usr/lib/*-linux-*/libxml2.so.2*:

--- a/slices/libxml2.yaml
+++ b/slices/libxml2.yaml
@@ -1,0 +1,11 @@
+package: libxml2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libicu70_libs
+      - liblzma5_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libxml2.so.*:


### PR DESCRIPTION
This change adds a new slice for [libxml2](https://packages.ubuntu.com/jammy/libxml2).