### PR TITLE
feat(24.04): add python3.11 slices and dependencies

### DIFF
--- a/slices/libbz2-1.0.yaml
+++ b/slices/libbz2-1.0.yaml
@@ -1,7 +1,8 @@
-package: liblzma5
+package: libbz2-1.0
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/*-linux-*/liblzma.so.*:
+      /lib/*-linux-*/libbz2.so.1*:

--- a/slices/libdb5.3.yaml
+++ b/slices/libdb5.3.yaml
@@ -1,7 +1,8 @@
-package: liblzma5
+package: libdb5.3
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/*-linux-*/liblzma.so.*:
+      /usr/lib/*-linux-*/libdb-5.3.so:

--- a/slices/libexpat1.yaml
+++ b/slices/libexpat1.yaml
@@ -1,0 +1,9 @@
+package: libexpat1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libexpat.so.1*:
+      /usr/lib/*-linux-*/libexpatw.so.1*:

--- a/slices/libffi8.yaml
+++ b/slices/libffi8.yaml
@@ -1,7 +1,8 @@
-package: liblzma5
+package: libffi8
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/*-linux-*/liblzma.so.*:
+      /usr/lib/*-linux-*/libffi.so.8*:

--- a/slices/libgssapi-krb5-2.yaml
+++ b/slices/libgssapi-krb5-2.yaml
@@ -1,0 +1,12 @@
+package: libgssapi-krb5-2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcom-err2_libs
+      - libk5crypto3_libs
+      - libkrb5-3_libs
+      - libkrb5support0_libs
+    contents:
+      /usr/lib/*-linux-*/libgssapi_krb5.so.2*:

--- a/slices/libncursesw6.yaml
+++ b/slices/libncursesw6.yaml
@@ -1,0 +1,12 @@
+package: libncursesw6
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/*-linux-*/libformw.so.6*:
+      /usr/lib/*-linux-*/libmenuw.so.6*:
+      /usr/lib/*-linux-*/libncursesw.so.6*:
+      /usr/lib/*-linux-*/libpanelw.so.6*:

--- a/slices/libnsl2.yaml
+++ b/slices/libnsl2.yaml
@@ -1,0 +1,9 @@
+package: libnsl2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libtirpc3_libs
+    contents:
+      /usr/lib/*-linux-*/libnsl.so.2*:

