### PR TITLE
feat: add php and it dependencies

### DIFF
--- a/slices/fontconfig-config.yaml
+++ b/slices/fontconfig-config.yaml
@@ -1,0 +1,32 @@
+package: fontconfig-config
+
+slices:
+  config:
+    essential:
+      - fonts-dejavu-core_config
+      - fonts-dejavu-core_fonts
+    contents:
+      /etc/fonts/conf.d/10-hinting-slight.conf:
+      /etc/fonts/conf.d/10-scale-bitmap-fonts.conf:
+      /etc/fonts/conf.d/10-sub-pixel-rgb.conf:
+      /etc/fonts/conf.d/10-yes-antialias.conf:
+      /etc/fonts/conf.d/11-lcdfilter-default.conf:
+      /etc/fonts/conf.d/20-unhint-small-vera.conf:
+      /etc/fonts/conf.d/30-metric-aliases.conf:
+      /etc/fonts/conf.d/40-nonlatin.conf:
+      /etc/fonts/conf.d/45-generic.conf:
+      /etc/fonts/conf.d/45-latin.conf:
+      /etc/fonts/conf.d/48-spacing.conf:
+      /etc/fonts/conf.d/49-sansserif.conf:
+      /etc/fonts/conf.d/50-user.conf:
+      /etc/fonts/conf.d/51-local.conf:
+      /etc/fonts/conf.d/60-generic.conf:
+      /etc/fonts/conf.d/60-latin.conf:
+      /etc/fonts/conf.d/65-fonts-persian.conf:
+      /etc/fonts/conf.d/65-nonlatin.conf:
+      /etc/fonts/conf.d/69-unifont.conf:
+      /etc/fonts/conf.d/70-no-bitmaps.conf:
+      /etc/fonts/conf.d/80-delicious.conf:
+      /etc/fonts/conf.d/90-synthetic.conf:
+      /etc/fonts/fonts.conf:
+      /usr/share/xml/fontconfig/fonts.dtd:

--- a/slices/fonts-dejavu-core.yaml
+++ b/slices/fonts-dejavu-core.yaml
@@ -1,0 +1,28 @@
+package: fonts-dejavu-core
+
+slices:
+  fonts:
+    contents:
+      /usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf:
+      
+  config:
+    contents:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-serif.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-sans.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-serif.conf:
+      /etc/fonts/conf.avail/57-dejavu-sans.conf:
+      /etc/fonts/conf.avail/57-dejavu-serif.conf:
+      /etc/fonts/conf.avail/58-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.avail/58-dejavu-lgc-serif.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-lgc-serif.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-sans.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-serif.conf:
+      /etc/fonts/conf.d/57-dejavu-sans.conf:
+      /etc/fonts/conf.d/57-dejavu-serif.conf:
+      /etc/fonts/conf.d/58-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.d/58-dejavu-lgc-serif.conf:

--- a/slices/libapparmor1.yaml
+++ b/slices/libapparmor1.yaml
@@ -1,0 +1,8 @@
+package: libapparmor1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libapparmor.so.1*:

--- a/slices/libargon2-1.yaml
+++ b/slices/libargon2-1.yaml
@@ -1,0 +1,8 @@
+package: libargon2-1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libargon2.so.1:

--- a/slices/libbrotli1.yaml
+++ b/slices/libbrotli1.yaml
@@ -1,0 +1,10 @@
+package: libbrotli1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libbrotlicommon.so.1*:
+      /usr/lib/*-linux-*/libbrotlidec.so.1*:
+      /usr/lib/*-linux-*/libbrotlienc.so.1*:

--- a/slices/libbz2-1.0.yaml
+++ b/slices/libbz2-1.0.yaml
@@ -1,0 +1,8 @@
+package: libbz2-1.0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libbz2.so.1*:

--- a/slices/libcurl4.yaml
+++ b/slices/libcurl4.yaml
@@ -1,0 +1,17 @@
+package: libcurl4
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnghttp2-14_libs
+      - libidn2-0_libs
+      - librtmp1_libs
+      - libssh-4_libs
+      - libpsl5_libs
+      - libgssapi-krb5-2_libs
+      - libldap2_libs
+      - libzstd1_libs
+      - libbrotli1_libs
+    contents:
+      /usr/lib/*-linux-*/libcurl.so.4*:

--- a/slices/libdeflate0.yaml
+++ b/slices/libdeflate0.yaml
@@ -1,0 +1,7 @@
+package: libdeflate0
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libdeflate.so.0:

--- a/slices/libexpat1.yaml
+++ b/slices/libexpat1.yaml
@@ -1,0 +1,9 @@
+package: libexpat1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libexpat.so.1*:
+      /usr/lib/*-linux-*/libexpatw.so.1*:

--- a/slices/libffi8.yaml
+++ b/slices/libffi8.yaml
@@ -1,0 +1,8 @@
+package: libffi8
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libffi.so.8*:

--- a/slices/libfontconfig1.yaml
+++ b/slices/libfontconfig1.yaml
@@ -1,0 +1,12 @@
+package: libfontconfig1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libexpat1_libs
+      - libfreetype6_libs
+      - libuuid1_libs
+      - fontconfig-config_config
+    contents:
+      /usr/lib/*-linux-*/libfontconfig.so.1*:

--- a/slices/libfreetype6.yaml
+++ b/slices/libfreetype6.yaml
@@ -1,0 +1,11 @@
+package: libfreetype6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - zlib1g_libs
+      - libbrotli1_libs
+      - libpng16-16_libs
+    contents:
+      /usr/lib/*-linux-*/libfreetype.so.6*:

--- a/slices/libgcrypt20.yaml
+++ b/slices/libgcrypt20.yaml
@@ -1,0 +1,8 @@
+package: libgcrypt20
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgpg-error0_libs
+    contents:
+      /usr/lib/*-linux-*/libgcrypt.so.20*:

--- a/slices/libgd3.yaml
+++ b/slices/libgd3.yaml
@@ -1,0 +1,13 @@
+package: libgd3
+slices:
+  libs:
+    essential:
+      - libfontconfig1_libs
+      - libfreetype6_libs
+      - libpng16-16_libs
+      - libjpeg-turbo8_libs
+      - libtiff6_libs
+      - libwebp7_libs
+      - libxpm4_libs
+    contents:
+      /usr/lib/*-linux-*/libgd.so.3*:

--- a/slices/libgnutls30.yaml
+++ b/slices/libgnutls30.yaml
@@ -1,0 +1,15 @@
+package: libgnutls30
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgmp10_libs
+      - libhogweed6_libs
+      - libidn2-0_libs
+      - libnettle8_libs
+      - libp11-kit0_libs
+      - libtasn1-6_libs
+      - libunistring2_libs
+    contents:
+      /usr/lib/*-linux-*/libgnutls*.so.30*:

--- a/slices/libgpg-error0.yaml
+++ b/slices/libgpg-error0.yaml
@@ -1,0 +1,7 @@
+package: libgpg-error0
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libgpg-error.so.0*:

--- a/slices/libhogweed6.yaml
+++ b/slices/libhogweed6.yaml
@@ -1,0 +1,10 @@
+package: libhogweed6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgmp10_libs
+      - libnettle8_libs
+    contents:
+      /usr/lib/*-linux-*/libhogweed.so.6*:

--- a/slices/libidn2-0.yaml
+++ b/slices/libidn2-0.yaml
@@ -1,0 +1,9 @@
+package: libidn2-0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libunistring2_libs
+    contents:
+      /usr/lib/*-linux-*/libidn2.so.0*:

--- a/slices/libjbig0.yaml
+++ b/slices/libjbig0.yaml
@@ -1,0 +1,7 @@
+package: libjbig0
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libjbig.so.0:

--- a/slices/libjpeg-turbo8.yaml
+++ b/slices/libjpeg-turbo8.yaml
@@ -1,0 +1,8 @@
+package: libjpeg-turbo8
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libjpeg.so.8*:

--- a/slices/libldap2.yaml
+++ b/slices/libldap2.yaml
@@ -1,0 +1,10 @@
+package: libldap2
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgnutls30_libs
+      - libsasl2-2_libs
+    contents:
+      /usr/lib/*-linux-*/liblber.so.2*:
+      /usr/lib/*-linux-*/libldap.so.2*:

--- a/slices/liblerc4.yaml
+++ b/slices/liblerc4.yaml
@@ -1,0 +1,9 @@
+package: liblerc4
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libLerc.so.4:

--- a/slices/liblz4-1.yaml
+++ b/slices/liblz4-1.yaml
@@ -1,0 +1,8 @@
+package: liblz4-1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblz4.so.1*:

--- a/slices/libnettle8.yaml
+++ b/slices/libnettle8.yaml
@@ -1,0 +1,8 @@
+package: libnettle8
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnettle.so.8*:

--- a/slices/libnghttp2-14.yaml
+++ b/slices/libnghttp2-14.yaml
@@ -1,0 +1,8 @@
+package: libnghttp2-14
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnghttp2.so.14*:

--- a/slices/libonig5.yaml
+++ b/slices/libonig5.yaml
@@ -1,0 +1,7 @@
+package: libonig5
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libonig.so.5*:

