### PR TITLE
feat: migrate slices from 23.04 to 23.10

### DIFF
--- a/slices/aspnetcore-runtime-6.0.yaml
+++ b/slices/aspnetcore-runtime-6.0.yaml
@@ -1,0 +1,8 @@
+package: aspnetcore-runtime-6.0
+# NOTE: not available for armhf riscv64 ppc64el s390x
+slices:
+  libs:
+    essential:
+      - dotnet-runtime-6.0_libs
+    contents:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/**:

--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -1,0 +1,61 @@
+package: base-files
+
+slices:
+  base:
+    essential:
+      - base-files_etc
+      - base-files_bin
+      - base-files_lib
+      - base-files_tmp
+      - base-files_var
+      - base-files_home
+
+  etc:
+    contents:
+      /etc/:
+
+  bin:
+    contents:
+      /bin/:
+      /sbin/:
+      /usr/bin/:
+      /usr/sbin/:
+
+  lib:
+    contents:
+      /lib/:
+      /usr/lib/:
+
+  tmp:
+    contents:
+      /tmp/:
+
+  var:
+    contents:
+      /run/:
+      /var/cache/:
+      /var/lib/:
+      /var/log/:
+      /var/run/:
+      /var/tmp/:
+
+  home:
+    contents:
+      /home/:
+      /root/:
+
+  release-info:
+    essential:
+      - base-files_etc
+      - base-files_lib
+    contents:
+      /etc/debian_version:
+      /etc/dpkg/origins/debian:
+      /etc/dpkg/origins/ubuntu:
+      /etc/dpkg/origins/default: {symlink: /etc/dpkg/origins/ubuntu}
+      /etc/host.conf:
+      /etc/issue:
+      /etc/issue.net:
+      /etc/lsb-release:
+      /etc/os-release:
+      /usr/lib/os-release:

--- a/slices/base-passwd.yaml
+++ b/slices/base-passwd.yaml
@@ -1,0 +1,14 @@
+package: base-passwd
+
+slices:
+  data:
+    contents:
+      /usr/share/base-passwd/group.master:  {until: mutate}
+      /usr/share/base-passwd/passwd.master: {until: mutate}
+      /etc/group:  {text: FIXME, mutable: true}
+      /etc/passwd: {text: FIXME, mutable: true}
+    mutate: |
+      gr = content.read("/usr/share/base-passwd/group.master")
+      content.write("/etc/group", gr)
+      pw = content.read("/usr/share/base-passwd/passwd.master")
+      content.write("/etc/passwd", pw)

--- a/slices/ca-certificates.yaml
+++ b/slices/ca-certificates.yaml
@@ -1,0 +1,12 @@
+package: ca-certificates
+
+slices:
+  data:
+    contents:
+      /etc/ssl/certs/ca-certificates.crt: {text: FIXME, mutable: true}
+      /usr/share/ca-certificates/mozilla/: {until: mutate}
+      /usr/share/ca-certificates/mozilla/*: {until: mutate}
+    mutate: |
+      certs_dir = "/usr/share/ca-certificates/mozilla/"
+      certs = [content.read(certs_dir + path) for path in content.list(certs_dir)]
+      content.write("/etc/ssl/certs/ca-certificates.crt", "".join(certs))

--- a/slices/dotnet-host.yaml
+++ b/slices/dotnet-host.yaml
@@ -1,0 +1,10 @@
+package: dotnet-host
+# NOTE: not available for armhf riscv64 ppc64el s390x
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/dotnet/dotnet:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -1,0 +1,11 @@
+package: dotnet-hostfxr-6.0
+# NOTE: not available for armhf riscv64 ppc64el s390x
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - dotnet-host_bins
+    contents:
+      /usr/lib/dotnet/host/fxr/*/libhostfxr.so:

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -1,0 +1,17 @@
+package: dotnet-runtime-6.0
+# NOTE: not available for armhf riscv64 ppc64el s390x
+slices:
+  libs:
+    essential:
+      - dotnet-hostfxr-6.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libicu72_libs
+      - liblttng-ust1_libs
+      - libssl3_libs
+      - libstdc++6_libs
+      - libunwind-13_libs
+      - libunwind8_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/**:

--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -1,0 +1,30 @@
+package: libc6
+
+slices:
+  config:
+    contents:
+      /etc/ld.so.conf.d/*-linux-*.conf:
+
+  libs:
+    contents:
+      /lib/*-linux-*/ld*.so.*:
+      /lib/*-linux-*/libBrokenLocale.so.*:
+      /lib/*-linux-*/libanl.so.*:
+      /lib/*-linux-*/libc.so.*:
+      /lib/*-linux-*/libc_malloc_debug.so.*:
+      /lib/*-linux-*/libdl.so.*:
+      /lib/*-linux-*/libm.so.*:
+      /lib/*-linux-*/libmemusage.so:
+      /lib/*-linux-*/libmvec.so.*: {arch: amd64}
+      /lib/*-linux-*/libnsl.so.*:
+      /lib/*-linux-*/libnss_compat.so.*:
+      /lib/*-linux-*/libnss_dns.so.*:
+      /lib/*-linux-*/libnss_files.so.*:
+      /lib/*-linux-*/libnss_hesiod.so.*:
+      /lib/*-linux-*/libpcprofile.so:
+      /lib/*-linux-*/libpthread.so.*:
+      /lib/*-linux-*/libresolv.so.*:
+      /lib/*-linux-*/librt.so.*:
+      /lib/*-linux-*/libthread_db.so.*:
+      /lib/*-linux-*/libutil.so.*:
+      /lib*/ld*.so.*:

