### PR TITLE
bug(24.04): make /var/run a symlink to /run

### DIFF
--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -36,8 +36,7 @@ slices:
       /var/cache/:
       /var/lib/:
       /var/log/:
-      # Recreate symlink that is in place
-      # on full Ubuntu installs and containers
+      # The /var/run symlink is enforced by the package's maintainer scripts
       /var/run/: {symlink: /run}
       /var/tmp/:
 

--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -36,7 +36,7 @@ slices:
       /var/cache/:
       /var/lib/:
       /var/log/:
-      /var/run/:
+      /var/run/: {symlink: /run}
       /var/tmp/:
 
   home:

--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -36,6 +36,8 @@ slices:
       /var/cache/:
       /var/lib/:
       /var/log/:
+      # Recreate symlink that is in place
+      # on full Ubuntu installs and containers
       /var/run/: {symlink: /run}
       /var/tmp/:
 


### PR DESCRIPTION
On full Ubuntu VMs/hardware installs, as well as the upstream Ubuntu containers, /var/run is a symlink to /run. Chiseled containers do not make this symlink - this causes issues with Docker Swarm installs (and probably other projects), which mount secrets into /run.