--- a/slices/libp11-kit0.yaml
+++ b/slices/libp11-kit0.yaml
@@ -1,0 +1,9 @@
+package: libp11-kit0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libffi8_libs
+    contents:
+      /usr/lib/*-linux-*/libp11-kit.so.0*:

--- a/slices/libpng16-16.yaml
+++ b/slices/libpng16-16.yaml
@@ -1,0 +1,8 @@
+package: libpng16-16
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpng16.so.16*:

--- a/slices/libpq5.yaml
+++ b/slices/libpq5.yaml
@@ -1,0 +1,10 @@
+package: libpq5
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgssapi-krb5-2_libs
+      - libldap2_libs
+      - libssl3_libs
+    contents:
+      /usr/lib/*-linux-*/libpq.so.5*:

--- a/slices/libpsl5.yaml
+++ b/slices/libpsl5.yaml
@@ -1,0 +1,8 @@
+package: libpsl5
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpsl.so.5*:

--- a/slices/librabbitmq4.yaml
+++ b/slices/librabbitmq4.yaml
@@ -1,0 +1,7 @@
+package: librabbitmq4
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/librabbitmq.so.4*:

--- a/slices/librtmp1.yaml
+++ b/slices/librtmp1.yaml
@@ -1,0 +1,7 @@
+package: librtmp1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/librtmp.so.1:

--- a/slices/libsasl2-2.yaml
+++ b/slices/libsasl2-2.yaml
@@ -1,0 +1,9 @@
+package: libsasl2-2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libsasl2-modules-db_libs
+    contents:
+      /usr/lib/*-linux-*/libsasl*.so.2*:

--- a/slices/libsasl2-modules-db.yaml
+++ b/slices/libsasl2-modules-db.yaml
@@ -1,0 +1,9 @@
+package: libsasl2-modules-db
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdb5.3_libs
+    contents:
+      /usr/lib/*-linux-*/sasl2/libsasldb.so*:

--- a/slices/libsodium23.yaml
+++ b/slices/libsodium23.yaml
@@ -1,0 +1,9 @@
+package: libsodium23
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libsodium.so.23:
+      /usr/lib/*-linux-*/libsodium.so.23.3.0:

--- a/slices/libsqlite3-0.yaml
+++ b/slices/libsqlite3-0.yaml
@@ -1,0 +1,7 @@
+package: libsqlite3-0
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libsqlite3.so.0*:

--- a/slices/libssh-4.yaml
+++ b/slices/libssh-4.yaml
@@ -1,0 +1,8 @@
+package: libssh-4
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libssh.so.4*:

--- a/slices/libsystemd0.yaml
+++ b/slices/libsystemd0.yaml
@@ -1,0 +1,13 @@
+package: libsystemd0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcap2_libs
+      - libgcrypt20_libs
+      - liblz4-1_libs
+      - liblzma5_libs
+      - libzstd1_libs
+    contents:
+      /usr/lib/*-linux-*/libsystemd.so.0*:

--- a/slices/libtasn1-6.yaml
+++ b/slices/libtasn1-6.yaml
@@ -1,0 +1,8 @@
+package: libtasn1-6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libtasn1.so.6*:

--- a/slices/libtiff6.yaml
+++ b/slices/libtiff6.yaml
@@ -1,0 +1,15 @@
+package: libtiff6
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdeflate0_libs
+      - libjbig0_libs
+      - libjpeg-turbo8_libs
+      - liblerc4_libs
+      - liblzma5_libs
+      - libwebp7_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libtiff.so.6*:

--- a/slices/libunistring2.yaml
+++ b/slices/libunistring2.yaml
@@ -1,0 +1,8 @@
+package: libunistring2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libunistring.so.2*:

--- a/slices/libuuid1.yaml
+++ b/slices/libuuid1.yaml
@@ -1,0 +1,8 @@
+package: libuuid1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libuuid.so.1*:

--- a/slices/libwebp7.yaml
+++ b/slices/libwebp7.yaml
@@ -1,0 +1,7 @@
+package: libwebp7
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libwebp.so.7*:

--- a/slices/libx11-6.yaml
+++ b/slices/libx11-6.yaml
@@ -1,0 +1,8 @@
+package: libx11-6
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libX11.so.6*:

--- a/slices/libxau6.yaml
+++ b/slices/libxau6.yaml
@@ -1,0 +1,7 @@
+package: libxau6
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libXau.so.6*:

--- a/slices/libxcb1.yaml
+++ b/slices/libxcb1.yaml
@@ -1,0 +1,9 @@
+package: libxcb1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxau6_libs
+      - libxdmcp6_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb.so.1*:

--- a/slices/libxdmcp6.yaml
+++ b/slices/libxdmcp6.yaml
@@ -1,0 +1,8 @@
+package: libxdmcp6
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libbsd0_libs
+    contents:
+      /usr/lib/*-linux-*/libXdmcp.so.6*:

--- a/slices/libxml2.yaml
+++ b/slices/libxml2.yaml
@@ -1,0 +1,11 @@
+package: libxml2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libicu72_libs
+      - liblzma5_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libxml2.so.2*:

--- a/slices/libxpm4.yaml
+++ b/slices/libxpm4.yaml
@@ -1,0 +1,8 @@
+package: libxpm4
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libXpm.so.4*:

--- a/slices/libxslt1.1.yaml
+++ b/slices/libxslt1.1.yaml
@@ -1,0 +1,9 @@
+package: libxslt1.1
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcrypt20_libs
+    contents:
+      /usr/lib/*-linux-*/libexslt.so.0*:
+      /usr/lib/*-linux-*/libxslt.so.1*:

--- a/slices/libzip4.yaml
+++ b/slices/libzip4.yaml
@@ -1,0 +1,10 @@
+package: libzip4
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libssl3_libs
+      - libbz2-1.0_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libzip.so.4*:

--- a/slices/php8.2-amqp.yaml
+++ b/slices/php8.2-amqp.yaml
@@ -1,0 +1,8 @@
+package: php8.2-amqp
+slices:
+  all:
+    essential:
+      - librabbitmq4_libs
+    contents:
+      /usr/lib/php/20220829/amqp.so:
+      /etc/php/8.2/cli/conf.d/20-amqp.ini: {copy: '/etc/php/8.2/mods-available/amqp.ini'}

--- a/slices/php8.2-amqp.yaml
+++ b/slices/php8.2-amqp.yaml
@@ -2,7 +2,19 @@ package: php8.2-amqp
 slices:
   all:
     essential:
+      - php8.2-amqp_cli
+      - php8.2-amqp_fpm
+
+  cli:
+    essential:
       - librabbitmq4_libs
     contents:
       /usr/lib/php/20220829/amqp.so:
       /etc/php/8.2/cli/conf.d/20-amqp.ini: {copy: '/etc/php/8.2/mods-available/amqp.ini'}
+
+  fpm:
+    essential:
+      - librabbitmq4_libs
+    contents:
+      /usr/lib/php/20220829/amqp.so:
+      /etc/php/8.2/fpm/conf.d/20-amqp.ini: {copy: '/etc/php/8.2/mods-available/amqp.ini'}

--- a/slices/php8.2-bcmath.yaml
+++ b/slices/php8.2-bcmath.yaml
@@ -1,0 +1,6 @@
+package: php8.2-bcmath
+slices:
+  all:
+    contents:
+      /usr/lib/php/20220829/bcmath.so:
+      /etc/php/8.2/cli/conf.d/20-bcmath.ini: {copy: '/usr/share/php8.2-bcmath/bcmath/bcmath.ini'}

--- a/slices/php8.2-bcmath.yaml
+++ b/slices/php8.2-bcmath.yaml
@@ -1,6 +1,16 @@
 package: php8.2-bcmath
 slices:
   all:
+    essential:
+      - php8.2-bcmath_cli
+      - php8.2-bcmath_fpm
+
+  cli:
     contents:
       /usr/lib/php/20220829/bcmath.so:
       /etc/php/8.2/cli/conf.d/20-bcmath.ini: {copy: '/usr/share/php8.2-bcmath/bcmath/bcmath.ini'}
+
+  fpm:
+    contents:
+      /usr/lib/php/20220829/bcmath.so:
+      /etc/php/8.2/fpm/conf.d/20-bcmath.ini: {copy: '/usr/share/php8.2-bcmath/bcmath/bcmath.ini'}

--- a/slices/php8.2-bz2.yaml
+++ b/slices/php8.2-bz2.yaml
@@ -2,7 +2,17 @@ package: php8.2-bz2
 slices:
   all:
     essential:
+      - php8.2-bz2_cli
+      - php8.2-bz2_fpm
+  cli:
+    essential:
       - libbz2-1.0_libs
     contents:
       /usr/lib/php/20220829/bz2.so:
       /etc/php/8.2/cli/conf.d/20-bz2.ini: {copy: '/usr/share/php8.2-bz2/bz2/bz2.ini'}
+  fpm:
+    essential:
+      - libbz2-1.0_libs
+    contents:
+      /usr/lib/php/20220829/bz2.so:
+      /etc/php/8.2/fpm/conf.d/20-bz2.ini: {copy: '/usr/share/php8.2-bz2/bz2/bz2.ini'}

