### PR TITLE
feat(22.04): Use dash instead of bash for grep deprecated slice

### DIFF
--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -4,7 +4,7 @@ slices:
   bins:
     essential:
       - libc6_libs
-      - libpcre2-8-0_libs
+      - libpcre3_libs
     contents:
       /bin/grep:
 
@@ -13,7 +13,8 @@ slices:
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
       - dash_bins
-      - libpcre2-8-0_libs
+      - grep_bins
+      - libpcre3_libs
     contents:
       /bin/egrep:
       /bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -14,7 +14,6 @@ slices:
     essential:
       - dash_bins
       - grep_bins
-      - libpcre3_libs
     contents:
       /bin/egrep:
       /bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -13,6 +13,7 @@ slices:
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
       - bash_bins
+      - libpcre3_libs
     contents:
       /bin/egrep:
       /bin/fgrep:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -4,16 +4,16 @@ slices:
   bins:
     essential:
       - libc6_libs
-      - libpcre3_libs
+      - libpcre2-8-0_libs
     contents:
       /bin/grep:
 
   deprecated:
-    # These are shell scripts requiring a symlink from /usr/bin/bash to /bin/sh
+    # These are shell scripts requiring a symlink from /usr/bin/dash to /bin/sh
     # See: https://manpages.ubuntu.com/manpages/jammy/en/man1/grep.1.html
     essential:
-      - bash_bins
-      - libpcre3_libs
+      - dash_bins
+      - libpcre2-8-0_libs
     contents:
       /bin/egrep:
       /bin/fgrep:


### PR DESCRIPTION
As noted in #117 amd #118 by @cjdcordeiro  the `deprecated` slice is missing an essential def for `libpcre3`. Backports the fix from those PRs to 22.04.