### PR TITLE
feat(22.04): add slice for dash

### DIFF
--- a/slices/dash.yaml
+++ b/slices/dash.yaml
@@ -1,0 +1,9 @@
+package: dash
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+    contents:
+      /bin/dash:
+      /bin/sh:


### PR DESCRIPTION
Adds slice for `dash` (already exists in `23.10` and `24.04`).