### PR TITLE
feat(22.04): add ubuntu archive signing key 2018

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,7 +1,44 @@
-format: chisel-v1
+format: chisel-v2
 
 archives:
     ubuntu:
         version: 22.04
         components: [main, universe]
         suites: [jammy, jammy-security, jammy-updates]
+        public-keys: [ubuntu-archive-key-2018]
+
+public-keys:
+    # Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>
+    # rsa4096/f6ecb3762474eda9d21b7022871920d1991bc93c 2018-09-17T15:01:46Z
+    ubuntu-archive-key-2018:
+        id: "871920D1991BC93C"
+        armor: |
+            -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+            mQINBFufwdoBEADv/Gxytx/LcSXYuM0MwKojbBye81s0G1nEx+lz6VAUpIUZnbkq
+            dXBHC+dwrGS/CeeLuAjPRLU8AoxE/jjvZVp8xFGEWHYdklqXGZ/gJfP5d3fIUBtZ
+            HZEJl8B8m9pMHf/AQQdsC+YzizSG5t5Mhnotw044LXtdEEkx2t6Jz0OGrh+5Ioxq
+            X7pZiq6Cv19BohaUioKMdp7ES6RYfN7ol6HSLFlrMXtVfh/ijpN9j3ZhVGVeRC8k
+            KHQsJ5PkIbmvxBiUh7SJmfZUx0IQhNMaDHXfdZAGNtnhzzNReb1FqNLSVkrS/Pns
+            AQzMhG1BDm2VOSF64jebKXffFqM5LXRQTeqTLsjUbbrqR6s/GCO8UF7jfUj6I7ta
+            LygmsHO/JD4jpKRC0gbpUBfaiJyLvuepx3kWoqL3sN0LhlMI80+fA7GTvoOx4tpq
+            VlzlE6TajYu+jfW3QpOFS5ewEMdL26hzxsZg/geZvTbArcP+OsJKRmhv4kNo6Ayd
+            yHQ/3ZV/f3X9mT3/SPLbJaumkgp3Yzd6t5PeBu+ZQk/mN5WNNuaihNEV7llb1Zhv
+            Y0Fxu9BVd/BNl0rzuxp3rIinB2TX2SCg7wE5xXkwXuQ/2eTDE0v0HlGntkuZjGow
+            DZkxHZQSxZVOzdZCRVaX/WEFLpKa2AQpw5RJrQ4oZ/OfifXyJzP27o03wQARAQAB
+            tEJVYnVudHUgQXJjaGl2ZSBBdXRvbWF0aWMgU2lnbmluZyBLZXkgKDIwMTgpIDxm
+            dHBtYXN0ZXJAdWJ1bnR1LmNvbT6JAjgEEwEKACIFAlufwdoCGwMGCwkIBwMCBhUI
+            AgkKCwQWAgMBAh4BAheAAAoJEIcZINGZG8k8LHMQAKS2cnxz/5WaoCOWArf5g6UH
+            beOCgc5DBm0hCuFDZWWv427aGei3CPuLw0DGLCXZdyc5dqE8mvjMlOmmAKKlj1uG
+            g3TYCbQWjWPeMnBPZbkFgkZoXJ7/6CB7bWRht1sHzpt1LTZ+SYDwOwJ68QRp7DRa
+            Zl9Y6QiUbeuhq2DUcTofVbBxbhrckN4ZteLvm+/nG9m/ciopc66LwRdkxqfJ32Cy
+            q+1TS5VaIJDG7DWziG+Kbu6qCDM4QNlg3LH7p14CrRxAbc4lvohRgsV4eQqsIcdF
+            kuVY5HPPj2K8TqpY6STe8Gh0aprG1RV8ZKay3KSMpnyV1fAKn4fM9byiLzQAovC0
+            LZ9MMMsrAS/45AvC3IEKSShjLFn1X1dRCiO6/7jmZEoZtAp53hkf8SMBsi78hVNr
+            BumZwfIdBA1v22+LY4xQK8q4XCoRcA9G+pvzU9YVW7cRnDZZGl0uwOw7z9PkQBF5
+            KFKjWDz4fCk+K6+YtGpovGKekGBb8I7EA6UpvPgqA/QdI0t1IBP0N06RQcs1fUaA
+            QEtz6DGy5zkRhR4pGSZn+dFET7PdAjEK84y7BdY4t+U1jcSIvBj0F2B7LwRL7xGp
+            SpIKi/ekAXLs117bvFHaCvmUYN7JVp1GMmVFxhIdx6CFm3fxG8QjNb5tere/YqK+
+            uOgcXny1UlwtCUzlrSaP
+            =9AdM
+            -----END PGP PUBLIC KEY BLOCK-----

--- a/chisel.yaml
+++ b/chisel.yaml
@@ -5,9 +5,9 @@ archives:
         version: 22.04
         components: [main, universe]
         suites: [jammy, jammy-security, jammy-updates]
-        public-keys: [ubuntu-archive-key-2018]
+        v1-public-keys: [ubuntu-archive-key-2018]
 
-public-keys:
+v1-public-keys:
     # Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>
     # rsa4096/f6ecb3762474eda9d21b7022871920d1991bc93c 2018-09-17T15:01:46Z
     ubuntu-archive-key-2018:

--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,4 +1,4 @@
-format: chisel-v2
+format: chisel-v1
 
 archives:
     ubuntu:


### PR DESCRIPTION
This PR adds the Ubuntu Archive Automatic Signing Key (2018) as a "public-key" in the chisel.yaml. The armored data was obtained by executing the following commands on a Ubuntu 22.04 machine:

    $ gpg --keyserver keyserver.ubuntu.com --receive-keys 871920D1991BC93C
    $ gpg --armor --export 871920D1991BC93C

~~BREAKING CHANGE: This PR introduces the new chisel yaml format "chisel-v2", in which ``public-keys`` (top-level) and ``archive.<name>.public-keys`` fields are introduced.~~ This changes is related to the addition of integrity checks in chisel. [1]

[1] https://github.com/canonical/chisel/pull/106