### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+# Proposed changes
+<!-- Describe the changes proposed in this PR.
+
+Provide good PR descriptions as the project maintainers aren't necessarily
+familiar with the packages you are slicing.
+
+We use conventional commits
+(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
+specified in your commit messages, make sure you describe the type of change
+being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
+-->
+
+## Related issues/PRs
+<!-- If any -->
+
+### Forward porting
+<!-- This change MUST also be proposed to all newer, and still supported,
+releases. List the corresponding PRs, or ignore if not applicable. -->
+
+## Testing
+<!-- Provide proof of testing and/or testing instructions, when applicable,
+to help speed up the review process. -->
+
+```bash
+# Example:
+#  chisel cut ... --root <path> <pkg>_<proposed-slice>
+#  sudo chroot <path> <app>
+```
+
+## Checklist
+<!-- Go over all the following points, and put an `x` in all the boxes
+that apply. -->
+
+* [ ] I have read the [contributing guidelines](
+https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
+* [ ] I have already submitted the [CLA form](
+https://ubuntu.com/legal/contributors/agreement)
+
+## Additional Context
+<!-- If relevant -->


### PR DESCRIPTION
This PR adds a new template for all future new PRs.

Here's an example: https://github.com/cjdcordeiro/chisel-releases/pull/7