### PR TITLE
fix(24.04): add missing path in openssl_config

### DIFF
--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -14,7 +14,7 @@ slices:
 
   config:
     contents:
-      /etc/ssl/certs:
+      /etc/ssl/certs/:
       /etc/ssl/openssl.cnf:
       /etc/ssl/private/:
       /usr/lib/ssl/certs:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -14,8 +14,9 @@ slices:
 
   config:
     contents:
-      /etc/ssl/private/:
+      /etc/ssl/certs:
       /etc/ssl/openssl.cnf:
+      /etc/ssl/private/:
       /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
       /usr/lib/ssl/private:


### PR DESCRIPTION
`/usr/lib/ssl/certs` is a symlink to `/etc/ssl/certs`. But the latter was not included in the slice, resulting in a broken symlink in the rootfs if the ca-certificates slices were not installed.

This PR adds the missing `/etc/ssl/certs` path.