--- a/slices/libpython3.11-minimal.yaml
+++ b/slices/libpython3.11-minimal.yaml
@@ -1,0 +1,113 @@
+package: libpython3.11-minimal
+
+# Most of the python3.11 standard libraries are split into
+# two major packages:
+# - libpython3.11-minimal (this one)
+# - libpython3.11-stdlib
+# While the libpython3.11-stdlib package has been chiselled logically
+# into granular slices, the same hasn't been done for this package.
+# The reason is simple, the libraries in this package are tightly
+# dependent upon each other.
+slices:
+  config:
+    contents:
+      /etc/python3.11/sitecustomize.py:
+
+  libs:
+    essential:
+      - libc6_libs
+      - libpython3.11-minimal_config
+      - libssl3_libs
+    contents:
+      /usr/lib/python3.11/__future__.py:
+      /usr/lib/python3.11/_collections_abc.py:
+      /usr/lib/python3.11/_compat_pickle.py:
+      /usr/lib/python3.11/_py_abc.py:
+      /usr/lib/python3.11/_sitebuiltins.py:
+      /usr/lib/python3.11/_strptime.py:
+      /usr/lib/python3.11/_sysconfigdata__*-linux-*.py:
+      /usr/lib/python3.11/_threading_local.py:
+      /usr/lib/python3.11/_weakrefset.py:
+      /usr/lib/python3.11/abc.py:
+      /usr/lib/python3.11/argparse.py:
+      /usr/lib/python3.11/ast.py:
+      /usr/lib/python3.11/base64.py:
+      /usr/lib/python3.11/bisect.py:
+      /usr/lib/python3.11/calendar.py:
+      /usr/lib/python3.11/codecs.py:
+      /usr/lib/python3.11/collections/**:
+      /usr/lib/python3.11/compileall.py:
+      /usr/lib/python3.11/configparser.py:
+      /usr/lib/python3.11/contextlib.py:
+      /usr/lib/python3.11/copy.py:
+      /usr/lib/python3.11/copyreg.py:
+      /usr/lib/python3.11/csv.py:
+      /usr/lib/python3.11/datetime.py:
+      /usr/lib/python3.11/dis.py:
+      /usr/lib/python3.11/email/**:
+      /usr/lib/python3.11/encodings/**:
+      /usr/lib/python3.11/enum.py:
+      /usr/lib/python3.11/filecmp.py:
+      /usr/lib/python3.11/fnmatch.py:
+      /usr/lib/python3.11/functools.py:
+      /usr/lib/python3.11/genericpath.py:
+      /usr/lib/python3.11/getopt.py:
+      /usr/lib/python3.11/glob.py:
+      /usr/lib/python3.11/hashlib.py:
+      /usr/lib/python3.11/heapq.py:
+      /usr/lib/python3.11/imp.py:
+      /usr/lib/python3.11/importlib/**:
+      /usr/lib/python3.11/inspect.py:
+      /usr/lib/python3.11/io.py:
+      /usr/lib/python3.11/ipaddress.py:
+      /usr/lib/python3.11/keyword.py:
+      /usr/lib/python3.11/lib-dynload/_hashlib.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_ssl.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/linecache.py:
+      /usr/lib/python3.11/locale.py:
+      /usr/lib/python3.11/logging/**:
+      /usr/lib/python3.11/opcode.py:
+      /usr/lib/python3.11/operator.py:
+      /usr/lib/python3.11/optparse.py:
+      /usr/lib/python3.11/os.py:
+      /usr/lib/python3.11/pathlib.py:
+      /usr/lib/python3.11/pickle.py:
+      /usr/lib/python3.11/pkgutil.py:
+      /usr/lib/python3.11/platform.py:
+      /usr/lib/python3.11/posixpath.py:
+      /usr/lib/python3.11/py_compile.py:
+      /usr/lib/python3.11/quopri.py:
+      /usr/lib/python3.11/random.py:
+      /usr/lib/python3.11/re/**:
+      /usr/lib/python3.11/reprlib.py:
+      /usr/lib/python3.11/runpy.py:
+      /usr/lib/python3.11/selectors.py:
+      /usr/lib/python3.11/signal.py:
+      /usr/lib/python3.11/site.py:
+      /usr/lib/python3.11/sitecustomize.py:
+      /usr/lib/python3.11/socket.py:
+      /usr/lib/python3.11/sre_compile.py:
+      /usr/lib/python3.11/sre_constants.py:
+      /usr/lib/python3.11/sre_parse.py:
+      /usr/lib/python3.11/ssl.py:
+      /usr/lib/python3.11/stat.py:
+      /usr/lib/python3.11/string.py:
+      /usr/lib/python3.11/stringprep.py:
+      /usr/lib/python3.11/struct.py:
+      /usr/lib/python3.11/subprocess.py:
+      /usr/lib/python3.11/sysconfig.py:
+      /usr/lib/python3.11/tempfile.py:
+      /usr/lib/python3.11/textwrap.py:
+      /usr/lib/python3.11/threading.py:
+      /usr/lib/python3.11/token.py:
+      /usr/lib/python3.11/tokenize.py:
+      /usr/lib/python3.11/traceback.py:
+      /usr/lib/python3.11/tracemalloc.py:
+      /usr/lib/python3.11/types.py:
+      /usr/lib/python3.11/typing.py:
+      /usr/lib/python3.11/urllib/**:
+      /usr/lib/python3.11/uu.py:
+      /usr/lib/python3.11/warnings.py:
+      /usr/lib/python3.11/weakref.py:
+      /usr/lib/python3.11/zipfile.py:
+      /usr/lib/python3.11/zipimport.py:

--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -1,0 +1,396 @@
+package: libpython3.11-stdlib
+
+# The slices in this package have been grouped with inspiration from the
+# Python 3.11 Standard Library
+# (https://docs.python.org/3.11/library/index.html).
+#
+# Aside from the "core" slice which contains the minimal libraries that
+# should come from this package and the "extra" slice which contains
+# miscellaneous libraries, all the other slice definitions are sorted by
+# their names. The "core" slice is placed at the very beginning and the
+# "extra" slice at the very end.
+slices:
+  # The "core" slice provides a very minimal libpython3.11-stdlib
+  core:
+    essential:
+      - libbz2-1.0_libs
+      - libc6_libs
+      - liblzma5_libs
+      - libpython3.11-minimal_libs
+      - media-types_data
+      - netbase_config
+    contents:
+      /usr/lib/python3.11/_bootsubprocess.py:
+      /usr/lib/python3.11/_compression.py:
+      /usr/lib/python3.11/bz2.py:
+      /usr/lib/python3.11/contextvars.py:
+      /usr/lib/python3.11/dataclasses.py:
+      /usr/lib/python3.11/gettext.py:
+      /usr/lib/python3.11/gzip.py:
+      /usr/lib/python3.11/http/__init__.py:
+      /usr/lib/python3.11/http/client.py:
+      /usr/lib/python3.11/lib-dynload/_bz2.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_codecs_*.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_contextvars.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_lzma.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_multibytecodec.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_queue.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_typing.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/mmap.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lzma.py:
+      /usr/lib/python3.11/mimetypes.py:
+      /usr/lib/python3.11/ntpath.py:
+      /usr/lib/python3.11/queue.py:
+      /usr/lib/python3.11/shutil.py:
+      /usr/lib/python3.11/socketserver.py:
+      /usr/lib/python3.11/tarfile.py:
+
+  # Shared AIX (IBM) support functions
+  aix-support:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/_aix_support.py:
+
+  # Generic Operating System Services
+  # https://docs.python.org/3.11/library/allos.html
+  all-os:
+    essential:
+      - libffi8_libs
+      - libncursesw6_libs
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_unix
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.11/_pyio.py:
+      /usr/lib/python3.11/ctypes/**:
+      /usr/lib/python3.11/curses/**:
+      /usr/lib/python3.11/getpass.py:
+      /usr/lib/python3.11/lib-dynload/_ctypes*.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_curses*.cpython-311-*-linux-*.so:
+
+  # Concurrent Execution
+  # https://docs.python.org/3.11/library/concurrency.html
+  concurrency:
+    essential:
+      - libpython3.11-stdlib_all-os
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_crypto
+    contents:
+      /usr/lib/python3.11/concurrent/**:
+      /usr/lib/python3.11/lib-dynload/_multiprocessing.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_posixshmem.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/multiprocessing/**:
+      /usr/lib/python3.11/sched.py:
+
+  # Cryptographic Services
+  # https://docs.python.org/3.11/library/crypto.html
+  crypto:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/hmac.py:
+      /usr/lib/python3.11/secrets.py:
+
+  # Custom Python Interpreters
+  # https://docs.python.org/3.11/library/custominterp.html
+  custom-interpreters:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_text
+    contents:
+      /usr/lib/python3.11/code.py:
+      /usr/lib/python3.11/codeop.py:
+
+  # Data Persistence
+  # https://docs.python.org/3.11/library/persistence.html
+  data-persistence:
+    essential:
+      - libdb5.3_libs
+      - libpython3.11-stdlib_core
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/python3.11/dbm/**:
+      /usr/lib/python3.11/lib-dynload/_dbm.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_sqlite3.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/shelve.py:
+      /usr/lib/python3.11/sqlite3/**:
+
+  # Data Types
+  # https://docs.python.org/3.11/library/datatypes.html
+  data-types:
+    essential:
+      - libpython3.11-stdlib_core
+      - tzdata_zoneinfo
+    contents:
+      /usr/lib/python3.11/graphlib.py:
+      /usr/lib/python3.11/lib-dynload/_zoneinfo.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/pprint.py:
+      /usr/lib/python3.11/zoneinfo/**:
+
+  # Debugging and Profiling
+  # https://docs.python.org/3.11/library/debug.html
+  debug:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_custom-interpreters
+      - libpython3.11-stdlib_data-types
+      - libpython3.11-stdlib_frameworks
+      - libpython3.11-stdlib_text
+    contents:
+      /usr/lib/python3.11/bdb.py:
+      /usr/lib/python3.11/cProfile.py:
+      /usr/lib/python3.11/lib-dynload/_lsprof.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/pdb.py:
+      /usr/lib/python3.11/profile.py:
+      /usr/lib/python3.11/pstats.py:
+      /usr/lib/python3.11/timeit.py:
+      /usr/lib/python3.11/trace.py:
+
+  # Development Tools
+  # https://docs.python.org/3.11/library/development.html
+  development-tools:
+    essential:
+      - libpython3.11-stdlib_all-os
+      - libpython3.11-stdlib_concurrency
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_data-types
+      - libpython3.11-stdlib_debug
+      - libpython3.11-stdlib_distribution
+      - libpython3.11-stdlib_internet
+      - libpython3.11-stdlib_ipc
+      - libpython3.11-stdlib_markup-tools
+      - libpython3.11-stdlib_net-data
+      - libpython3.11-stdlib_numeric
+      - libpython3.11-stdlib_text
+      - libpython3.11-stdlib_unix
+    contents:
+      /usr/lib/python3.11/__phello__/**:
+      /usr/lib/python3.11/doctest.py:
+      /usr/lib/python3.11/lib-dynload/_testbuffer.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_testcapi.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_testimportmultiple.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_testinternalcapi.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_testmultiphase.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_xxsubinterpreters.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/_xxtestfuzz.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/xxlimited_35.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/xxlimited.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/test/**:
+      /usr/lib/python3.11/unittest/**:
+
+  # Software Packaging and Distribution
+  # https://docs.python.org/3.11/library/distribution.html
+  distribution:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_osx-support
+    contents:
+      /usr/lib/python3.11/_distutils_system_mod.py:
+      /usr/lib/python3.11/distutils/**:
+      /usr/lib/python3.11/venv/**:
+      /usr/lib/python3.11/zipapp.py:
+
+  # File Formats
+  # https://docs.python.org/3.11/library/fileformats.html
+  file-formats:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_frameworks
+      - libpython3.11-stdlib_markup-tools
+    contents:
+      /usr/lib/python3.11/netrc.py:
+      /usr/lib/python3.11/plistlib.py:
+      /usr/lib/python3.11/tomllib/**:
+      /usr/lib/python3.11/xdrlib.py:
+
+  # File and Directory Access
+  # https://docs.python.org/3.11/library/filesys.html
+  filesys:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/fileinput.py:
+
+  # Program Frameworks
+  # https://docs.python.org/3.11/library/frameworks.html
+  frameworks:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_text
+    contents:
+      /usr/lib/python3.11/cmd.py:
+      /usr/lib/python3.11/shlex.py:
+      /usr/lib/python3.11/turtle.py:
+
+  # Importing Modules
+  # https://docs.python.org/3.11/library/modules.html
+  importing:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/modulefinder.py:
+
+  # Internet Protocols and Support
+  # https://docs.python.org/3.11/library/internet.html
+  internet:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_crypto
+      - libpython3.11-stdlib_file-formats
+      - libpython3.11-stdlib_frameworks
+      - libpython3.11-stdlib_ipc
+      - libpython3.11-stdlib_markup-tools
+      - libpython3.11-stdlib_numeric
+      - libpython3.11-stdlib_pydoc
+      - libuuid1_libs
+    contents:
+      /usr/lib/python3.11/cgi.py:
+      /usr/lib/python3.11/cgitb.py:
+      /usr/lib/python3.11/ftplib.py:
+      /usr/lib/python3.11/http/cookiejar.py:
+      /usr/lib/python3.11/http/cookies.py:
+      /usr/lib/python3.11/http/server.py:
+      /usr/lib/python3.11/imaplib.py:
+      /usr/lib/python3.11/lib-dynload/_uuid.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/nntplib.py:
+      /usr/lib/python3.11/nturl2path.py:
+      /usr/lib/python3.11/poplib.py:
+      /usr/lib/python3.11/smtpd.py:
+      /usr/lib/python3.11/smtplib.py:
+      /usr/lib/python3.11/telnetlib.py:
+      /usr/lib/python3.11/uuid.py:
+      /usr/lib/python3.11/webbrowser.py:
+      /usr/lib/python3.11/wsgiref/**:
+      /usr/lib/python3.11/xmlrpc/**:
+
+  # Networking and Interprocess Communication
+  # https://docs.python.org/3.11/library/ipc.html
+  ipc:
+    essential:
+      - libpython3.11-stdlib_concurrency
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/asynchat.py:
+      /usr/lib/python3.11/asyncio/**:
+      /usr/lib/python3.11/asyncore.py:
+      /usr/lib/python3.11/lib-dynload/_asyncio.cpython-311-*-linux-*.so:
+
+  # Python Language Services
+  # https://docs.python.org/3.11/library/language.html
+  language:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/pickletools.py:
+      /usr/lib/python3.11/pyclbr.py:
+      /usr/lib/python3.11/symtable.py:
+      /usr/lib/python3.11/tabnanny.py:
+
+  # Structured Markup Processing Tools (HTML, XML)
+  # https://docs.python.org/3.11/library/markup.html
+  markup-tools:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/_markupbase.py:
+      /usr/lib/python3.11/html/**:
+      /usr/lib/python3.11/xml/**:
+
+  # Multimedia Services
+  # https://docs.python.org/3.11/library/mm.html
+  multimedia:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/aifc.py:
+      /usr/lib/python3.11/chunk.py:
+      /usr/lib/python3.11/colorsys.py:
+      /usr/lib/python3.11/imghdr.py:
+      /usr/lib/python3.11/lib-dynload/audioop.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/ossaudiodev.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/sndhdr.py:
+      /usr/lib/python3.11/sunau.py:
+      /usr/lib/python3.11/wave.py:
+
+  # Internet Data Handling
+  # https://docs.python.org/3.11/library/netdata.html
+  net-data:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/json/**:
+      /usr/lib/python3.11/lib-dynload/_json.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/mailbox.py:
+      /usr/lib/python3.11/mailcap.py:
+
+  # Numeric and Mathematical Modules
+  # https://docs.python.org/3.11/library/numeric.html
+  numeric:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/_pydecimal.py:
+      /usr/lib/python3.11/decimal.py:
+      /usr/lib/python3.11/fractions.py:
+      /usr/lib/python3.11/lib-dynload/_decimal.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/numbers.py:
+      /usr/lib/python3.11/statistics.py:
+
+  # Shared OS X support functions
+  osx-support:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/_osx_support.py:
+
+  # pydoc - Documentation generator and online help system
+  # https://docs.python.org/3.11/library/pydoc.html
+  pydoc:
+    essential:
+      - libpython3.11-stdlib_core
+    contents:
+      /usr/lib/python3.11/pydoc_data/**:
+      /usr/lib/python3.11/pydoc.py:
+
+  # Text Processing Services
+  # https://docs.python.org/3.11/library/text.html
+  text:
+    essential:
+      - libpython3.11-stdlib_core
+      - libreadline8_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.11/difflib.py:
+      /usr/lib/python3.11/lib-dynload/readline.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/rlcompleter.py:
+
+  # Unix Specific Services
+  # https://docs.python.org/3.11/library/unix.html
+  unix:
+    essential:
+      - libcrypt1_libs
+      - libnsl2_libs
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_frameworks
+      - libtirpc3_libs
+    contents:
+      /usr/lib/python3.11/crypt.py:
+      /usr/lib/python3.11/lib-dynload/_crypt.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/nis.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/resource.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/termios.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/pipes.py:
+      /usr/lib/python3.11/pty.py:
+      /usr/lib/python3.11/tty.py:
+
+  # Outliers and Deprecated Modules
+  # The "extra" slice consists of easter-eggs and deprecated modules
+  extras:
+    essential:
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_internet
+    contents:
+      /usr/lib/python3.11/__hello__.py:
+      /usr/lib/python3.11/antigravity.py:
+      /usr/lib/python3.11/this.py:

--- a/slices/libreadline8.yaml
+++ b/slices/libreadline8.yaml
@@ -1,0 +1,11 @@
+package: libreadline8
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libtinfo6_libs
+      - readline-common_config
+    contents:
+      /usr/lib/*-linux-*/libhistory.so.8*:
+      /usr/lib/*-linux-*/libreadline.so.8*:

--- a/slices/libsqlite3-0.yaml
+++ b/slices/libsqlite3-0.yaml
@@ -1,0 +1,8 @@
+package: libsqlite3-0
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libsqlite3.so.0*:

--- a/slices/libtirpc-common.yaml
+++ b/slices/libtirpc-common.yaml
@@ -1,0 +1,6 @@
+package: libtirpc-common
+
+slices:
+  config:
+    contents:
+      /etc/netconfig:

--- a/slices/libtirpc3.yaml
+++ b/slices/libtirpc3.yaml
@@ -1,0 +1,10 @@
+package: libtirpc3
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgssapi-krb5-2_libs
+      - libtirpc-common_config
+    contents:
+      /lib/*-linux-*/libtirpc.so.3*:

--- a/slices/libuuid1.yaml
+++ b/slices/libuuid1.yaml
@@ -1,7 +1,8 @@
-package: liblzma5
+package: libuuid1
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/*-linux-*/liblzma.so.*:
+      /usr/lib/*-linux-*/libuuid.so.1*:

--- a/slices/media-types.yaml
+++ b/slices/media-types.yaml
@@ -1,0 +1,6 @@
+package: media-types
+
+slices:
+  data:
+    contents:
+      /etc/mime.types:

--- a/slices/python3.11-minimal.yaml
+++ b/slices/python3.11-minimal.yaml
@@ -1,0 +1,15 @@
+package: python3.11-minimal
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libexpat1_libs
+      - libpython3.11-minimal_libs
+      - zlib1g_libs
+    contents:
+      /usr/bin/python3.11:
+      # The next two directories are created to mimic the behaviour in
+      # the "postinst" script.
+      /usr/local/lib/python3.11/: {make: true, mode: 02775}
+      /usr/local/lib/python3.11/dist-packages/: {make: true, mode: 02775}

