### PR TITLE
feat: add new archive for libpsl5 to ubuntu-22.04 release

### DIFF
--- a/slices/libpsl5.yaml
+++ b/slices/libpsl5.yaml
@@ -1,6 +1,6 @@
-#Libpsl allows checking domains against the Public Suffix List. 
-#It can be used to avoid privacy-leaking 'super-cookies', 'super domain' certificates, 
-#for domain highlighting purposes sorting domain lists by site and more.
+# Libpsl allows checking domains against the Public Suffix List. It can be  
+# used to avoid privacy-leaking 'super-cookies', 'super domain' certificates, 
+# for domain highlighting purposes sorting domain lists by site and more.
 package: libpsl5
 
 slices:

--- a/slices/libpsl5.yaml
+++ b/slices/libpsl5.yaml
@@ -1,4 +1,4 @@
-# Libpsl allows checking domains against the Public Suffix List. It can be  
+# Libpsl5 allows checking domains against the Public Suffix List. It can be  
 # used to avoid privacy-leaking 'super-cookies', 'super domain' certificates, 
 # for domain highlighting purposes sorting domain lists by site and more.
 package: libpsl5

--- a/slices/libpsl5.yaml
+++ b/slices/libpsl5.yaml
@@ -1,0 +1,13 @@
+#Libpsl allows checking domains against the Public Suffix List. 
+#It can be used to avoid privacy-leaking 'super-cookies', 'super domain' certificates, 
+#for domain highlighting purposes sorting domain lists by site and more.
+package: libpsl5
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libidn2-0_libs
+      - libunistring2_libs
+    contents:
+      /usr/lib/*-linux-*/libpsl.so.5*:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -13,8 +13,9 @@ slices:
 
   config:
     contents:
-      /etc/ssl/private/:
+      /etc/ssl/certs/:
       /etc/ssl/openssl.cnf:
+      /etc/ssl/private/:
       /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
       /usr/lib/ssl/private:


### PR DESCRIPTION
Libpsl allows checking domains against the Public Suffix List. It can be used to avoid privacy-leaking 'super-cookies', 'super domain' certificates, for domain highlighting purposes sorting domain lists by site and more.

Refer below package list for dependencies list
https://packages.ubuntu.com/jammy/libs/libpsl5