### PR TITLE
chore: fix archive version while logging

### DIFF
--- a/.github/scripts/install_slices/install_slices.py
+++ b/.github/scripts/install_slices/install_slices.py
@@ -128,9 +128,10 @@ def parse_archive(release: str) -> Archive:
         sys.exit(1)
     # load the yaml data into Archive
     archive_data = data["archives"]["ubuntu"]
-    archive = Archive(
-        str(archive_data["version"]), archive_data["components"], archive_data["suites"]
-    )
+    version = archive_data["version"]
+    if isinstance(version, float):
+        version = f"{version:.2f}"
+    archive = Archive(str(version), archive_data["components"], archive_data["suites"])
     return archive
 
 

--- a/.github/scripts/install_slices/test_install_slices.py
+++ b/.github/scripts/install_slices/test_install_slices.py
@@ -116,6 +116,22 @@ class TestScriptMethods(unittest.TestCase):
         # test parsing remote release
         archive = parse_archive("ubuntu-22.04")
         self.assertEqual(archive, DEFAULT_ARCHIVE)
+        # test parsing archive version properly
+        chisel_yaml = DEFAULT_CHISEL_YAML.replace("22.04", "23.10")
+        chisel_yaml = chisel_yaml.replace("jammy", "mantic")
+        with tempfile.TemporaryDirectory() as tmpfs:
+            filepath = os.path.join(tmpfs, "chisel.yaml")
+            with open(filepath, "w", encoding="utf-8") as file:
+                file.write(chisel_yaml)
+            archive = parse_archive(tmpfs)
+            self.assertEqual(
+                archive,
+                Archive(
+                    version="23.10",
+                    components=["main", "universe"],
+                    suites=["mantic", "mantic-security", "mantic-updates"],
+                ),
+            )
 
     def test_full_slice_name(self):
         """


### PR DESCRIPTION
Archive version was being changed to 23.1 instead 23.10 for values with trailing zeroes. This PR fixes the bug.

https://github.com/canonical/chisel-releases/actions/runs/8014505888/job/21893215155?pr=14