--- a/slices/php8.2-bz2.yaml
+++ b/slices/php8.2-bz2.yaml
@@ -1,0 +1,8 @@
+package: php8.2-bz2
+slices:
+  all:
+    essential:
+      - libbz2-1.0_libs
+    contents:
+      /usr/lib/php/20220829/bz2.so:
+      /etc/php/8.2/cli/conf.d/20-bz2.ini: {copy: '/usr/share/php8.2-bz2/bz2/bz2.ini'}

--- a/slices/php8.2-cli.yaml
+++ b/slices/php8.2-cli.yaml
@@ -4,7 +4,7 @@ slices:
   all:
     essential:
       - php8.2-cli_base
-      - php8.2-common_all
+      - php8.2-common_all-cli
 
   base:
     essential:
@@ -16,6 +16,6 @@ slices:
       - libpcre2-8-0_libs
       - libsodium23_libs
       - libargon2-1_libs
-      - php8.2-common_base
+      - php8.2-common_base-cli
     contents:
       /usr/bin/php: {copy: /usr/bin/php8.2}

--- a/slices/php8.2-cli.yaml
+++ b/slices/php8.2-cli.yaml
@@ -1,0 +1,21 @@
+package: php8.2-cli
+
+slices:
+  all:
+    essential:
+      - php8.2-cli_base
+      - php8.2-common_all
+
+  base:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libxml2_libs
+      - libssl3_libs
+      - libpcre2-8-0_libs
+      - libsodium23_libs
+      - libargon2-1_libs
+      - php8.2-common_base
+    contents:
+      /usr/bin/php: {copy: /usr/bin/php8.2}

--- a/slices/php8.2-common.yaml
+++ b/slices/php8.2-common.yaml
@@ -3,114 +3,323 @@ package: php8.2-common
 slices:
   all:
     essential:
-      - php8.2-common_base
-      - php8.2-common_calendar
-      - php8.2-common_ctype
-      - php8.2-common_exif
-      - php8.2-common_ffi
-      - php8.2-common_fileinfo
-      - php8.2-common_ftp
-      - php8.2-common_gettext
-      - php8.2-common_iconv
-      - php8.2-common_pdo
-      - php8.2-common_phar
-      - php8.2-common_posix
-      - php8.2-common_shmop
-      - php8.2-common_sockets
-      - php8.2-common_sysvmsg
-      - php8.2-common_sysvsem
-      - php8.2-common_sysvshm
-      - php8.2-common_tokenizer
+      - php8.2-common_all-cli
+      - php8.2-common_all-fpm
+
+  all-cli:
+    essential:
+      - php8.2-common_base-cli
+      - php8.2-common_calendar-cli
+      - php8.2-common_ctype-cli
+      - php8.2-common_exif-cli
+      - php8.2-common_ffi-cli
+      - php8.2-common_fileinfo-cli
+      - php8.2-common_ftp-cli
+      - php8.2-common_gettext-cli
+      - php8.2-common_iconv-cli
+      - php8.2-common_pdo-cli
+      - php8.2-common_phar-cli
+      - php8.2-common_posix-cli
+      - php8.2-common_shmop-cli
+      - php8.2-common_sockets-cli
+      - php8.2-common_sysvmsg-cli
+      - php8.2-common_sysvsem-cli
+      - php8.2-common_sysvshm-cli
+      - php8.2-common_tokenizer-cli
+
+  all-fpm:
+    essential:
+      - php8.2-common_base-fpm
+      - php8.2-common_calendar-fpm
+      - php8.2-common_ctype-fpm
+      - php8.2-common_exif-fpm
+      - php8.2-common_ffi-fpm
+      - php8.2-common_fileinfo-fpm
+      - php8.2-common_ftp-fpm
+      - php8.2-common_gettext-fpm
+      - php8.2-common_iconv-fpm
+      - php8.2-common_pdo-fpm
+      - php8.2-common_phar-fpm
+      - php8.2-common_posix-fpm
+      - php8.2-common_shmop-fpm
+      - php8.2-common_sockets-fpm
+      - php8.2-common_sysvmsg-fpm
+      - php8.2-common_sysvsem-fpm
+      - php8.2-common_sysvshm-fpm
+      - php8.2-common_tokenizer-fpm
 
   base:
+    essential:
+     - php8.2-common_base-cli
+     - php8.2-common_base-fpm
+
+  base-cli:
     essential:
       - tzdata_etc
     contents:
       /etc/php/8.2/cli/php.ini: {copy: '/usr/lib/php/8.2/php.ini-production'}
 
+  base-fpm:
+    essential:
+      - tzdata_etc
+    contents:
+      /etc/php/8.2/fpm/php.ini: {copy: '/usr/lib/php/8.2/php.ini-production'}
+
   calendar:
+    essential:
+      - php8.2-common_calendar-cli
+      - php8.2-common_calendar-fpm
+
+  calendar-cli:
     contents:
       /usr/lib/php/20220829/calendar.so:
       /etc/php/8.2/cli/conf.d/20-calendar.ini: {copy: '/usr/share/php8.2-common/common/calendar.ini'}
 
+  calendar-fpm:
+    contents:
+      /usr/lib/php/20220829/calendar.so:
+      /etc/php/8.2/fpm/conf.d/20-calendar.ini: {copy: '/usr/share/php8.2-common/common/calendar.ini'}
+
   ctype:
+    essential:
+      - php8.2-common_ctype-cli
+      - php8.2-common_ctype-fpm
+
+  ctype-cli:
     contents:
       /usr/lib/php/20220829/ctype.so:
       /etc/php/8.2/cli/conf.d/20-ctype.ini: {copy: '/usr/share/php8.2-common/common/ctype.ini'}
 
+  ctype-fpm:
+    contents:
+      /usr/lib/php/20220829/ctype.so:
+      /etc/php/8.2/fpm/conf.d/20-ctype.ini: {copy: '/usr/share/php8.2-common/common/ctype.ini'}
+
   exif:
+    essential:
+      - php8.2-common_exif-cli
+      - php8.2-common_exif-fpm
+
+  exif-cli:
     contents:
       /usr/lib/php/20220829/exif.so:
       /etc/php/8.2/cli/conf.d/20-exif.ini: {copy: '/usr/share/php8.2-common/common/exif.ini'}
 
+  exif-fpm:
+    contents:
+      /usr/lib/php/20220829/exif.so:
+      /etc/php/8.2/fpm/conf.d/20-exif.ini: {copy: '/usr/share/php8.2-common/common/exif.ini'}
+
   ffi:
+    essential:
+      - php8.2-common_ffi-cli
+      - php8.2-common_ffi-fpm
+
+  ffi-cli:
     essential:
       - libffi8_libs
     contents:
       /usr/lib/php/20220829/ffi.so:
       /etc/php/8.2/cli/conf.d/20-ffi.ini: {copy: '/usr/share/php8.2-common/common/ffi.ini'}
 
+  ffi-fpm:
+    essential:
+      - libffi8_libs
+    contents:
+      /usr/lib/php/20220829/ffi.so:
+      /etc/php/8.2/fpm/conf.d/20-ffi.ini: {copy: '/usr/share/php8.2-common/common/ffi.ini'}
+
   fileinfo:
+    essential:
+      - php8.2-common_fileinfo-cli
+      - php8.2-common_fileinfo-fpm
+
+  fileinfo-cli:
     contents:
       /usr/lib/php/20220829/fileinfo.so:
       /etc/php/8.2/cli/conf.d/20-fileinfo.ini: {copy: '/usr/share/php8.2-common/common/fileinfo.ini'}
 
+  fileinfo-fpm:
+    contents:
+      /usr/lib/php/20220829/fileinfo.so:
+      /etc/php/8.2/fpm/conf.d/20-fileinfo.ini: {copy: '/usr/share/php8.2-common/common/fileinfo.ini'}
+
   ftp:
+    essential:
+      - php8.2-common_ftp-cli
+      - php8.2-common_ftp-fpm
+
+  ftp-cli:
     contents:
       /usr/lib/php/20220829/ftp.so:
       /etc/php/8.2/cli/conf.d/20-ftp.ini: {copy: '/usr/share/php8.2-common/common/ftp.ini'}
 
+  ftp-fpm:
+    contents:
+      /usr/lib/php/20220829/ftp.so:
+      /etc/php/8.2/fpm/conf.d/20-ftp.ini: {copy: '/usr/share/php8.2-common/common/ftp.ini'}
+
   gettext:
+    essential:
+      - php8.2-common_gettext-cli
+      - php8.2-common_gettext-fpm
+
+  gettext-cli:
     contents:
       /usr/lib/php/20220829/gettext.so:
       /etc/php/8.2/cli/conf.d/20-gettext.ini: {copy: '/usr/share/php8.2-common/common/gettext.ini'}
 
+  gettext-fpm:
+    contents:
+      /usr/lib/php/20220829/gettext.so:
+      /etc/php/8.2/fpm/conf.d/20-gettext.ini: {copy: '/usr/share/php8.2-common/common/gettext.ini'}
+
   iconv:
+    essential:
+      - php8.2-common_iconv-cli
+      - php8.2-common_iconv-fpm
+
+  iconv-cli:
     contents:
       /usr/lib/php/20220829/iconv.so:
       /etc/php/8.2/cli/conf.d/20-iconv.ini: {copy: '/usr/share/php8.2-common/common/iconv.ini'}
 
