### PR TITLE
add dash package for ubuntu 23.10

### DIFF
--- a/slices/dash.yaml
+++ b/slices/dash.yaml
@@ -1,0 +1,9 @@
+package: dash
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+    contents:
+      /bin/dash:
+      /bin/sh:


### PR DESCRIPTION
You need any shell to use an ubuntu chisel-based image in a Gitlab pipeline. Therefore I added the basic one `/bin/sh`