### PR TITLE
feat(22.04): Add grep slice

### DIFF
--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -7,6 +7,7 @@ slices:
       - libpcre3_libs
     contents:
       /bin/grep:
+
   deprecated:
     # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -6,7 +6,13 @@ slices:
       - libc6_libs
       - libpcre3_libs
     contents:
+      /bin/grep:
+  deprecated:
+    # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
+    # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
+    essential:
+      - bash_bins
+    contents:
       /bin/egrep:
       /bin/fgrep:
-      /bin/grep:
       /usr/bin/rgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -1,0 +1,12 @@
+package: grep
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libpcre3_libs
+    contents:
+      /bin/egrep:
+      /bin/grep:
+      /bin/fgrep:
+      /usr/bin/rgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -7,6 +7,6 @@ slices:
       - libpcre3_libs
     contents:
       /bin/egrep:
-      /bin/grep:
       /bin/fgrep:
+      /bin/grep:
       /usr/bin/rgrep:


### PR DESCRIPTION
Add `grep` slice for Ubuntu 22.04.

Supports running `grep`, `egrep`, etc.