### PR TITLE
feat: Ubuntu 23.10 slices for NGINX

### DIFF
--- a/slices/iproute2.yaml
+++ b/slices/iproute2.yaml
@@ -1,0 +1,75 @@
+package: iproute2
+
+slices:
+  # iproute2 is a utility package which typically could be split into
+  # utility-specific slices. The `bins` slice however brings in all the
+  # utilities for cases where iproute2 is used as a dependency for another
+  # package (eg. nginx), where we can't easily know which utilities are
+  # actually going to be needed.
+  bins:
+    # Leaving the debconf dependency out as we don't currently need pkg mgmt.
+    # Also, debconf is used by the pkg's maintainer scripts, which are handled
+    # differently in Chisel. 
+    essential:
+      - iproute2_config
+      - iproute2_libs
+      - libcap2-bin_bins
+    contents:
+      /bin/ip:
+      /sbin/ip:
+      /bin/ss:
+      /sbin/bridge:
+      /sbin/dcb:
+      /sbin/devlink:
+      /sbin/rtacct:
+      /sbin/rtmon:
+      # "tc" is an obvious candidate for getting its own "traffic-control"
+      # slice in the future, if needed.
+      /sbin/tc:
+      /sbin/tipc:
+      /sbin/vdpa:
+      /usr/bin/lnstat:
+      /usr/bin/ctstat:
+      /usr/bin/rtstat:
+      /usr/bin/nstat:
+      /usr/bin/rdma:
+      /usr/bin/routel:
+      /usr/sbin/arpd:
+      /usr/sbin/genl:
+
+  config:
+    # Corresponds to the pkg's conffiles
+    contents:
+      /etc/iproute2/bpf_pinning:
+      /etc/iproute2/ematch_map:
+      /etc/iproute2/group:
+      /etc/iproute2/nl_protos:
+      /etc/iproute2/rt_dsfield:
+      /etc/iproute2/rt_protos:
+      /etc/iproute2/rt_protos.d/:
+      /etc/iproute2/rt_realms:
+      /etc/iproute2/rt_scopes:
+      /etc/iproute2/rt_tables:
+      /etc/iproute2/rt_tables.d/:
+
+  libs:
+    essential:
+      - libbpf1_libs
+      - libbsd0_libs
+      - libc6_libs
+      - libcap2_libs
+      - libdb5.3_libs
+      - libelf1_libs
+      - libmnl0_libs
+      - libselinux1_libs
+      - libtirpc3_libs
+      - libxtables12_libs
+    contents:
+      /usr/include/iproute2/bpf_elf.h:
+      /usr/lib/*-linux-*/tc/experimental.dist:
+      /usr/lib/*-linux-*/tc/m_xt.so:
+      /usr/lib/*-linux-*/tc/m_ipt.so:
+      /usr/lib/*-linux-*/tc/normal.dist:
+      /usr/lib/*-linux-*/tc/pareto.dist:
+      /usr/lib/*-linux-*/tc/paretonormal.dist:
+      /usr/lib/*-linux-*/tc/q_atm.so:

--- a/slices/libbpf1.yaml
+++ b/slices/libbpf1.yaml
@@ -1,0 +1,10 @@
+package: libbpf1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libelf1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libbpf.so.1*:

--- a/slices/libbsd0.yaml
+++ b/slices/libbsd0.yaml
@@ -1,0 +1,9 @@
+package: libbsd0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libmd0_libs
+    contents:
+      /usr/lib/*-linux-*/libbsd.so.0*:

--- a/slices/libcap2-bin.yaml
+++ b/slices/libcap2-bin.yaml
@@ -1,0 +1,12 @@
+package: libcap2-bin
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libcap2_libs
+    contents:
+      /sbin/capsh:
+      /sbin/getcap:
+      /sbin/getpcaps:
+      /sbin/setcap:

--- a/slices/libcap2.yaml
+++ b/slices/libcap2.yaml
@@ -1,0 +1,10 @@
+package: libcap2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libcap.so.2*:
+      /lib/*-linux-*/libpsx.so.2*:
+

--- a/slices/libdb5.3.yaml
+++ b/slices/libdb5.3.yaml
@@ -1,0 +1,8 @@
+package: libdb5.3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libdb-5.3.so:

--- a/slices/libelf1.yaml
+++ b/slices/libelf1.yaml
@@ -1,0 +1,11 @@
+package: libelf1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libelf-0.*.so:
+      /usr/lib/*-linux-*/libelf.so.1:

--- a/slices/libgssapi-krb5-2.yaml
+++ b/slices/libgssapi-krb5-2.yaml
@@ -1,0 +1,12 @@
+package: libgssapi-krb5-2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcom-err2_libs
+      - libk5crypto3_libs
+      - libkrb5-3_libs
+      - libkrb5support0_libs
+    contents:
+      /usr/lib/*-linux-*/libgssapi_krb5.so.2*:

--- a/slices/libmd0.yaml
+++ b/slices/libmd0.yaml
@@ -1,0 +1,8 @@
+package: libmd0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libmd.so.0*:

--- a/slices/libmnl0.yaml
+++ b/slices/libmnl0.yaml
@@ -1,0 +1,8 @@
+package: libmnl0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libmnl.so.0*:

--- a/slices/libpcre2-8-0.yaml
+++ b/slices/libpcre2-8-0.yaml
@@ -1,0 +1,8 @@
+package: libpcre2-8-0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpcre2-8.so.0*:

--- a/slices/libselinux1.yaml
+++ b/slices/libselinux1.yaml
@@ -1,0 +1,9 @@
+package: libselinux1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libpcre2-8-0_libs
+    contents:
+      /lib/*-linux-*/libselinux.so.1:

--- a/slices/libtirpc-common.yaml
+++ b/slices/libtirpc-common.yaml
@@ -1,0 +1,6 @@
+package: libtirpc-common
+
+slices:
+  config:
+    contents:
+      /etc/netconfig:

--- a/slices/libtirpc3.yaml
+++ b/slices/libtirpc3.yaml
@@ -1,0 +1,10 @@
+package: libtirpc3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgssapi-krb5-2_libs
+      - libtirpc-common_config
+    contents:
+      /lib/*-linux-*/libtirpc.so.3*:

--- a/slices/libxtables12.yaml
+++ b/slices/libxtables12.yaml
@@ -1,0 +1,8 @@
+package: libxtables12
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libxtables.so.12*:

--- a/slices/libzstd1.yaml
+++ b/slices/libzstd1.yaml
@@ -1,0 +1,8 @@
+package: libzstd1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libzstd.so.1*:

--- a/slices/nginx-common.yaml
+++ b/slices/nginx-common.yaml
@@ -1,0 +1,60 @@
+package: nginx-common
+
+slices:
+  # Leaving the debconf dependency out as we don't currently need pkg mgmt.
+  # Also, debconf is especially used for the maintainer scripts, which are
+  # handled differently in Chisel.
+  # There's also no need (yet) for any init- and systemd-related files.
+  config:
+    contents:
+      /etc/logrotate.d/nginx:
+      /etc/nginx/fastcgi.conf:
+      /etc/nginx/fastcgi_params:
+      /etc/nginx/koi-utf:
+      /etc/nginx/koi-win:
+      /etc/nginx/mime.types:
+      /etc/nginx/nginx.conf:
+      /etc/nginx/proxy_params:
+      /etc/nginx/scgi_params:
+      /etc/nginx/sites-available/default:
+      /etc/nginx/snippets/fastcgi-php.conf:
+      /etc/nginx/snippets/snakeoil.conf:
+      /etc/nginx/uwsgi_params:
+      /etc/nginx/win-utf:
+      # Created by the maintainer scripts
+      /var/log/nginx/: {make: true, mode: 0755}
+      /var/log/nginx/access.log: {text: "", mode: 640} 
+      /var/log/nginx/error.log: {text: "", mode: 640}
+      /etc/nginx/sites-enabled/default: {symlink: /etc/nginx/sites-available/default}
+      /var/www/html/: {make: true}
+      /var/lib/nginx/: {make: true}
+
+  ufw-config:
+    contents:
+      /etc/ufw/applications.d/nginx:
+
+  apport:
+    contents:
+      /usr/share/apport/package-hooks/source_nginx.py:
+
+  index:
+    contents:
+      /usr/share/nginx/html/index.html:
+      /var/www/html/index.nginx-debian.html: {copy: /usr/share/nginx/html/index.html}
+
+  modules:
+    contents:
+      /usr/share/nginx/modules:
+
+  vim-addons:
+    essential:
+      - nginx-common_vim-config
+    contents:
+      /usr/share/vim/addons/ftdetect/nginx.vim:
+      /usr/share/vim/addons/ftplugin/nginx.vim:
+      /usr/share/vim/addons/indent/nginx.vim:
+      /usr/share/vim/addons/syntax/nginx.vim:
+  
+  vim-config:
+    contents:
+      /usr/share/vim/registry/nginx.yaml:

--- a/slices/nginx.yaml
+++ b/slices/nginx.yaml
@@ -1,0 +1,16 @@
+package: nginx
+
+slices:
+  bins:
+    essential:
+      # iproute2 seems to only be required for executing the maintainer
+      # scripts, which is something that is handled differently in Chisel.
+      # - iproute2_bins
+      - libc6_libs
+      - libcrypt1_libs
+      - libpcre2-8-0_libs
+      - libssl3_libs
+      - nginx-common_config
+      - zlib1g_libs
+    contents:
+      /usr/sbin/nginx:


### PR DESCRIPTION
Needs https://github.com/canonical/chisel-releases/pull/58

This PR adds the necessary slice definitions for NGINX and its dependencies. 

A couple of noteworthy mentions:
 - `iproute2` is also being sliced in this PR, but is ultimately not included in the list of dependencies for Nginx. The rationale is that, although listed as a pkg dependency, `iproute2` seems to only be used by the Nginx maintainer scripts and thus not essential for a correct nginx behaviour. May `iproute2` be actually needed for nginx at runtime, we can simply uncomment that dependency later on.
 - a similar rationally is being applied for `debconf` which seems to be used by some of these packages, but only for the maintainer scripts.

## Testing

The following will give you a functional Nginx filesystem. `nginx-common_index` is only needed for demonstrating the default index.html example, but can be dropped in production installations.

```bash
chisel cut --release $PWD \
                --root nginx-rootfs \
                base-files_var \
                base-passwd_data \
                nginx_bins \
                nginx-common_index
```