### PR TITLE
fix(24.04): update file path in zlib1g_libs

### DIFF
--- a/slices/zlib1g.yaml
+++ b/slices/zlib1g.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/*-linux-*/libz.so.*:
+      /usr/lib/*-linux-*/libz.so.*:


### PR DESCRIPTION
The libz.so files have moved location in 24.04. This commit updates the zlib1g_libs slice with proper path.