--- a/slices/python3.11.yaml
+++ b/slices/python3.11.yaml
@@ -1,0 +1,54 @@
+package: python3.11
+
+slices:
+  # The "core" slice provides a very minimal, yet functioning python3.11.
+  # It includes very few modules from the libpython3.11-stdlib package.
+  core:
+    essential:
+      - python3.11-minimal_bins
+      - libpython3.11-stdlib_core
+      - media-types_data
+
+  # The "standard" slice extends "core" with all the Python
+  # modules from the libpython3.11-stdlib package.
+  standard:
+    essential:
+      - libpython3.11-stdlib_aix-support
+      - libpython3.11-stdlib_all-os
+      - libpython3.11-stdlib_concurrency
+      - libpython3.11-stdlib_core
+      - libpython3.11-stdlib_crypto
+      - libpython3.11-stdlib_custom-interpreters
+      - libpython3.11-stdlib_data-persistence
+      - libpython3.11-stdlib_data-types
+      - libpython3.11-stdlib_debug
+      - libpython3.11-stdlib_development-tools
+      - libpython3.11-stdlib_distribution
+      - libpython3.11-stdlib_extras
+      - libpython3.11-stdlib_file-formats
+      - libpython3.11-stdlib_filesys
+      - libpython3.11-stdlib_frameworks
+      - libpython3.11-stdlib_importing
+      - libpython3.11-stdlib_internet
+      - libpython3.11-stdlib_ipc
+      - libpython3.11-stdlib_language
+      - libpython3.11-stdlib_markup-tools
+      - libpython3.11-stdlib_multimedia
+      - libpython3.11-stdlib_net-data
+      - libpython3.11-stdlib_numeric
+      - libpython3.11-stdlib_osx-support
+      - libpython3.11-stdlib_pydoc
+      - libpython3.11-stdlib_text
+      - libpython3.11-stdlib_unix
+      - python3.11_core
+
+  # The "utlis" slice extends "core" with various tools.
+  utils:
+    essential:
+      - libpython3.11-stdlib_debug
+      - libpython3.11-stdlib_pydoc
+      - python3.11_core
+    contents:
+      /usr/bin/pdb3.11:
+      /usr/bin/pydoc3.11:
+      /usr/bin/pygettext3.11:

--- a/slices/readline-common.yaml
+++ b/slices/readline-common.yaml
@@ -1,0 +1,6 @@
+package: readline-common
+
+slices:
+  config:
+    contents:
+      /etc/inputrc: { copy: /usr/share/readline/inputrc }


### PR DESCRIPTION
This PR adds the slice definition files for the Python 3.11 package and it's dependencies. The Python library packages are organized similarly to that of Python3.11 for mantic: #90.

---

:red_circle: Depends on the following PRs:

- [x] #93
- [x] #92 

---

Diff in python-specific slices from 23.10 (#90):
```diff
$ git diff feat/23.10/python3.11 -- slices/*python*
diff --git a/slices/libpython3.11-stdlib.yaml b/slices/libpython3.11-stdlib.yaml
index 3903e3d..39fdfa4 100644
--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -18,6 +18,7 @@ slices:
       - liblzma5_libs
       - libpython3.11-minimal_libs
       - media-types_data
+      - netbase_config
     contents:
       /usr/lib/python3.11/_bootsubprocess.py:
       /usr/lib/python3.11/_compression.py:
```