### PR TITLE
chore(23.10): add workflow to test slices

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: CI
+run-name: CI for ${{ github.ref }}
+
+on:
+  push:
+    branches:
+      - "ubuntu-*"
+  pull_request:
+    branches:
+      - "ubuntu-*"
+
+jobs:
+  installability-tests:
+    name: Installability tests
+    uses: canonical/chisel-releases/.github/workflows/install-slices.yaml@main


### PR DESCRIPTION
This commit adds a workflow to test installing changed or all slices, based on the files changed.

---

Equivalent of #120.