### PR TITLE
hotfix(24.04): broken path in libgcc-s1_libs

### DIFF
--- a/slices/libgcc-s1.yaml
+++ b/slices/libgcc-s1.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/*-linux-*/libgcc_s.so.*:
+      /usr/lib/*-linux-*/libgcc_s.so.*:


### PR DESCRIPTION
The `libgcc_s.so` path [has changed in the libgcc-s1 package in 24.04](https://packages.ubuntu.com/noble/amd64/libgcc-s1/filelist). This PR updates the new path in the slice definition file.