+  iconv-fpm:
+    contents:
+      /usr/lib/php/20220829/iconv.so:
+      /etc/php/8.2/fpm/conf.d/20-iconv.ini: {copy: '/usr/share/php8.2-common/common/iconv.ini'}
+
   pdo:
+    essential:
+      - php8.2-common_pdo-cli
+      - php8.2-common_pdo-fpm
+
+  pdo-cli:
     contents:
       /usr/lib/php/20220829/pdo.so:
       /etc/php/8.2/cli/conf.d/10-pdo.ini: {copy: '/usr/share/php8.2-common/common/pdo.ini'}
 
+  pdo-fpm:
+    contents:
+      /usr/lib/php/20220829/pdo.so:
+      /etc/php/8.2/fpm/conf.d/10-pdo.ini: {copy: '/usr/share/php8.2-common/common/pdo.ini'}
+
   phar:
+    essential:
+      - php8.2-common_phar-cli
+      - php8.2-common_phar-fpm
+
+  phar-cli:
     contents:
       /usr/lib/php/20220829/phar.so:
       /etc/php/8.2/cli/conf.d/20-phar.ini: {copy: '/usr/share/php8.2-common/common/phar.ini'}
 
+  phar-fpm:
+    contents:
+      /usr/lib/php/20220829/phar.so:
+      /etc/php/8.2/fpm/conf.d/20-phar.ini: {copy: '/usr/share/php8.2-common/common/phar.ini'}
+
   posix:
+    essential:
+      - php8.2-common_posix-cli
+      - php8.2-common_posix-fpm
+
+  posix-cli:
     contents:
       /usr/lib/php/20220829/posix.so:
       /etc/php/8.2/cli/conf.d/20-posix.ini: {copy: '/usr/share/php8.2-common/common/posix.ini'}
 
+  posix-fpm:
+    contents:
+      /usr/lib/php/20220829/posix.so:
+      /etc/php/8.2/fpm/conf.d/20-posix.ini: {copy: '/usr/share/php8.2-common/common/posix.ini'}
+
   shmop:
+    essential:
+      - php8.2-common_shmop-cli
+      - php8.2-common_shmop-fpm
+
+  shmop-cli:
     contents:
       /usr/lib/php/20220829/shmop.so:
       /etc/php/8.2/cli/conf.d/20-shmop.ini: {copy: '/usr/share/php8.2-common/common/shmop.ini'}
 
+  shmop-fpm:
+    contents:
+      /usr/lib/php/20220829/shmop.so:
+      /etc/php/8.2/fpm/conf.d/20-shmop.ini: {copy: '/usr/share/php8.2-common/common/shmop.ini'}
+
   sockets:
+    essential:
+      - php8.2-common_sockets-cli
+      - php8.2-common_sockets-fpm
+
+  sockets-cli:
     contents:
       /usr/lib/php/20220829/sockets.so:
       /etc/php/8.2/cli/conf.d/20-sockets.ini: {copy: '/usr/share/php8.2-common/common/sockets.ini'}
 
+  sockets-fpm:
+    contents:
+      /usr/lib/php/20220829/sockets.so:
+      /etc/php/8.2/fpm/conf.d/20-sockets.ini: {copy: '/usr/share/php8.2-common/common/sockets.ini'}
+
   sysvmsg:
+    essential:
+      - php8.2-common_sysvmsg-cli
+      - php8.2-common_sysvmsg-fpm
+
+  sysvmsg-cli:
     contents:
       /usr/lib/php/20220829/sysvmsg.so:
       /etc/php/8.2/cli/conf.d/20-sysvmsg.ini: {copy: '/usr/share/php8.2-common/common/sysvmsg.ini'}
 
+  sysvmsg-fpm:
+    contents:
+      /usr/lib/php/20220829/sysvmsg.so:
+      /etc/php/8.2/fpm/conf.d/20-sysvmsg.ini: {copy: '/usr/share/php8.2-common/common/sysvmsg.ini'}
+
   sysvsem:
+    essential:
+      - php8.2-common_sysvsem-cli
+      - php8.2-common_sysvsem-fpm
+
+  sysvsem-cli:
     contents:
       /usr/lib/php/20220829/sysvsem.so:
       /etc/php/8.2/cli/conf.d/20-sysvsem.ini: {copy: '/usr/share/php8.2-common/common/sysvsem.ini'}
 
+  sysvsem-fpm:
+    contents:
+      /usr/lib/php/20220829/sysvsem.so:
+      /etc/php/8.2/fpm/conf.d/20-sysvsem.ini: {copy: '/usr/share/php8.2-common/common/sysvsem.ini'}
+
   sysvshm:
+    essential:
+      - php8.2-common_sysvshm-cli
+      - php8.2-common_sysvshm-fpm
+
+  sysvshm-cli:
     contents:
       /usr/lib/php/20220829/sysvshm.so:
       /etc/php/8.2/cli/conf.d/20-sysvshm.ini: {copy: '/usr/share/php8.2-common/common/sysvshm.ini'}
 
+  sysvshm-fpm:
+    contents:
+      /usr/lib/php/20220829/sysvshm.so:
+      /etc/php/8.2/fpm/conf.d/20-sysvshm.ini: {copy: '/usr/share/php8.2-common/common/sysvshm.ini'}
+
   tokenizer:
+    essential:
+      - php8.2-common_tokenizer-cli
+      - php8.2-common_tokenizer-fpm
+
+  tokenizer-cli:
     contents:
       /usr/lib/php/20220829/tokenizer.so:
       /etc/php/8.2/cli/conf.d/20-tokenizer.ini: {copy: '/usr/share/php8.2-common/common/tokenizer.ini'}
+
+  tokenizer-fpm:
+    contents:
+      /usr/lib/php/20220829/tokenizer.so:
+      /etc/php/8.2/fpm/conf.d/20-tokenizer.ini: {copy: '/usr/share/php8.2-common/common/tokenizer.ini'}

--- a/slices/php8.2-common.yaml
+++ b/slices/php8.2-common.yaml
@@ -1,0 +1,116 @@
+package: php8.2-common
+
+slices:
+  all:
+    essential:
+      - php8.2-common_base
+      - php8.2-common_calendar
+      - php8.2-common_ctype
+      - php8.2-common_exif
+      - php8.2-common_ffi
+      - php8.2-common_fileinfo
+      - php8.2-common_ftp
+      - php8.2-common_gettext
+      - php8.2-common_iconv
+      - php8.2-common_pdo
+      - php8.2-common_phar
+      - php8.2-common_posix
+      - php8.2-common_shmop
+      - php8.2-common_sockets
+      - php8.2-common_sysvmsg
+      - php8.2-common_sysvsem
+      - php8.2-common_sysvshm
+      - php8.2-common_tokenizer
+
+  base:
+    essential:
+      - tzdata_etc
+    contents:
+      /etc/php/8.2/cli/php.ini: {copy: '/usr/lib/php/8.2/php.ini-production'}
+
+  calendar:
+    contents:
+      /usr/lib/php/20220829/calendar.so:
+      /etc/php/8.2/cli/conf.d/20-calendar.ini: {copy: '/usr/share/php8.2-common/common/calendar.ini'}
+
+  ctype:
+    contents:
+      /usr/lib/php/20220829/ctype.so:
+      /etc/php/8.2/cli/conf.d/20-ctype.ini: {copy: '/usr/share/php8.2-common/common/ctype.ini'}
+
+  exif:
+    contents:
+      /usr/lib/php/20220829/exif.so:
+      /etc/php/8.2/cli/conf.d/20-exif.ini: {copy: '/usr/share/php8.2-common/common/exif.ini'}
+
+  ffi:
+    essential:
+      - libffi8_libs
+    contents:
+      /usr/lib/php/20220829/ffi.so:
+      /etc/php/8.2/cli/conf.d/20-ffi.ini: {copy: '/usr/share/php8.2-common/common/ffi.ini'}
+
+  fileinfo:
+    contents:
+      /usr/lib/php/20220829/fileinfo.so:
+      /etc/php/8.2/cli/conf.d/20-fileinfo.ini: {copy: '/usr/share/php8.2-common/common/fileinfo.ini'}
+
+  ftp:
+    contents:
+      /usr/lib/php/20220829/ftp.so:
+      /etc/php/8.2/cli/conf.d/20-ftp.ini: {copy: '/usr/share/php8.2-common/common/ftp.ini'}
+
+  gettext:
+    contents:
+      /usr/lib/php/20220829/gettext.so:
+      /etc/php/8.2/cli/conf.d/20-gettext.ini: {copy: '/usr/share/php8.2-common/common/gettext.ini'}
+
+  iconv:
+    contents:
+      /usr/lib/php/20220829/iconv.so:
+      /etc/php/8.2/cli/conf.d/20-iconv.ini: {copy: '/usr/share/php8.2-common/common/iconv.ini'}
+
+  pdo:
+    contents:
+      /usr/lib/php/20220829/pdo.so:
+      /etc/php/8.2/cli/conf.d/10-pdo.ini: {copy: '/usr/share/php8.2-common/common/pdo.ini'}
+
+  phar:
+    contents:
+      /usr/lib/php/20220829/phar.so:
+      /etc/php/8.2/cli/conf.d/20-phar.ini: {copy: '/usr/share/php8.2-common/common/phar.ini'}
+
+  posix:
+    contents:
+      /usr/lib/php/20220829/posix.so:
+      /etc/php/8.2/cli/conf.d/20-posix.ini: {copy: '/usr/share/php8.2-common/common/posix.ini'}
+
+  shmop:
+    contents:
+      /usr/lib/php/20220829/shmop.so:
+      /etc/php/8.2/cli/conf.d/20-shmop.ini: {copy: '/usr/share/php8.2-common/common/shmop.ini'}
+
+  sockets:
+    contents:
+      /usr/lib/php/20220829/sockets.so:
+      /etc/php/8.2/cli/conf.d/20-sockets.ini: {copy: '/usr/share/php8.2-common/common/sockets.ini'}
+
+  sysvmsg:
+    contents:
+      /usr/lib/php/20220829/sysvmsg.so:
+      /etc/php/8.2/cli/conf.d/20-sysvmsg.ini: {copy: '/usr/share/php8.2-common/common/sysvmsg.ini'}
+
+  sysvsem:
+    contents:
+      /usr/lib/php/20220829/sysvsem.so:
+      /etc/php/8.2/cli/conf.d/20-sysvsem.ini: {copy: '/usr/share/php8.2-common/common/sysvsem.ini'}
+
+  sysvshm:
+    contents:
+      /usr/lib/php/20220829/sysvshm.so:
+      /etc/php/8.2/cli/conf.d/20-sysvshm.ini: {copy: '/usr/share/php8.2-common/common/sysvshm.ini'}
+
+  tokenizer:
+    contents:
+      /usr/lib/php/20220829/tokenizer.so:
+      /etc/php/8.2/cli/conf.d/20-tokenizer.ini: {copy: '/usr/share/php8.2-common/common/tokenizer.ini'}

