### PR TITLE
nginx-common: remove logrotate config

### DIFF
--- a/slices/nginx-common.yaml
+++ b/slices/nginx-common.yaml
@@ -7,7 +7,6 @@ slices:
   # There's also no need (yet) for any init- and systemd-related files.
   config:
     contents:
-      /etc/logrotate.d/nginx:
       /etc/nginx/fastcgi.conf:
       /etc/nginx/fastcgi_params:
       /etc/nginx/koi-utf:
@@ -28,6 +27,10 @@ slices:
       /etc/nginx/sites-enabled/default: {symlink: /etc/nginx/sites-available/default}
       /var/www/html/: {make: true}
       /var/lib/nginx/: {make: true}
+
+  logrotate-config:
+    contents:
+      /etc/logrotate.d/nginx:
 
   ufw-config:
     contents:


### PR DESCRIPTION
You won't need log rotate in a docker container, when the best practise is to use `/dev/stdout`