### PR TITLE
feat(24.04): add grep slice

### DIFF
--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -13,7 +13,7 @@ slices:
     # See: https://manpages.ubuntu.com/manpages/noble/en/man1/grep.1.html
     essential:
       - dash_bins
-      - libpcre2-8-0_libs
+      - grep_bins
     contents:
       /usr/bin/egrep:
       /usr/bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -7,11 +7,13 @@ slices:
       - libpcre3_libs
     contents:
       /bin/grep:
+
   deprecated:
     # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
-    # See: https://manpages.ubuntu.com/manpages/noble/en/man1/grep.1.html
+    # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
       - bash_bins
+      - libpcre3_libs
     contents:
       /bin/egrep:
       /bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -4,7 +4,7 @@ slices:
   bins:
     essential:
       - libc6_libs
-      - libpcre3_libs
+      - libpcre2-8-0_libs
     contents:
       /usr/bin/grep:
 
@@ -13,7 +13,7 @@ slices:
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
       - bash_bins
-      - libpcre3_libs
+      - libpcre2-8-0_libs
     contents:
       /usr/bin/egrep:
       /usr/bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -9,10 +9,10 @@ slices:
       /usr/bin/grep:
 
   deprecated:
-    # These are shell scripts requiring a symlink from /usr/bin/bash to /usr/bin/sh
-    # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
+    # These are shell scripts requiring a symlink from /usr/bin/dash to /usr/bin/sh
+    # See: https://manpages.ubuntu.com/manpages/noble/en/man1/grep.1.html
     essential:
-      - bash_bins
+      - dash_bins
       - libpcre2-8-0_libs
     contents:
       /usr/bin/egrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -6,15 +6,15 @@ slices:
       - libc6_libs
       - libpcre3_libs
     contents:
-      /bin/grep:
+      /usr/bin/grep:
 
   deprecated:
-    # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
+    # These are shell scripts requiring a symlink from /usr/bin/bash to /usr/bin/sh
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
       - bash_bins
       - libpcre3_libs
     contents:
-      /bin/egrep:
-      /bin/fgrep:
+      /usr/bin/egrep:
+      /usr/bin/fgrep:
       /usr/bin/rgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -1,0 +1,18 @@
+package: grep
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libpcre3_libs
+    contents:
+      /bin/grep:
+  deprecated:
+    # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
+    # See: https://manpages.ubuntu.com/manpages/noble/en/man1/grep.1.html
+    essential:
+      - bash_bins
+    contents:
+      /bin/egrep:
+      /bin/fgrep:
+      /usr/bin/rgrep:


### PR DESCRIPTION
Add `grep` slice for Ubuntu 24.04.

Supports running `grep`, `egrep`, etc.