--- a/slices/php8.2-curl.yaml
+++ b/slices/php8.2-curl.yaml
@@ -2,7 +2,17 @@ package: php8.2-curl
 slices:
   all:
     essential:
+      - php8.2-curl_cli
+      - php8.2-curl_fpm
+  cli:
+    essential:
       - libcurl4_libs
     contents:
       /usr/lib/php/20220829/curl.so:
       /etc/php/8.2/cli/conf.d/20-curl.ini: {copy: '/usr/share/php8.2-curl/curl/curl.ini'}
+  fpm:
+    essential:
+      - libcurl4_libs
+    contents:
+      /usr/lib/php/20220829/curl.so:
+      /etc/php/8.2/fpm/conf.d/20-curl.ini: {copy: '/usr/share/php8.2-curl/curl/curl.ini'}

--- a/slices/php8.2-curl.yaml
+++ b/slices/php8.2-curl.yaml
@@ -1,0 +1,8 @@
+package: php8.2-curl
+slices:
+  all:
+    essential:
+      - libcurl4_libs
+    contents:
+      /usr/lib/php/20220829/curl.so:
+      /etc/php/8.2/cli/conf.d/20-curl.ini: {copy: '/usr/share/php8.2-curl/curl/curl.ini'}

--- a/slices/php8.2-fpm.yaml
+++ b/slices/php8.2-fpm.yaml
@@ -4,18 +4,39 @@ slices:
   all:
     essential:
       - php8.2-fpm_base
-      - php8.2-common_all
+      - php8.2-common_all-fpm
 
   base:
     essential:
       - libc6_libs
+      - libapparmor1_libs
+      - libacl1_libs
       - libgcc-s1_libs
       - libstdc++6_libs
       - libxml2_libs
       - libssl3_libs
       - libpcre2-8-0_libs
+      - libsystemd0_libs
       - libsodium23_libs
       - libargon2-1_libs
-      - php8.2-common_base
+      - php8.2-common_base-fpm
+      - base-passwd_data
     contents:
-      /usr/sbin/php-fpm: {copy: /usr/sbin/php-fpm8.1}
+      /usr/sbin/php-fpm: {copy: /usr/sbin/php-fpm8.2}
+      /etc/php/8.2/fpm/php-fpm.conf: {mutable: true}
+      /etc/php/8.2/fpm/pool.d/www.conf: {mutable: true}
+    mutate: |
+      fpmConfig = content.read("/etc/php/8.2/fpm/php-fpm.conf")
+      fpmConfig = fpmConfig.replace("error_log = /var/log/php8.2-fpm.log", "error_log = /proc/self/fd/2")
+      fpmConfig = fpmConfig.replace(";log_limit = 4096", "log_limit = 8192")
+      fpmConfig = fpmConfig.replace(";daemonize = yes", "daemonize = no")
+      fpmConfig = fpmConfig.replace("pid = /run/php/php8.2-fpm.pid", ";pid = /run/php/php8.2-fpm.pid")
+      content.write("/etc/php/8.2/fpm/php-fpm.conf", fpmConfig)
+
+      fpmPoolConfig = content.read("/etc/php/8.2/fpm/pool.d/www.conf")
+      fpmPoolConfig = fpmPoolConfig.replace(";clear_env = no", "clear_env = no")
+      fpmPoolConfig = fpmPoolConfig.replace(";catch_workers_output = yes", "catch_workers_output = yes")
+      fpmPoolConfig = fpmPoolConfig.replace(";decorate_workers_output = no", "decorate_workers_output = no")
+      fpmPoolConfig = fpmPoolConfig.replace("listen = /run/php/php8.2-fpm.sock", "listen = 9000")
+      fpmPoolConfig = fpmPoolConfig.replace(";access.log = log/$pool.access.log", "access.log = /proc/self/fd/2")
+      content.write("/etc/php/8.2/fpm/pool.d/www.conf", fpmPoolConfig)

--- a/slices/php8.2-fpm.yaml
+++ b/slices/php8.2-fpm.yaml
@@ -1,0 +1,21 @@
+package: php8.2-fpm
+
+slices:
+  all:
+    essential:
+      - php8.2-fpm_base
+      - php8.2-common_all
+
+  base:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libxml2_libs
+      - libssl3_libs
+      - libpcre2-8-0_libs
+      - libsodium23_libs
+      - libargon2-1_libs
+      - php8.2-common_base
+    contents:
+      /usr/sbin/php-fpm: {copy: /usr/sbin/php-fpm8.1}

--- a/slices/php8.2-gd.yaml
+++ b/slices/php8.2-gd.yaml
@@ -2,7 +2,17 @@ package: php8.2-gd
 slices:
   all:
     essential:
+      - php8.2-gd_cli
+      - php8.2-gd_fpm
+  cli:
+    essential:
       - libgd3_libs
     contents:
       /usr/lib/php/20220829/gd.so:
       /etc/php/8.2/cli/conf.d/20-gd.ini: {copy: '/usr/share/php8.2-gd/gd/gd.ini'}
+  fpm:
+    essential:
+      - libgd3_libs
+    contents:
+      /usr/lib/php/20220829/gd.so:
+      /etc/php/8.2/fpm/conf.d/20-gd.ini: {copy: '/usr/share/php8.2-gd/gd/gd.ini'}

--- a/slices/php8.2-gd.yaml
+++ b/slices/php8.2-gd.yaml
@@ -1,0 +1,8 @@
+package: php8.2-gd
+slices:
+  all:
+    essential:
+      - libgd3_libs
+    contents:
+      /usr/lib/php/20220829/gd.so:
+      /etc/php/8.2/cli/conf.d/20-gd.ini: {copy: '/usr/share/php8.2-gd/gd/gd.ini'}

--- a/slices/php8.2-gmp.yaml
+++ b/slices/php8.2-gmp.yaml
@@ -1,0 +1,8 @@
+package: php8.2-gmp
+slices:
+  all:
+    essential:
+      - libgmp10_libs
+    contents:
+      /usr/lib/php/20220829/gmp.so:
+      /etc/php/8.2/cli/conf.d/20-gmp.ini: {copy: '/usr/share/php8.2-gmp/gmp/gmp.ini'}

--- a/slices/php8.2-gmp.yaml
+++ b/slices/php8.2-gmp.yaml
@@ -2,7 +2,17 @@ package: php8.2-gmp
 slices:
   all:
     essential:
+      - php8.2-gmp_cli
+      - php8.2-gmp_fpm
+  cli:
+    essential:
       - libgmp10_libs
     contents:
       /usr/lib/php/20220829/gmp.so:
       /etc/php/8.2/cli/conf.d/20-gmp.ini: {copy: '/usr/share/php8.2-gmp/gmp/gmp.ini'}
+  fpm:
+    essential:
+      - libgmp10_libs
+    contents:
+      /usr/lib/php/20220829/gmp.so:
+      /etc/php/8.2/fpm/conf.d/20-gmp.ini: {copy: '/usr/share/php8.2-gmp/gmp/gmp.ini'}

--- a/slices/php8.2-igbinary.yaml
+++ b/slices/php8.2-igbinary.yaml
@@ -1,0 +1,6 @@
+package: php8.2-igbinary
+slices:
+  all:
+    contents:
+      /usr/lib/php/20220829/igbinary.so:
+      /etc/php/8.2/cli/conf.d/20-igbinary.ini: {copy: '/etc/php/8.2/mods-available/igbinary.ini'}

--- a/slices/php8.2-igbinary.yaml
+++ b/slices/php8.2-igbinary.yaml
@@ -1,6 +1,14 @@
 package: php8.2-igbinary
 slices:
   all:
