### PR TITLE
fix(23.10): remove Byte Order Marks from files

### DIFF
--- a/slices/libgmp10.yaml
+++ b/slices/libgmp10.yaml
@@ -1,4 +1,4 @@
-﻿package: libgmp10
+package: libgmp10
 
 slices:
   libs:


### PR DESCRIPTION
A few slice definition files in the ubuntu-23.10 release contain Byte Order Mark (BOM) [1-2]. This is not needed for our purposes and ASCII text is currently fine for the slice definition files. Hence, this PR removes all the BOMs from the files in this branch.

Note: to check the status of the files, you may run

    file chisel.yaml slices/*

Refernces:
1. https://en.wikipedia.org/wiki/Byte_order_mark
2. https://stackoverflow.com/q/2223882

---

Related: https://github.com/canonical/chisel-releases/pull/115