--- a/slices/libcom-err2.yaml
+++ b/slices/libcom-err2.yaml
@@ -1,0 +1,8 @@
+package: libcom-err2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libcom_err.so.*:

--- a/slices/libcrypt1.yaml
+++ b/slices/libcrypt1.yaml
@@ -1,0 +1,8 @@
+package: libcrypt1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libcrypt.so.*:

--- a/slices/libgcc-s1.yaml
+++ b/slices/libgcc-s1.yaml
@@ -1,0 +1,8 @@
+package: libgcc-s1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libgcc_s.so.*:

--- a/slices/libicu72.yaml
+++ b/slices/libicu72.yaml
@@ -1,0 +1,15 @@
+package: libicu72
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libicudata.so.72*:
+      /usr/lib/*-linux-*/libicui18n.so.72*:
+      /usr/lib/*-linux-*/libicuio.so.72*:
+      /usr/lib/*-linux-*/libicutest.so.72*:
+      /usr/lib/*-linux-*/libicutu.so.72*:
+      /usr/lib/*-linux-*/libicuuc.so.72*:

--- a/slices/libk5crypto3.yaml
+++ b/slices/libk5crypto3.yaml
@@ -1,0 +1,9 @@
+package: libk5crypto3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libkrb5support0_libs
+    contents:
+      /usr/lib/*-linux-*/libk5crypto.so.*:

--- a/slices/libkeyutils1.yaml
+++ b/slices/libkeyutils1.yaml
@@ -1,0 +1,8 @@
+package: libkeyutils1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libkeyutils.so.*:

--- a/slices/libkrb5-3.yaml
+++ b/slices/libkrb5-3.yaml
@@ -1,0 +1,15 @@
+package: libkrb5-3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcom-err2_libs
+      - libk5crypto3_libs
+      - libkeyutils1_libs
+      - libkrb5support0_libs
+      - libssl3_libs
+    contents:
+      /usr/lib/*-linux-*/krb5/plugins/libkrb5/:
+      /usr/lib/*-linux-*/krb5/plugins/preauth/spake.so:
+      /usr/lib/*-linux-*/libkrb5.so.*:

--- a/slices/libkrb5support0.yaml
+++ b/slices/libkrb5support0.yaml
@@ -1,0 +1,8 @@
+package: libkrb5support0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libkrb5support.so.*:

--- a/slices/liblttng-ust-common1.yaml
+++ b/slices/liblttng-ust-common1.yaml
@@ -1,0 +1,7 @@
+package: liblttng-ust-common1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-common.so.*:

--- a/slices/liblttng-ust-ctl5.yaml
+++ b/slices/liblttng-ust-ctl5.yaml
@@ -1,0 +1,9 @@
+package: liblttng-ust-ctl5
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblttng-ust-common1_libs
+      - libnuma1_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-ctl.so.*:

--- a/slices/liblttng-ust1.yaml
+++ b/slices/liblttng-ust1.yaml
@@ -1,0 +1,18 @@
+package: liblttng-ust1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblttng-ust-common1_libs
+      - liblttng-ust-ctl5_libs
+      - libnuma1_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-cyg-profile-fast.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-cyg-profile.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-dl.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-fd.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-fork.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-libc-wrapper.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-pthread-wrapper.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-tracepoint.so.*:
+      /usr/lib/*-linux-*/liblttng-ust.so.*:

--- a/slices/liblzma5.yaml
+++ b/slices/liblzma5.yaml
@@ -1,0 +1,7 @@
+package: liblzma5
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/liblzma.so.*:

--- a/slices/libnuma1.yaml
+++ b/slices/libnuma1.yaml
@@ -1,0 +1,7 @@
+package: libnuma1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnuma.so.*:

--- a/slices/libssl3.yaml
+++ b/slices/libssl3.yaml
@@ -1,0 +1,13 @@
+package: libssl3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/engines-3/afalg.so:
+      /usr/lib/*-linux-*/engines-3/loader_attic.so:
+      /usr/lib/*-linux-*/engines-3/padlock.so:
+      /usr/lib/*-linux-*/libcrypto.so.*:
+      /usr/lib/*-linux-*/libssl.so.*:
+      /usr/lib/*-linux-*/ossl-modules/legacy.so:

--- a/slices/libstdc++6.yaml
+++ b/slices/libstdc++6.yaml
@@ -1,0 +1,9 @@
+package: libstdc++6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+    contents:
+      /usr/lib/*-linux-*/libstdc++.so.*:

--- a/slices/libunwind-13.yaml
+++ b/slices/libunwind-13.yaml
@@ -1,0 +1,11 @@
+package: libunwind-13
+# NOTE: this package is not available for s390x
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/llvm-13/lib/libunwind.so.1.*:
+      /usr/lib/llvm-13/lib/libunwind.so.1:
+      /usr/lib/*-linux-*/libunwind.so.1.*:
+      /usr/lib/*-linux-*/libunwind.so.1:

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -1,0 +1,10 @@
+package: libunwind8
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblzma5_libs
+    contents:
+      /usr/lib/*-linux-*/libunwind-*.so.*:
+      /usr/lib/*-linux-*/libunwind.so.8.*:
+      /usr/lib/*-linux-*/libunwind.so.8:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -7,6 +7,7 @@ slices:
       - libc6_config
       - libssl3_libs
       - openssl_config
+      - openssl_data
     contents:
       /usr/bin/c_rehash:
       /usr/bin/openssl:
@@ -18,3 +19,7 @@ slices:
       /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
       /usr/lib/ssl/private:
+
+  data:
+    contents:
+      /usr/lib/ssl/cert.pem:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -1,0 +1,20 @@
+package: openssl
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libc6_config
+      - libssl3_libs
+      - openssl_config
+    contents:
+      /usr/bin/c_rehash:
+      /usr/bin/openssl:
+
+  config:
+    contents:
+      /etc/ssl/private/:
+      /etc/ssl/openssl.cnf:
+      /usr/lib/ssl/certs:
+      /usr/lib/ssl/openssl.cnf:
+      /usr/lib/ssl/private:

--- a/slices/zlib1g.yaml
+++ b/slices/zlib1g.yaml
@@ -1,0 +1,8 @@
+package: zlib1g
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libz.so.*:


### PR DESCRIPTION
This PR brings onto 23.10 the core slices from 23.04.

The major differences are:
   - `libicu71` is renamed to `libicu72` in Mantic