+    essential:
+      - php8.2-igbinary_cli
+      - php8.2-igbinary_fpm
+  cli:
     contents:
       /usr/lib/php/20220829/igbinary.so:
       /etc/php/8.2/cli/conf.d/20-igbinary.ini: {copy: '/etc/php/8.2/mods-available/igbinary.ini'}
+  fpm:
+    contents:
+      /usr/lib/php/20220829/igbinary.so:
+      /etc/php/8.2/fpm/conf.d/20-igbinary.ini: {copy: '/etc/php/8.2/mods-available/igbinary.ini'}

--- a/slices/php8.2-intl.yaml
+++ b/slices/php8.2-intl.yaml
@@ -1,6 +1,14 @@
 package: php8.2-intl
 slices:
   all:
+    essential:
+      - php8.2-intl_cli
+      - php8.2-intl_fpm
+  cli:
     contents:
       /usr/lib/php/20220829/intl.so:
       /etc/php/8.2/cli/conf.d/20-intl.ini: {copy: '/usr/share/php8.2-intl/intl/intl.ini'}
+  fpm:
+    contents:
+      /usr/lib/php/20220829/intl.so:
+      /etc/php/8.2/fpm/conf.d/20-intl.ini: {copy: '/usr/share/php8.2-intl/intl/intl.ini'}

--- a/slices/php8.2-intl.yaml
+++ b/slices/php8.2-intl.yaml
@@ -1,0 +1,6 @@
+package: php8.2-intl
+slices:
+  all:
+    contents:
+      /usr/lib/php/20220829/intl.so:
+      /etc/php/8.2/cli/conf.d/20-intl.ini: {copy: '/usr/share/php8.2-intl/intl/intl.ini'}

--- a/slices/php8.2-ldap.yaml
+++ b/slices/php8.2-ldap.yaml
@@ -2,7 +2,17 @@ package: php8.2-ldap
 slices:
   all:
     essential:
+      - php8.2-ldap_cli
+      - php8.2-ldap_fpm
+  cli:
+    essential:
       - libldap2_libs
     contents:
       /usr/lib/php/20220829/ldap.so:
       /etc/php/8.2/cli/conf.d/20-ldap.ini: {copy: '/usr/share/php8.2-ldap/ldap/ldap.ini'}
+  fpm:
+    essential:
+      - libldap2_libs
+    contents:
+      /usr/lib/php/20220829/ldap.so:
+      /etc/php/8.2/fpm/conf.d/20-ldap.ini: {copy: '/usr/share/php8.2-ldap/ldap/ldap.ini'}

--- a/slices/php8.2-ldap.yaml
+++ b/slices/php8.2-ldap.yaml
@@ -1,0 +1,8 @@
+package: php8.2-ldap
+slices:
+  all:
+    essential:
+      - libldap2_libs
+    contents:
+      /usr/lib/php/20220829/ldap.so:
+      /etc/php/8.2/cli/conf.d/20-ldap.ini: {copy: '/usr/share/php8.2-ldap/ldap/ldap.ini'}

--- a/slices/php8.2-mbstring.yaml
+++ b/slices/php8.2-mbstring.yaml
@@ -1,0 +1,9 @@
+package: php8.2-mbstring
+
+slices:
+  all:
+    essential:
+      - libonig5_libs
+    contents:
+      /usr/lib/php/20220829/mbstring.so:
+      /etc/php/8.2/cli/conf.d/20-mbstring.ini: {copy: '/usr/share/php8.2-mbstring/mbstring/mbstring.ini'}

--- a/slices/php8.2-mbstring.yaml
+++ b/slices/php8.2-mbstring.yaml
@@ -1,9 +1,18 @@
 package: php8.2-mbstring
-
 slices:
   all:
+    essential:
+      - php8.2-mbstring_cli
+      - php8.2-mbstring_fpm
+  cli:
     essential:
       - libonig5_libs
     contents:
       /usr/lib/php/20220829/mbstring.so:
       /etc/php/8.2/cli/conf.d/20-mbstring.ini: {copy: '/usr/share/php8.2-mbstring/mbstring/mbstring.ini'}
+  fpm:
+    essential:
+      - libonig5_libs
+    contents:
+      /usr/lib/php/20220829/mbstring.so:
+      /etc/php/8.2/fpm/conf.d/20-mbstring.ini: {copy: '/usr/share/php8.2-mbstring/mbstring/mbstring.ini'}

--- a/slices/php8.2-mysql.yaml
+++ b/slices/php8.2-mysql.yaml
@@ -1,27 +1,57 @@
 package: php8.2-mysql
 
 slices:
-  libs:
+  libs-cli:
     contents:
       /usr/lib/php/20220829/mysqlnd.so:
       /etc/php/8.2/cli/conf.d/10-mysqlnd.ini: {copy: '/usr/share/php8.2-mysql/mysql/mysqlnd.ini'}
 
-  pdo:
+  libs-fpm:
+    contents:
+      /usr/lib/php/20220829/mysqlnd.so:
+      /etc/php/8.2/fpm/conf.d/10-mysqlnd.ini: {copy: '/usr/share/php8.2-mysql/mysql/mysqlnd.ini'}
+
+  pdo-cli:
     essential:
-      - php8.2-mysql_libs
+      - php8.2-mysql_libs-cli
     contents:
       /usr/lib/php/20220829/pdo_mysql.so:
       /etc/php/8.2/cli/conf.d/20-pdo_mysql.ini: {copy: '/usr/share/php8.2-mysql/mysql/pdo_mysql.ini'}
 
-  mysqli:
+  pdo-fpm:
     essential:
-      - php8.2-mysql_libs
+      - php8.2-mysql_libs-fpm
+    contents:
+      /usr/lib/php/20220829/pdo_mysql.so:
+      /etc/php/8.2/fpm/conf.d/20-pdo_mysql.ini: {copy: '/usr/share/php8.2-mysql/mysql/pdo_mysql.ini'}
+
+  mysqli-cli:
+    essential:
+      - php8.2-mysql_libs-fpm
     contents:
       /usr/lib/php/20220829/mysqli.so:
       /etc/php/8.2/cli/conf.d/20-mysqli.ini: {copy: '/usr/share/php8.2-mysql/mysql/mysqli.ini'}
 
+  mysqli-fpm:
+    essential:
+      - php8.2-mysql_libs-fpm
+    contents:
+      /usr/lib/php/20220829/mysqli.so:
+      /etc/php/8.2/fpm/conf.d/20-mysqli.ini: {copy: '/usr/share/php8.2-mysql/mysql/mysqli.ini'}
+
+  all-cli:
+    essential:
+      - php8.2-mysql_libs-cli
+      - php8.2-mysql_pdo-cli
+      - php8.2-mysql_mysqli-cli
+
+  all-fpm:
+    essential:
+      - php8.2-mysql_libs-fpm
+      - php8.2-mysql_pdo-fpm
+      - php8.2-mysql_mysqli-fpm
+
   all:
     essential:
-      - php8.2-mysql_libs
-      - php8.2-mysql_pdo
-      - php8.2-mysql_mysqli
+      - php8.2-mysql_all-cli
+      - php8.2-mysql_all-fpm

--- a/slices/php8.2-mysql.yaml
+++ b/slices/php8.2-mysql.yaml
@@ -1,0 +1,27 @@
+package: php8.2-mysql
+
+slices:
+  libs:
+    contents:
+      /usr/lib/php/20220829/mysqlnd.so:
+      /etc/php/8.2/cli/conf.d/10-mysqlnd.ini: {copy: '/usr/share/php8.2-mysql/mysql/mysqlnd.ini'}
+
+  pdo:
+    essential:
+      - php8.2-mysql_libs
+    contents:
+      /usr/lib/php/20220829/pdo_mysql.so:
+      /etc/php/8.2/cli/conf.d/20-pdo_mysql.ini: {copy: '/usr/share/php8.2-mysql/mysql/pdo_mysql.ini'}
+
+  mysqli:
+    essential:
+      - php8.2-mysql_libs
+    contents:
+      /usr/lib/php/20220829/mysqli.so:
+      /etc/php/8.2/cli/conf.d/20-mysqli.ini: {copy: '/usr/share/php8.2-mysql/mysql/mysqli.ini'}
+
+  all:
+    essential:
+      - php8.2-mysql_libs
+      - php8.2-mysql_pdo
+      - php8.2-mysql_mysqli

--- a/slices/php8.2-opcache.yaml
+++ b/slices/php8.2-opcache.yaml
@@ -1,0 +1,7 @@
+package: php8.2-opcache
+
+slices:
+  all:
+    contents:
+      /usr/lib/php/20220829/opcache.so:
+      /etc/php/8.2/cli/conf.d/10-opcache.ini: {copy: '/usr/share/php8.2-opcache/opcache/opcache.ini'}

--- a/slices/php8.2-opcache.yaml
+++ b/slices/php8.2-opcache.yaml
@@ -2,6 +2,14 @@ package: php8.2-opcache
 
 slices:
   all:
+    essential:
+      - php8.2-opcache_cli
+      - php8.2-opcache_fpm
+  cli:
     contents:
       /usr/lib/php/20220829/opcache.so:
       /etc/php/8.2/cli/conf.d/10-opcache.ini: {copy: '/usr/share/php8.2-opcache/opcache/opcache.ini'}
