### PR TITLE
ci(cla-check): add CLA check for the repo

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,0 +1,11 @@
+name: CLA Check
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1


### PR DESCRIPTION
The proposed GH workflow will check if the author of the PR has signed our CLA.

This is a reusable workflow that can be called from the release branches.

Tested in https://github.com/cjdcordeiro/chisel-releases/actions/runs/7876013322.