### PR TITLE
feat(23.10): add grep slice

### DIFF
--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -4,16 +4,16 @@ slices:
   bins:
     essential:
       - libc6_libs
-      - libpcre3_libs
+      - libpcre2-8-0_libs
     contents:
       /bin/grep:
 
   deprecated:
-    # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
+    # These are shell scripts requiring a symlink from /usr/bin/dash to /bin/sh
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
-      - bash_bins
-      - libpcre3_libs
+      - dash_bins
+      - grep_bins
     contents:
       /bin/egrep:
       /bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -1,0 +1,18 @@
+package: grep
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libpcre3_libs
+    contents:
+      /bin/grep:
+  deprecated:
+    # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
+    # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
+    essential:
+      - bash_bins
+    contents:
+      /bin/egrep:
+      /bin/fgrep:
+      /usr/bin/rgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -7,11 +7,13 @@ slices:
       - libpcre3_libs
     contents:
       /bin/grep:
+
   deprecated:
     # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
       - bash_bins
+      - libpcre3_libs
     contents:
       /bin/egrep:
       /bin/fgrep:


### PR DESCRIPTION
Add `grep` slice for Ubuntu 23.10.

Supports running `grep`, `egrep`, etc.