### PR TITLE
feat(24.04): Add findutils slice

### DIFF
--- a/slices/findutils.yaml
+++ b/slices/findutils.yaml
@@ -1,0 +1,10 @@
+package: findutils
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libselinux1_libs      
+    contents:
+      /usr/bin/find:
+      /usr/bin/xargs:


### PR DESCRIPTION
Adds findutils slice def to 24.04, to support running `find` and `xargs` in chiseled containers.

(see #105)