### PR TITLE
fix(22.04): remove Byte Order Marks from files

### DIFF
--- a/slices/libdb5.3.yaml
+++ b/slices/libdb5.3.yaml
@@ -1,4 +1,4 @@
-﻿package: libdb5.3
+package: libdb5.3
 
 slices:
   libs:

--- a/slices/libgmp10.yaml
+++ b/slices/libgmp10.yaml
@@ -1,4 +1,4 @@
-﻿package: libgmp10
+package: libgmp10
 
 slices:
   libs:

--- a/slices/libgnutls30.yaml
+++ b/slices/libgnutls30.yaml
@@ -1,4 +1,4 @@
-﻿package: libgnutls30
+package: libgnutls30
 
 slices:
   libs:

--- a/slices/libhogweed6.yaml
+++ b/slices/libhogweed6.yaml
@@ -1,4 +1,4 @@
-﻿package: libhogweed6
+package: libhogweed6
 
 slices:
   libs:

--- a/slices/libidn2-0.yaml
+++ b/slices/libidn2-0.yaml
@@ -1,4 +1,4 @@
-﻿package: libidn2-0
+package: libidn2-0
 
 slices:
   libs:

--- a/slices/libldap-2.5-0.yaml
+++ b/slices/libldap-2.5-0.yaml
@@ -1,4 +1,4 @@
-﻿package: libldap-2.5-0
+package: libldap-2.5-0
 
 slices:
   libs:

--- a/slices/libnettle8.yaml
+++ b/slices/libnettle8.yaml
@@ -1,4 +1,4 @@
-﻿package: libnettle8
+package: libnettle8
 
 slices:
   libs:

--- a/slices/libp11-kit0.yaml
+++ b/slices/libp11-kit0.yaml
@@ -1,4 +1,4 @@
-﻿package: libp11-kit0
+package: libp11-kit0
 
 slices:
   libs:

--- a/slices/libsasl2-2.yaml
+++ b/slices/libsasl2-2.yaml
@@ -1,4 +1,4 @@
-﻿package: libsasl2-2
+package: libsasl2-2
 
 slices:
   libs:

--- a/slices/libsasl2-modules-db.yaml
+++ b/slices/libsasl2-modules-db.yaml
@@ -1,4 +1,4 @@
-﻿package: libsasl2-modules-db
+package: libsasl2-modules-db
 
 slices:
   libs:

--- a/slices/libtasn1-6.yaml
+++ b/slices/libtasn1-6.yaml
@@ -1,4 +1,4 @@
-﻿package: libtasn1-6
+package: libtasn1-6
 
 slices:
   libs:

--- a/slices/libunistring2.yaml
+++ b/slices/libunistring2.yaml
@@ -1,4 +1,4 @@
-﻿package: libunistring2
+package: libunistring2
 
 slices:
   libs:


### PR DESCRIPTION
A few slice definition files in the ubuntu-22.04 release contains Byte Order Mark (BOM) [1-2]. This is not needed for our purposes and ASCII text is fine for the slice definition files at the moment. Hence, this PR removes all the BOMs from the files in this branch.

Note: to check the status of the files, you may run

    file chisel.yaml slices/*

Refernces:
1. https://en.wikipedia.org/wiki/Byte_order_mark
2. https://stackoverflow.com/q/2223882