+  fpm:
+    contents:
+      /usr/lib/php/20220829/opcache.so:
+      /etc/php/8.2/fpm/conf.d/10-opcache.ini: {copy: '/usr/share/php8.2-opcache/opcache/opcache.ini'}

--- a/slices/php8.2-pgsql.yaml
+++ b/slices/php8.2-pgsql.yaml
@@ -1,0 +1,11 @@
+package: php8.2-pgsql
+slices:
+  all:
+    essential:
+      - libc6_libs
+      - libpq5_libs
+    contents:
+      /usr/lib/php/20220829/pdo_pgsql.so:
+      /usr/lib/php/20220829/pgsql.so:
+      /etc/php/8.2/cli/conf.d/20-pgsql.ini: {copy: '/usr/share/php8.2-pgsql/pgsql/pgsql.ini'}
+      /etc/php/8.2/cli/conf.d/20-pdo_pgsql.ini: {copy: '/usr/share/php8.2-pgsql/pgsql/pdo_pgsql.ini'}

--- a/slices/php8.2-pgsql.yaml
+++ b/slices/php8.2-pgsql.yaml
@@ -2,6 +2,10 @@ package: php8.2-pgsql
 slices:
   all:
     essential:
+      - php8.2-pgsql_cli
+      - php8.2-pgsql_fpm
+  cli:
+    essential:
       - libc6_libs
       - libpq5_libs
     contents:
@@ -9,3 +13,12 @@ slices:
       /usr/lib/php/20220829/pgsql.so:
       /etc/php/8.2/cli/conf.d/20-pgsql.ini: {copy: '/usr/share/php8.2-pgsql/pgsql/pgsql.ini'}
       /etc/php/8.2/cli/conf.d/20-pdo_pgsql.ini: {copy: '/usr/share/php8.2-pgsql/pgsql/pdo_pgsql.ini'}
+  fpm:
+    essential:
+      - libc6_libs
+      - libpq5_libs
+    contents:
+      /usr/lib/php/20220829/pdo_pgsql.so:
+      /usr/lib/php/20220829/pgsql.so:
+      /etc/php/8.2/fpm/conf.d/20-pgsql.ini: {copy: '/usr/share/php8.2-pgsql/pgsql/pgsql.ini'}
+      /etc/php/8.2/fpm/conf.d/20-pdo_pgsql.ini: {copy: '/usr/share/php8.2-pgsql/pgsql/pdo_pgsql.ini'}

--- a/slices/php8.2-soap.yaml
+++ b/slices/php8.2-soap.yaml
@@ -2,7 +2,17 @@ package: php8.2-soap
 slices:
   all:
     essential:
+      - php8.2-soap_cli
+      - php8.2-soap_fpm
+  cli:
+    essential:
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/soap.so:
       /etc/php/8.2/cli/conf.d/20-soap.ini: {copy: '/usr/share/php8.2-soap/soap/soap.ini'}
+  fpm:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/soap.so:
+      /etc/php/8.2/fpm/conf.d/20-soap.ini: {copy: '/usr/share/php8.2-soap/soap/soap.ini'}

--- a/slices/php8.2-soap.yaml
+++ b/slices/php8.2-soap.yaml
@@ -1,0 +1,8 @@
+package: php8.2-soap
+slices:
+  all:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/soap.so:
+      /etc/php/8.2/cli/conf.d/20-soap.ini: {copy: '/usr/share/php8.2-soap/soap/soap.ini'}

--- a/slices/php8.2-sqlite3.yaml
+++ b/slices/php8.2-sqlite3.yaml
@@ -1,0 +1,8 @@
+package: php8.2-sqlite3
+slices:
+  all:
+    essential:
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/php/20220829/sqlite3.so:
+      /etc/php/8.2/cli/conf.d/20-sqlite3.ini: {copy: '/usr/share/php8.2-sqlite3/sqlite3/sqlite3.ini'}

--- a/slices/php8.2-sqlite3.yaml
+++ b/slices/php8.2-sqlite3.yaml
@@ -2,6 +2,16 @@ package: php8.2-sqlite3
 slices:
   all:
     essential:
+      - php8.2-sqlite3_cli
+      - php8.2-sqlite3_fpm
+  cli:
+    essential:
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/php/20220829/sqlite3.so:
+      /etc/php/8.2/cli/conf.d/20-sqlite3.ini: {copy: '/usr/share/php8.2-sqlite3/sqlite3/sqlite3.ini'}
+  fpm:
+    essential:
       - libsqlite3-0_libs
     contents:
       /usr/lib/php/20220829/sqlite3.so:

--- a/slices/php8.2-xml.yaml
+++ b/slices/php8.2-xml.yaml
@@ -3,52 +3,134 @@ package: php8.2-xml
 slices:
   all:
     essential:
-      - php8.2-xml_dom
-      - php8.2-xml_simplexml
-      - php8.2-xml_xml
-      - php8.2-xml_xmlreader
-      - php8.2-xml_xmlwriter
-      - php8.2-xml_xsl
-  
+      - php8.2-xml_cli
+      - php8.2-xml_fpm
+  cli:
+    essential:
+      - php8.2-xml_dom-cli
+      - php8.2-xml_simplexml-cli
+      - php8.2-xml_xml-cli
+      - php8.2-xml_xmlreader-cli
+      - php8.2-xml_xmlwriter-cli
+      - php8.2-xml_xsl-cli
+  fpm:
+    essential:
+      - php8.2-xml_dom-fpm
+      - php8.2-xml_simplexml-fpm
+      - php8.2-xml_xml-fpm
+      - php8.2-xml_xmlreader-fpm
+      - php8.2-xml_xmlwriter-fpm
+      - php8.2-xml_xsl-fpm
   dom:
+    essential:
+      - php8.2-xml_dom-cli
+      - php8.2-xml_dom-fpm
+  dom-cli:
     essential:
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/dom.so:
       /etc/php/8.2/cli/conf.d/20-dom.ini: {copy: '/usr/share/php8.2-xml/xml/dom.ini'}
+  dom-fpm:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/dom.so:
+      /etc/php/8.2/fpm/conf.d/20-dom.ini: {copy: '/usr/share/php8.2-xml/xml/dom.ini'}
 
   simplexml:
+    essential:
+      - php8.2-xml_simplexml-cli
+      - php8.2-xml_simplexml-fpm
+
+  simplexml-cli:
     essential:
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/simplexml.so:
       /etc/php/8.2/cli/conf.d/20-simplexml.ini: {copy: '/usr/share/php8.2-xml/xml/simplexml.ini'}
 
+  simplexml-fpm:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/simplexml.so:
+      /etc/php/8.2/fpm/conf.d/20-simplexml.ini: {copy: '/usr/share/php8.2-xml/xml/simplexml.ini'}
+
   xml:
+    essential:
+      - php8.2-xml_xml-cli
+      - php8.2-xml_xml-fpm
+
+  xml-cli:
     essential:
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/xml.so:
       /etc/php/8.2/cli/conf.d/20-xml.ini: {copy: '/usr/share/php8.2-xml/xml/xml.ini'}
 
+  xml-fpm:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xml.so:
+      /etc/php/8.2/fpm/conf.d/20-xml.ini: {copy: '/usr/share/php8.2-xml/xml/xml.ini'}
+
   xmlreader:
+    essential:
+      - php8.2-xml_xmlreader-cli
+      - php8.2-xml_xmlreader-fpm
+
+  xmlreader-cli:
     essential:
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/xmlreader.so:
       /etc/php/8.2/cli/conf.d/20-xmlreader.ini: {copy: '/usr/share/php8.2-xml/xml/xmlreader.ini'}
 
+  xmlreader-fpm:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xmlreader.so:
+      /etc/php/8.2/fpm/conf.d/20-xmlreader.ini: {copy: '/usr/share/php8.2-xml/xml/xmlreader.ini'}
+
   xmlwriter:
+    essential:
+      - php8.2-xml_xmlwriter-cli
+      - php8.2-xml_xmlwriter-fpm
+
+  xmlwriter-cli:
     essential:
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/xmlwriter.so:
       /etc/php/8.2/cli/conf.d/20-xmlwriter.ini: {copy: '/usr/share/php8.2-xml/xml/xmlwriter.ini'}
 
+  xmlwriter-fpm:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xmlwriter.so:
+      /etc/php/8.2/fpm/conf.d/20-xmlwriter.ini: {copy: '/usr/share/php8.2-xml/xml/xmlwriter.ini'}
+
   xsl:
+    essential:
+      - php8.2-xml_xsl-cli
+      - php8.2-xml_xsl-fpm
+
+  xsl-cli:
     essential:
       - libxslt1.1_libs
       - libxml2_libs
     contents:
       /usr/lib/php/20220829/xsl.so:
       /etc/php/8.2/cli/conf.d/20-xsl.ini: {copy: '/usr/share/php8.2-xml/xml/xsl.ini'}
+
+  xsl-fpm:
+    essential:
+      - libxslt1.1_libs
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xsl.so:
+      /etc/php/8.2/fpm/conf.d/20-xsl.ini: {copy: '/usr/share/php8.2-xml/xml/xsl.ini'}

