### PR TITLE
fix(24.04): library paths for libcrypt1, libkeyutils1 and libselinux1

### DIFF
--- a/slices/libcrypt1.yaml
+++ b/slices/libcrypt1.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/*-linux-*/libcrypt.so.*:
+      /usr/lib/*-linux-*/libcrypt.so.1*:

--- a/slices/libkeyutils1.yaml
+++ b/slices/libkeyutils1.yaml
@@ -5,4 +5,4 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /lib/*-linux-*/libkeyutils.so.*:
+      /usr/lib/*-linux-*/libkeyutils.so.1*:

--- a/slices/libselinux1.yaml
+++ b/slices/libselinux1.yaml
@@ -6,4 +6,4 @@ slices:
       - libc6_libs
       - libpcre2-8-0_libs
     contents:
-      /lib/*-linux-*/libselinux.so.1:
+      /usr/lib/*-linux-*/libselinux.so.1:


### PR DESCRIPTION
The file paths seems to have changed. This fixes it. Needed by #135 and #137 