### PR TITLE
fix(focal): invalid path in libc6_libs

### DIFF
--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -8,7 +8,7 @@ slices:
   libs:
     contents:
       /lib/*-linux-*/ld-*.*.so:
-      /lib/*-linux-*/ld-*.so.*:
+      /lib/*-linux-*/ld*.so.*:
       /lib/*-linux-*/libBrokenLocale-*.*.so:
       /lib/*-linux-*/libBrokenLocale.so.*:
       /lib/*-linux-*/libSegFault.so:


### PR DESCRIPTION
Fixes #45.

libc6_libs had a path which doesn't match for various architectures such as ppc64el, s390x.

    /lib/*-linux-*/ld-*.so.*:

This commit edits the path to accommodate those architectures.