--- a/slices/php8.2-xml.yaml
+++ b/slices/php8.2-xml.yaml
@@ -1,0 +1,54 @@
+package: php8.2-xml
+
+slices:
+  all:
+    essential:
+      - php8.2-xml_dom
+      - php8.2-xml_simplexml
+      - php8.2-xml_xml
+      - php8.2-xml_xmlreader
+      - php8.2-xml_xmlwriter
+      - php8.2-xml_xsl
+  
+  dom:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/dom.so:
+      /etc/php/8.2/cli/conf.d/20-dom.ini: {copy: '/usr/share/php8.2-xml/xml/dom.ini'}
+
+  simplexml:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/simplexml.so:
+      /etc/php/8.2/cli/conf.d/20-simplexml.ini: {copy: '/usr/share/php8.2-xml/xml/simplexml.ini'}
+
+  xml:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xml.so:
+      /etc/php/8.2/cli/conf.d/20-xml.ini: {copy: '/usr/share/php8.2-xml/xml/xml.ini'}
+
+  xmlreader:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xmlreader.so:
+      /etc/php/8.2/cli/conf.d/20-xmlreader.ini: {copy: '/usr/share/php8.2-xml/xml/xmlreader.ini'}
+
+  xmlwriter:
+    essential:
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xmlwriter.so:
+      /etc/php/8.2/cli/conf.d/20-xmlwriter.ini: {copy: '/usr/share/php8.2-xml/xml/xmlwriter.ini'}
+
+  xsl:
+    essential:
+      - libxslt1.1_libs
+      - libxml2_libs
+    contents:
+      /usr/lib/php/20220829/xsl.so:
+      /etc/php/8.2/cli/conf.d/20-xsl.ini: {copy: '/usr/share/php8.2-xml/xml/xsl.ini'}

--- a/slices/php8.2-zip.yaml
+++ b/slices/php8.2-zip.yaml
@@ -1,0 +1,9 @@
+package: php8.2-zip
+
+slices:
+  all:
+    essential:
+      - libzip4_libs
+    contents:
+      /usr/lib/php/20220829/zip.so:
+      /etc/php/8.2/cli/conf.d/20-zip.ini: {copy: '/usr/share/php8.2-zip/zip/zip.ini'}

--- a/slices/php8.2-zip.yaml
+++ b/slices/php8.2-zip.yaml
@@ -3,7 +3,17 @@ package: php8.2-zip
 slices:
   all:
     essential:
+      - php8.2-zip_cli
+      - php8.2-zip_fpm
+  cli:
+    essential:
       - libzip4_libs
     contents:
       /usr/lib/php/20220829/zip.so:
       /etc/php/8.2/cli/conf.d/20-zip.ini: {copy: '/usr/share/php8.2-zip/zip/zip.ini'}
+  fpm:
+    essential:
+      - libzip4_libs
+    contents:
+      /usr/lib/php/20220829/zip.so:
+      /etc/php/8.2/fpm/conf.d/20-zip.ini: {copy: '/usr/share/php8.2-zip/zip/zip.ini'}

--- a/slices/tzdata.yaml
+++ b/slices/tzdata.yaml
@@ -1,0 +1,191 @@
+package: tzdata
+
+slices:
+  # The "base" slice contains Canonical timezone abbreviations. These are primary,
+  # preferred zone names that are often used as abbreviations for location-specific
+  # timezones across the globe. Example: Europe/Sofia observes EET.
+  base:
+    contents:
+      /usr/share/zoneinfo/CET:
+      /usr/share/zoneinfo/CST6CDT:
+      /usr/share/zoneinfo/EET:
+      /usr/share/zoneinfo/EST:
+      /usr/share/zoneinfo/EST5EDT:
+      /usr/share/zoneinfo/Factory:
+      /usr/share/zoneinfo/HST:
+      /usr/share/zoneinfo/iso3166.tab:
+      /usr/share/zoneinfo/leapseconds:
+      /usr/share/zoneinfo/leap-seconds.list:
+      /usr/share/zoneinfo/localtime:
+      /usr/share/zoneinfo/MET:
+      /usr/share/zoneinfo/MST:
+      /usr/share/zoneinfo/MST7MDT:
+      /usr/share/zoneinfo/PST8PDT:
+      /usr/share/zoneinfo/tzdata.zi:
+      /usr/share/zoneinfo/WET:
+
+  africa:
+    essential:
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Africa/*:
+      /usr/share/zoneinfo/Egypt:
+      /usr/share/zoneinfo/Libya:
+
+  america:
+    essential:
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/America/**:
+      /usr/share/zoneinfo/posix/America/**:
+      /usr/share/zoneinfo/right/America/**:
+      /usr/share/zoneinfo/Cuba:
+      /usr/share/zoneinfo/Jamaica:
+      /usr/share/zoneinfo/Navajo:
+
+  antarctica:
+    essential:
+      - tzdata_config
+      - tzdata_eurasia
+      - tzdata_pacific
+    contents:
+      /usr/share/zoneinfo/Antarctica/*:
+
+  arctic:
+    essential:
+      - tzdata_config
+      - tzdata_eurasia
+    contents:
+      /usr/share/zoneinfo/Arctic/*:
+
+  atlantic:
+    essential:
+      - tzdata_africa
+      - tzdata_config
+      - tzdata_eurasia
+    contents:
+      /usr/share/zoneinfo/Atlantic/*:
+
+  australia:
+    essential:
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Australia/*:
+
+  # Some counties, although geographically belonging to a continent, are kept
+  # in their own slice since that is how they are structured in the tzdata deb.
+  brazil:
+    essential:
+      - tzdata_america
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Brazil/*:
+
+  canada:
+    essential:
+      - tzdata_america
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Canada/*:
+  chile:
+    essential:
+      - tzdata_america
+      - tzdata_config
+      - tzdata_pacific
+    contents:
+      /usr/share/zoneinfo/Chile/*:
+
+  config:
+    contents:
+      # The .tab files are intended as an aid for users, to help them select
+      # timezones appropriate for their practical needs.
+      /usr/share/zoneinfo/zone1970.tab:
+      /usr/share/zoneinfo/zone.tab:
+
+  # "Etc" is meant to provide "timezones" that don't fit with the standard timezones.
+  # As an example, UTC isn't actually a timezone, but a standard. Like Zulu and others,
+  # most of these can be used for time information, but derive from different domains
+  # (like the military). Same for others.
+  etc:
+    contents:
+      /usr/share/zoneinfo/Etc/*:
+      /usr/share/zoneinfo/UTC:
+      /usr/share/zoneinfo/WET:
+
+  eurasia:
+    essential:
+      # tzdata_africa is needed because the "Iceland" symlink needs it.
+      - tzdata_africa
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Asia/*:
+      /usr/share/zoneinfo/Europe/*:
+      /usr/share/zoneinfo/Eire:
+      /usr/share/zoneinfo/GB:
+      /usr/share/zoneinfo/GB-Eire:
+      /usr/share/zoneinfo/Hongkong:
+      /usr/share/zoneinfo/Iceland:
+      /usr/share/zoneinfo/Iran:
+      /usr/share/zoneinfo/Israel:
+      /usr/share/zoneinfo/Japan:
+      /usr/share/zoneinfo/Poland:
+      /usr/share/zoneinfo/Portugal:
+      /usr/share/zoneinfo/PRC:
+      /usr/share/zoneinfo/ROC:
+      /usr/share/zoneinfo/ROK:
+      /usr/share/zoneinfo/Singapore:
+      /usr/share/zoneinfo/Turkey:
+      /usr/share/zoneinfo/W-SU:
+
+  indian:
+    essential:
+      - tzdata_africa
+      - tzdata_config
+      - tzdata_eurasia
+    contents:
+      /usr/share/zoneinfo/Indian/*:
+
+  mexico:
+    essential:
+      - tzdata_america
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Mexico/*:
+
+  pacific:
+    essential:
+      - tzdata_config
+    contents:
+      /usr/share/zoneinfo/Pacific/*:
+      /usr/share/zoneinfo/Kwajalein:
+      /usr/share/zoneinfo/NZ:
+      /usr/share/zoneinfo/NZ-CHAT:
+
+  united-states:
+    essential:
+      - tzdata_america
+      - tzdata_config
+      - tzdata_pacific
+    contents:
+      /usr/share/zoneinfo/US/*:
+
+  # Install all timezones.
+  zoneinfo:
+    essential:
+      - tzdata_africa
+      - tzdata_america
+      - tzdata_antarctica
+      - tzdata_arctic
+      - tzdata_atlantic
+      - tzdata_australia
+      - tzdata_base
+      - tzdata_brazil
+      - tzdata_canada
+      - tzdata_chile
+      - tzdata_config
+      - tzdata_etc
+      - tzdata_eurasia
+      - tzdata_indian
+      - tzdata_mexico
+      - tzdata_pacific
+      - tzdata_united-states


### PR DESCRIPTION
Added PHP 8.2 and its dependencies.

I tried out yesterday-first time Chisel, and it worked so well for simple binaries. I work a lot with PHP and for all that stuff exists PHP packages on Ubuntu. Therefore, I added slices for most PHP packages.

both with following extensions: gd intl mysqli pdo_mysql pcntl sockets zip ffi opcache
Official PHP Alpine Image: 147MB
Chisel PHP is: 98.2MB

and the Chisel one even is glibc, so no hassle with musl