### PR TITLE
fix(ubuntu-23.10): permission configuration for log files

### DIFF
--- a/slices/nginx-common.yaml
+++ b/slices/nginx-common.yaml
@@ -23,8 +23,8 @@ slices:
       /etc/nginx/win-utf:
       # Created by the maintainer scripts
       /var/log/nginx/: {make: true, mode: 0755}
-      /var/log/nginx/access.log: {text: "", mode: 640} 
-      /var/log/nginx/error.log: {text: "", mode: 640}
+      /var/log/nginx/access.log: {text: "", mode: 0640} 
+      /var/log/nginx/error.log: {text: "", mode: 0640}
       /etc/nginx/sites-enabled/default: {symlink: /etc/nginx/sites-available/default}
       /var/www/html/: {make: true}
       /var/lib/nginx/: {make: true}


### PR DESCRIPTION
otherwise I get

```
------
 > [internal] load build context:
------
ERROR: failed to solve: error from sender: failed to xattr rootfs/var/log/nginx/access.log: permission denied
```