### PR TITLE
chore(22.04): add lint job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,3 +15,7 @@ jobs:
   installability-tests:
     name: Installability tests
     uses: canonical/chisel-releases/.github/workflows/install-slices.yaml@main
+
+  lint:
+    name: Lint
+    uses: canonical/chisel-releases/.github/workflows/lint.yaml@main

--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,44 +1,44 @@
 format: chisel-v1
 
 archives:
-    ubuntu:
-        version: 22.04
-        components: [main, universe]
-        suites: [jammy, jammy-security, jammy-updates]
-        v1-public-keys: [ubuntu-archive-key-2018]
+  ubuntu:
+    version: 22.04
+    components: [main, universe]
+    suites: [jammy, jammy-security, jammy-updates]
+    v1-public-keys: [ubuntu-archive-key-2018]
 
 v1-public-keys:
-    # Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>
-    # rsa4096/f6ecb3762474eda9d21b7022871920d1991bc93c 2018-09-17T15:01:46Z
-    ubuntu-archive-key-2018:
-        id: "871920D1991BC93C"
-        armor: |
-            -----BEGIN PGP PUBLIC KEY BLOCK-----
+  # Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>
+  # rsa4096/f6ecb3762474eda9d21b7022871920d1991bc93c 2018-09-17T15:01:46Z
+  ubuntu-archive-key-2018:
+    id: "871920D1991BC93C"
+    armor: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
 
-            mQINBFufwdoBEADv/Gxytx/LcSXYuM0MwKojbBye81s0G1nEx+lz6VAUpIUZnbkq
-            dXBHC+dwrGS/CeeLuAjPRLU8AoxE/jjvZVp8xFGEWHYdklqXGZ/gJfP5d3fIUBtZ
-            HZEJl8B8m9pMHf/AQQdsC+YzizSG5t5Mhnotw044LXtdEEkx2t6Jz0OGrh+5Ioxq
-            X7pZiq6Cv19BohaUioKMdp7ES6RYfN7ol6HSLFlrMXtVfh/ijpN9j3ZhVGVeRC8k
-            KHQsJ5PkIbmvxBiUh7SJmfZUx0IQhNMaDHXfdZAGNtnhzzNReb1FqNLSVkrS/Pns
-            AQzMhG1BDm2VOSF64jebKXffFqM5LXRQTeqTLsjUbbrqR6s/GCO8UF7jfUj6I7ta
-            LygmsHO/JD4jpKRC0gbpUBfaiJyLvuepx3kWoqL3sN0LhlMI80+fA7GTvoOx4tpq
-            VlzlE6TajYu+jfW3QpOFS5ewEMdL26hzxsZg/geZvTbArcP+OsJKRmhv4kNo6Ayd
-            yHQ/3ZV/f3X9mT3/SPLbJaumkgp3Yzd6t5PeBu+ZQk/mN5WNNuaihNEV7llb1Zhv
-            Y0Fxu9BVd/BNl0rzuxp3rIinB2TX2SCg7wE5xXkwXuQ/2eTDE0v0HlGntkuZjGow
-            DZkxHZQSxZVOzdZCRVaX/WEFLpKa2AQpw5RJrQ4oZ/OfifXyJzP27o03wQARAQAB
-            tEJVYnVudHUgQXJjaGl2ZSBBdXRvbWF0aWMgU2lnbmluZyBLZXkgKDIwMTgpIDxm
-            dHBtYXN0ZXJAdWJ1bnR1LmNvbT6JAjgEEwEKACIFAlufwdoCGwMGCwkIBwMCBhUI
-            AgkKCwQWAgMBAh4BAheAAAoJEIcZINGZG8k8LHMQAKS2cnxz/5WaoCOWArf5g6UH
-            beOCgc5DBm0hCuFDZWWv427aGei3CPuLw0DGLCXZdyc5dqE8mvjMlOmmAKKlj1uG
-            g3TYCbQWjWPeMnBPZbkFgkZoXJ7/6CB7bWRht1sHzpt1LTZ+SYDwOwJ68QRp7DRa
-            Zl9Y6QiUbeuhq2DUcTofVbBxbhrckN4ZteLvm+/nG9m/ciopc66LwRdkxqfJ32Cy
-            q+1TS5VaIJDG7DWziG+Kbu6qCDM4QNlg3LH7p14CrRxAbc4lvohRgsV4eQqsIcdF
-            kuVY5HPPj2K8TqpY6STe8Gh0aprG1RV8ZKay3KSMpnyV1fAKn4fM9byiLzQAovC0
-            LZ9MMMsrAS/45AvC3IEKSShjLFn1X1dRCiO6/7jmZEoZtAp53hkf8SMBsi78hVNr
-            BumZwfIdBA1v22+LY4xQK8q4XCoRcA9G+pvzU9YVW7cRnDZZGl0uwOw7z9PkQBF5
-            KFKjWDz4fCk+K6+YtGpovGKekGBb8I7EA6UpvPgqA/QdI0t1IBP0N06RQcs1fUaA
-            QEtz6DGy5zkRhR4pGSZn+dFET7PdAjEK84y7BdY4t+U1jcSIvBj0F2B7LwRL7xGp
-            SpIKi/ekAXLs117bvFHaCvmUYN7JVp1GMmVFxhIdx6CFm3fxG8QjNb5tere/YqK+
-            uOgcXny1UlwtCUzlrSaP
-            =9AdM
-            -----END PGP PUBLIC KEY BLOCK-----
+      mQINBFufwdoBEADv/Gxytx/LcSXYuM0MwKojbBye81s0G1nEx+lz6VAUpIUZnbkq
+      dXBHC+dwrGS/CeeLuAjPRLU8AoxE/jjvZVp8xFGEWHYdklqXGZ/gJfP5d3fIUBtZ
+      HZEJl8B8m9pMHf/AQQdsC+YzizSG5t5Mhnotw044LXtdEEkx2t6Jz0OGrh+5Ioxq
+      X7pZiq6Cv19BohaUioKMdp7ES6RYfN7ol6HSLFlrMXtVfh/ijpN9j3ZhVGVeRC8k
+      KHQsJ5PkIbmvxBiUh7SJmfZUx0IQhNMaDHXfdZAGNtnhzzNReb1FqNLSVkrS/Pns
+      AQzMhG1BDm2VOSF64jebKXffFqM5LXRQTeqTLsjUbbrqR6s/GCO8UF7jfUj6I7ta
+      LygmsHO/JD4jpKRC0gbpUBfaiJyLvuepx3kWoqL3sN0LhlMI80+fA7GTvoOx4tpq
+      VlzlE6TajYu+jfW3QpOFS5ewEMdL26hzxsZg/geZvTbArcP+OsJKRmhv4kNo6Ayd
+      yHQ/3ZV/f3X9mT3/SPLbJaumkgp3Yzd6t5PeBu+ZQk/mN5WNNuaihNEV7llb1Zhv
+      Y0Fxu9BVd/BNl0rzuxp3rIinB2TX2SCg7wE5xXkwXuQ/2eTDE0v0HlGntkuZjGow
+      DZkxHZQSxZVOzdZCRVaX/WEFLpKa2AQpw5RJrQ4oZ/OfifXyJzP27o03wQARAQAB
+      tEJVYnVudHUgQXJjaGl2ZSBBdXRvbWF0aWMgU2lnbmluZyBLZXkgKDIwMTgpIDxm
+      dHBtYXN0ZXJAdWJ1bnR1LmNvbT6JAjgEEwEKACIFAlufwdoCGwMGCwkIBwMCBhUI
+      AgkKCwQWAgMBAh4BAheAAAoJEIcZINGZG8k8LHMQAKS2cnxz/5WaoCOWArf5g6UH
+      beOCgc5DBm0hCuFDZWWv427aGei3CPuLw0DGLCXZdyc5dqE8mvjMlOmmAKKlj1uG
+      g3TYCbQWjWPeMnBPZbkFgkZoXJ7/6CB7bWRht1sHzpt1LTZ+SYDwOwJ68QRp7DRa
+      Zl9Y6QiUbeuhq2DUcTofVbBxbhrckN4ZteLvm+/nG9m/ciopc66LwRdkxqfJ32Cy
+      q+1TS5VaIJDG7DWziG+Kbu6qCDM4QNlg3LH7p14CrRxAbc4lvohRgsV4eQqsIcdF
+      kuVY5HPPj2K8TqpY6STe8Gh0aprG1RV8ZKay3KSMpnyV1fAKn4fM9byiLzQAovC0
+      LZ9MMMsrAS/45AvC3IEKSShjLFn1X1dRCiO6/7jmZEoZtAp53hkf8SMBsi78hVNr
+      BumZwfIdBA1v22+LY4xQK8q4XCoRcA9G+pvzU9YVW7cRnDZZGl0uwOw7z9PkQBF5
+      KFKjWDz4fCk+K6+YtGpovGKekGBb8I7EA6UpvPgqA/QdI0t1IBP0N06RQcs1fUaA
+      QEtz6DGy5zkRhR4pGSZn+dFET7PdAjEK84y7BdY4t+U1jcSIvBj0F2B7LwRL7xGp
+      SpIKi/ekAXLs117bvFHaCvmUYN7JVp1GMmVFxhIdx6CFm3fxG8QjNb5tere/YqK+
+      uOgcXny1UlwtCUzlrSaP
+      =9AdM
+      -----END PGP PUBLIC KEY BLOCK-----

--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -3,12 +3,12 @@ package: base-files
 slices:
   base:
     essential:
-      - base-files_etc
       - base-files_bin
+      - base-files_etc
+      - base-files_home
       - base-files_lib
       - base-files_tmp
       - base-files_var
-      - base-files_home
 
   etc:
     contents:
@@ -52,8 +52,8 @@ slices:
     contents:
       /etc/debian_version:
       /etc/dpkg/origins/debian:
-      /etc/dpkg/origins/ubuntu:
       /etc/dpkg/origins/default: {symlink: /etc/dpkg/origins/ubuntu}
+      /etc/dpkg/origins/ubuntu:
       /etc/host.conf:
       /etc/issue:
       /etc/issue.net:

--- a/slices/base-passwd.yaml
+++ b/slices/base-passwd.yaml
@@ -3,10 +3,10 @@ package: base-passwd
 slices:
   data:
     contents:
-      /usr/share/base-passwd/group.master:  {until: mutate}
-      /usr/share/base-passwd/passwd.master: {until: mutate}
-      /etc/group:  {text: FIXME, mutable: true}
+      /etc/group: {text: FIXME, mutable: true}
       /etc/passwd: {text: FIXME, mutable: true}
+      /usr/share/base-passwd/group.master: {until: mutate}
+      /usr/share/base-passwd/passwd.master: {until: mutate}
     mutate: |
       gr = content.read("/usr/share/base-passwd/group.master")
       content.write("/etc/group", gr)

--- a/slices/bash.yaml
+++ b/slices/bash.yaml
@@ -17,5 +17,5 @@ slices:
       # user should manually link /bin/sh to /bin/bash
       /bin/bash:
       /bin/rbash:
-      /usr/bin/clear_console:
       /usr/bin/bashbug:
+      /usr/bin/clear_console:

--- a/slices/ca-certificates-java.yaml
+++ b/slices/ca-certificates-java.yaml
@@ -8,6 +8,5 @@ slices:
     contents:
       /etc/default/cacerts:
       /etc/ssl/certs/java/:
-
-    # we need to run `keytool` in postinst, but we can't yet do
-    # this from a mutation script
+      # we need to run `keytool` in postinst, but we can't yet do
+      # this from a mutation script

--- a/slices/ca-certificates.yaml
+++ b/slices/ca-certificates.yaml
@@ -8,5 +8,7 @@ slices:
       /usr/share/ca-certificates/mozilla/*: {until: mutate}
     mutate: |
       certs_dir = "/usr/share/ca-certificates/mozilla/"
-      certs = [content.read(certs_dir + path) for path in content.list(certs_dir)]
+      certs = [
+        content.read(certs_dir + path) for path in content.list(certs_dir)
+      ]
       content.write("/etc/ssl/certs/ca-certificates.crt", "".join(certs))

--- a/slices/curl.yaml
+++ b/slices/curl.yaml
@@ -4,7 +4,7 @@ slices:
   bins:
     essential:
       - libc6_libs
-      - libcurl4_libs    
+      - libcurl4_libs
       - zlib1g_libs
     contents:
       /usr/bin/curl:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -2,9 +2,9 @@ package: dotnet-hostfxr-6.0
 slices:
   libs:
     essential:
+      - dotnet-host_bins
       - libc6_libs
       - libgcc-s1_libs
       - libstdc++6_libs
-      - dotnet-host_bins
     contents:
       /usr/lib/dotnet/host/fxr/*/libhostfxr.so:

--- a/slices/findutils.yaml
+++ b/slices/findutils.yaml
@@ -4,7 +4,7 @@ slices:
   bins:
     essential:
       - libc6_libs
-      - libselinux1_libs      
+      - libselinux1_libs
     contents:
       /usr/bin/find:
       /usr/bin/xargs:

--- a/slices/fonts-dejavu-core.yaml
+++ b/slices/fonts-dejavu-core.yaml
@@ -9,7 +9,7 @@ slices:
       /usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf:
       /usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf:
       /usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf:
-      
+
   config:
     contents:
       /etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-sans-mono.conf:

--- a/slices/libasan6.yaml
+++ b/slices/libasan6.yaml
@@ -4,8 +4,9 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libstdc++6_libs
       - libgcc-s1_libs
-    # Although gcc-11-base is a package dependency, it is not needed for this libs slice and is thus omitted.
+      - libstdc++6_libs
+      # Although gcc-11-base is a package dependency, it is not needed for this
+      # libs slice and is thus omitted.
     contents:
       /usr/lib/*-linux-*/libasan.so.6*:

--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -7,6 +7,7 @@ slices:
 
   libs:
     contents:
+      /lib*/ld*.so.*:
       /lib/*-linux-*/ld*.so.*:
       /lib/*-linux-*/libBrokenLocale.so.*:
       /lib/*-linux-*/libanl.so.*:
@@ -27,4 +28,3 @@ slices:
       /lib/*-linux-*/librt.so.*:
       /lib/*-linux-*/libthread_db.so.*:
       /lib/*-linux-*/libutil.so.*:
-      /lib*/ld*.so.*:

--- a/slices/libcurl4.yaml
+++ b/slices/libcurl4.yaml
@@ -3,18 +3,18 @@ package: libcurl4
 
 slices:
   libs:
-    essential:     
+    essential:
       - libbrotli1_libs
       - libc6_libs
       - libgssapi-krb5-2_libs
       - libidn2-0_libs
       - libldap-2.5-0_libs
+      - libnghttp2-14_libs
       - libpsl5_libs
+      - librtmp1_libs
       - libssh-4_libs
       - libssl3_libs
-      - libnghttp2-14_libs
       - libzstd1_libs
-      - librtmp1_libs
       - zlib1g_libs
     contents:
-      /usr/lib/*-linux-*/libcurl.so.4*:       
+      /usr/lib/*-linux-*/libcurl.so.4*:

--- a/slices/libfontconfig1.yaml
+++ b/slices/libfontconfig1.yaml
@@ -3,10 +3,10 @@ package: libfontconfig1
 slices:
   libs:
     essential:
+      - fontconfig-config_config
       - libc6_libs
       - libexpat1_libs
       - libfreetype6_libs
       - libuuid1_libs
-      - fontconfig-config_config
     contents:
       /usr/lib/*-linux-*/libfontconfig.so.1*:

--- a/slices/libfreetype6.yaml
+++ b/slices/libfreetype6.yaml
@@ -3,9 +3,9 @@ package: libfreetype6
 slices:
   libs:
     essential:
-      - libc6_libs
-      - zlib1g_libs
       - libbrotli1_libs
+      - libc6_libs
       - libpng16-16_libs
+      - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/libfreetype.so.6*:

--- a/slices/libgcrypt20.yaml
+++ b/slices/libgcrypt20.yaml
@@ -5,6 +5,6 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libgpg-error0_libs         
+      - libgpg-error0_libs
     contents:
       /usr/lib/*-linux-*/libgcrypt.so.20*:

--- a/slices/libglib2.0-0.yaml
+++ b/slices/libglib2.0-0.yaml
@@ -10,8 +10,8 @@ slices:
 
   libs:
     essential:
-      - libglib2.0-0_core
       - libffi8_libs
+      - libglib2.0-0_core
       - libmount1_libs
       - libselinux1_libs
       - zlib1g_libs

--- a/slices/libgomp1.yaml
+++ b/slices/libgomp1.yaml
@@ -4,6 +4,7 @@ slices:
   libs:
     essential:
       - libc6_libs
-    # Although gcc-12-base is a package dependency, it is not needed for this libs slice and is thus omitted.
+      # Although gcc-12-base is a package dependency, it is not needed for this
+      # libs slice and is thus omitted.
     contents:
       /usr/lib/*-linux-*/libgomp.so.1*:

--- a/slices/libldap-2.5-0.yaml
+++ b/slices/libldap-2.5-0.yaml
@@ -7,5 +7,5 @@ slices:
       - libgnutls30_libs
       - libsasl2-2_libs
     contents:
-      /usr/lib/*-linux-*/libldap-2.5.so.0*:
       /usr/lib/*-linux-*/liblber-2.5.so.0*:
+      /usr/lib/*-linux-*/libldap-2.5.so.0*:

--- a/slices/libmount1.yaml
+++ b/slices/libmount1.yaml
@@ -3,8 +3,8 @@ package: libmount1
 slices:
   libs:
     essential:
+      - libblkid1_libs
       - libc6_libs
       - libselinux1_libs
-      - libblkid1_libs
     contents:
       /usr/lib/*-linux-*/libmount.so.1*:

--- a/slices/libnghttp2-14.yaml
+++ b/slices/libnghttp2-14.yaml
@@ -1,9 +1,9 @@
-# Library implementing HTTP/2 protocol 
+# Library implementing HTTP/2 protocol
 package: libnghttp2-14
 
 slices:
   libs:
     essential:
-      - libc6_libs         
+      - libc6_libs
     contents:
       /usr/lib/*-linux-*/libnghttp2.so.14*:

--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -7,5 +7,5 @@ slices:
       - libnspr4_libs
       - libsqlite3-0_libs
     contents:
-      /usr/lib/*-linux-*/libnssutil3.so:
       /usr/lib/*-linux-*/libnss3.so:
+      /usr/lib/*-linux-*/libnssutil3.so:

--- a/slices/libpsl5.yaml
+++ b/slices/libpsl5.yaml
@@ -1,5 +1,5 @@
-# Libpsl5 allows checking domains against the Public Suffix List. It can be  
-# used to avoid privacy-leaking 'super-cookies', 'super domain' certificates, 
+# Libpsl5 allows checking domains against the Public Suffix List. It can be
+# used to avoid privacy-leaking 'super-cookies', 'super domain' certificates,
 # for domain highlighting purposes sorting domain lists by site and more.
 package: libpsl5
 

--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -172,8 +172,8 @@ slices:
       /usr/lib/python3.11/lib-dynload/_testmultiphase.cpython-311-*-linux-*.so:
       /usr/lib/python3.11/lib-dynload/_xxsubinterpreters.cpython-311-*-linux-*.so:
       /usr/lib/python3.11/lib-dynload/_xxtestfuzz.cpython-311-*-linux-*.so:
-      /usr/lib/python3.11/lib-dynload/xxlimited_35.cpython-311-*-linux-*.so:
       /usr/lib/python3.11/lib-dynload/xxlimited.cpython-311-*-linux-*.so:
+      /usr/lib/python3.11/lib-dynload/xxlimited_35.cpython-311-*-linux-*.so:
       /usr/lib/python3.11/test/**:
       /usr/lib/python3.11/unittest/**:
 
@@ -349,8 +349,8 @@ slices:
     essential:
       - libpython3.11-stdlib_core
     contents:
-      /usr/lib/python3.11/pydoc_data/**:
       /usr/lib/python3.11/pydoc.py:
+      /usr/lib/python3.11/pydoc_data/**:
 
   # Text Processing Services
   # https://docs.python.org/3.11/library/text.html

--- a/slices/librtmp1.yaml
+++ b/slices/librtmp1.yaml
@@ -4,11 +4,11 @@ package: librtmp1
 slices:
   libs:
     essential:
-      - libc6_libs   
+      - libc6_libs
       - libgmp10_libs
       - libgnutls30_libs
       - libhogweed6_libs
       - libnettle8_libs
-      - zlib1g_libs 
+      - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/librtmp.so.1*:

--- a/slices/libssh-4.yaml
+++ b/slices/libssh-4.yaml
@@ -10,7 +10,6 @@ slices:
       - libc6_libs
       - libgssapi-krb5-2_libs
       - libssl3_libs
-      - zlib1g_libs       
+      - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/libssh.so.4*:
-       

--- a/slices/libunwind-13.yaml
+++ b/slices/libunwind-13.yaml
@@ -4,7 +4,7 @@ slices:
     essential:
       - libc6_libs
     contents:
-      /usr/lib/llvm-13/lib/libunwind.so.1.*:
-      /usr/lib/llvm-13/lib/libunwind.so.1:
-      /usr/lib/*-linux-*/libunwind.so.1.*:
       /usr/lib/*-linux-*/libunwind.so.1:
+      /usr/lib/*-linux-*/libunwind.so.1.*:
+      /usr/lib/llvm-13/lib/libunwind.so.1:
+      /usr/lib/llvm-13/lib/libunwind.so.1.*:

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -6,5 +6,5 @@ slices:
       - liblzma5_libs
     contents:
       /usr/lib/*-linux-*/libunwind-*.so.*:
-      /usr/lib/*-linux-*/libunwind.so.8.*:
       /usr/lib/*-linux-*/libunwind.so.8:
+      /usr/lib/*-linux-*/libunwind.so.8.*:

--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -16,19 +16,17 @@ slices:
       # This security path is also in "core" as it describes permissions for
       # various classes and how they can interact with the system.
       /etc/java-8-openjdk/security/java.policy:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/java.policy:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/meta-index:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/resources.jar:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/rt.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/bin/java:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjsig.so: {arch: armhf}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjvm.so: {arch: armhf}
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/jli/libjli.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/jvm.cfg-default:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjava.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjsig.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libnet.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libnio.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libverify.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libzip.so:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjsig.so:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjsig.so: {arch: armhf}
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjvm.so: {arch: armhf}
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjsig.so:
         arch:
           - amd64
@@ -39,15 +37,17 @@ slices:
           - amd64
           - arm64
           - ppc64el
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/hijrah-config-umalqura.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/calendars.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/content-types.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/logging.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/net.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/jvm.cfg-default:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/currency.data:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/hijrah-config-umalqura.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/logging.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/meta-index:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/net.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/resources.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/rt.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/java.policy:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/tzdb.dat:
-      /usr/lib/jvm/java-8-openjdk-*/jre/bin/java:
 
   locale:
     essential:
@@ -58,18 +58,12 @@ slices:
 
   security:
     essential:
-      - libpcsclite1_libs
       - ca-certificates-java_data
+      - libpcsclite1_libs
       - openjdk-8-jre-headless_core
     contents:
+      /etc/java-8-openjdk/security/blacklisted.certs:
       /etc/java-8-openjdk/security/java.security:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/java.security:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/blacklisted.certs:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/cacerts:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/limited/US_export_policy.jar:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/limited/local_policy.jar:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/unlimited/US_export_policy.jar:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/unlimited/local_policy.jar:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libj2gss.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libj2pcsc.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libj2pkcs11.so:
@@ -80,18 +74,29 @@ slices:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/sunpkcs11.jar:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/jce.jar:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/jsse.jar:
-      /etc/java-8-openjdk/security/blacklisted.certs:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/blacklisted.certs:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/cacerts:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/java.security:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/limited/US_export_policy.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/limited/local_policy.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/unlimited/US_export_policy.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/unlimited/local_policy.jar:
 
   # Abstract Window Toolkit.
   # Classes and components for creating GUI elements (windows, graphics, etc.).
   awt:
     essential:
-      - openjdk-8-jre-headless_core
-      - liblcms2-2_libs
       - libfontconfig1_libs
       - libfreetype6_libs
       - libjpeg-turbo8_libs
+      - liblcms2-2_libs
+      - openjdk-8-jre-headless_core
     contents:
+      /etc/java-8-openjdk/flavormap.properties:
+      /etc/java-8-openjdk/images/cursors/cursors.properties:
+      /etc/java-8-openjdk/psfont.properties.ja:
+      /etc/java-8-openjdk/psfontj2d.properties:
+      /etc/java-8-openjdk/swing.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libawt.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libawt_headless.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libfontmanager.so:
@@ -99,30 +104,25 @@ slices:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjavalcms.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libmlib_image.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/charsets.jar:
-      /etc/java-8-openjdk/flavormap.properties:
-      /etc/java-8-openjdk/images/cursors/cursors.properties:
-      /etc/java-8-openjdk/swing.properties:
-      /etc/java-8-openjdk/psfont.properties.ja:
-      /etc/java-8-openjdk/psfontj2d.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/images/cursors/cursors.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/flavormap.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/swing.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/psfontj2d.properties:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/psfont.properties.ja:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/CIEXYZ.pf:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/GRAY.pf:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/LINEAR_RGB.pf:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/PYCC.pf:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/sRGB.pf:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/flavormap.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/images/cursors/cursors.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/psfont.properties.ja:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/psfontj2d.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/swing.properties:
 
   # Enabled management and monitoring capabilities for Java apps.
   management:
     essential:
       - openjdk-8-jre-headless_core
     contents:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/management-agent.jar:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libmanagement.so:
       /etc/java-8-openjdk/management/management.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libmanagement.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/management-agent.jar:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/management/management.properties:
 
   # Java Flight Recorder - API for collecting diagnostic and profilling data.
@@ -130,34 +130,39 @@ slices:
     essential:
       - openjdk-8-jre-headless_core
     contents:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jfr.jar: {arch: [amd64,arm64,armhf,ppc64el]}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jfr.jar:
+        arch: [amd64, arm64, armhf, ppc64el]
 
   # Shared libraries for supporting heap profilling.
   hprof:
     essential:
       - openjdk-8-jre-headless_core
     contents:
-      /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libnpt.so: { arch: amd64 }
-      /usr/lib/jvm/java-8-openjdk-arm64/jre/lib/aarch64/libnpt.so: { arch: arm64 }
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libhprof.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjava_crw_demo.so:
+      /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libnpt.so:
+        arch: amd64
+      /usr/lib/jvm/java-8-openjdk-arm64/jre/lib/aarch64/libnpt.so:
+        arch: arm64
 
   # Shared libraries for supporting debugging capabilities.
   debug:
     essential:
       - openjdk-8-jre-headless_core
     contents:
-      /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libnpt.so: { arch: amd64 }
-      /usr/lib/jvm/java-8-openjdk-arm64/jre/lib/aarch64/libnpt.so: { arch: arm64 }
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjdwp.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libdt_socket.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjdwp.so:
+      /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libnpt.so:
+        arch: amd64
+      /usr/lib/jvm/java-8-openjdk-arm64/jre/lib/aarch64/libnpt.so:
+        arch: arm64
 
   tools:
     essential:
       - openjdk-8-jre-headless_core
     contents:
-      /usr/lib/jvm/java-8-openjdk-*/jre/bin/keytool:
       /usr/lib/jvm/java-8-openjdk-*/bin/keytool:
+      /usr/lib/jvm/java-8-openjdk-*/jre/bin/keytool:
 
   # Java Programming Language Instrumentation Services interface.
   jplis:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -3,8 +3,8 @@ package: openssl
 slices:
   bins:
     essential:
-      - libc6_libs
       - libc6_config
+      - libc6_libs
       - libssl3_libs
       - openssl_config
     contents:

--- a/slices/python3.11.yaml
+++ b/slices/python3.11.yaml
@@ -5,9 +5,9 @@ slices:
   # It includes very few modules from the libpython3.11-stdlib package.
   core:
     essential:
-      - python3.11-minimal_bins
       - libpython3.11-stdlib_core
       - media-types_data
+      - python3.11-minimal_bins
 
   # The "standard" slice extends "core" with all the Python
   # modules from the libpython3.11-stdlib package.

--- a/slices/tzdata.yaml
+++ b/slices/tzdata.yaml
@@ -1,9 +1,10 @@
 package: tzdata
 
 slices:
-  # The "base" slice contains Canonical timezone abbreviations. These are primary,
-  # preferred zone names that are often used as abbreviations for location-specific
-  # timezones across the globe. Example: Europe/Sofia observes EET.
+  # The "base" slice contains Canonical timezone abbreviations. These are
+  # primary, preferred zone names that are often used as abbreviations for
+  # location-specific timezones across the globe. Example: Europe/Sofia observes
+  # EET.
   base:
     contents:
       /usr/share/zoneinfo/CET:
@@ -13,13 +14,15 @@ slices:
       /usr/share/zoneinfo/EST5EDT:
       /usr/share/zoneinfo/Factory:
       /usr/share/zoneinfo/HST:
-      /usr/share/zoneinfo/iso3166.tab:
-      /usr/share/zoneinfo/leapseconds:
-      /usr/share/zoneinfo/leap-seconds.list:
-      /usr/share/zoneinfo/localtime:
       /usr/share/zoneinfo/MET:
       /usr/share/zoneinfo/MST:
       /usr/share/zoneinfo/MST7MDT:
+      /usr/share/zoneinfo/PST8PDT:
+      /usr/share/zoneinfo/WET:
+      /usr/share/zoneinfo/iso3166.tab:
+      /usr/share/zoneinfo/leap-seconds.list:
+      /usr/share/zoneinfo/leapseconds:
+      /usr/share/zoneinfo/localtime:
       /usr/share/zoneinfo/posix/CET:
       /usr/share/zoneinfo/posix/CST6CDT:
       /usr/share/zoneinfo/posix/EET:
@@ -32,7 +35,6 @@ slices:
       /usr/share/zoneinfo/posix/MST7MDT:
       /usr/share/zoneinfo/posix/PST8PDT:
       /usr/share/zoneinfo/posix/WET:
-      /usr/share/zoneinfo/PST8PDT:
       /usr/share/zoneinfo/right/CET:
       /usr/share/zoneinfo/right/CST6CDT:
       /usr/share/zoneinfo/right/EET:
@@ -46,20 +48,19 @@ slices:
       /usr/share/zoneinfo/right/PST8PDT:
       /usr/share/zoneinfo/right/WET:
       /usr/share/zoneinfo/tzdata.zi:
-      /usr/share/zoneinfo/WET:
 
   africa:
     essential:
       - tzdata_config
     contents:
       /usr/share/zoneinfo/Africa/*:
-      /usr/share/zoneinfo/posix/Africa/*:
-      /usr/share/zoneinfo/right/Africa/*:
       /usr/share/zoneinfo/Egypt:
       /usr/share/zoneinfo/Libya:
+      /usr/share/zoneinfo/posix/Africa/*:
       /usr/share/zoneinfo/posix/Egypt:
-      /usr/share/zoneinfo/right/Egypt:
       /usr/share/zoneinfo/posix/Libya:
+      /usr/share/zoneinfo/right/Africa/*:
+      /usr/share/zoneinfo/right/Egypt:
       /usr/share/zoneinfo/right/Libya:
 
   america:
@@ -67,18 +68,18 @@ slices:
       - tzdata_config
     contents:
       /usr/share/zoneinfo/America/**:
-      /usr/share/zoneinfo/posix/America/**:
-      /usr/share/zoneinfo/right/America/**:
       /usr/share/zoneinfo/Cuba:
       /usr/share/zoneinfo/Jamaica:
       /usr/share/zoneinfo/Navajo:
+      /usr/share/zoneinfo/posix/America/**:
       /usr/share/zoneinfo/posix/Cuba:
-      /usr/share/zoneinfo/right/Cuba:
       /usr/share/zoneinfo/posix/Jamaica:
-      /usr/share/zoneinfo/right/Jamaica:
       /usr/share/zoneinfo/posix/Navajo:
-      /usr/share/zoneinfo/right/Navajo:
       /usr/share/zoneinfo/posixrules:
+      /usr/share/zoneinfo/right/America/**:
+      /usr/share/zoneinfo/right/Cuba:
+      /usr/share/zoneinfo/right/Jamaica:
+      /usr/share/zoneinfo/right/Navajo:
 
   antarctica:
     essential:
@@ -151,45 +152,45 @@ slices:
     contents:
       # The .tab files are intended as an aid for users, to help them select
       # timezones appropriate for their practical needs.
-      /usr/share/zoneinfo/zone1970.tab:
       /usr/share/zoneinfo/zone.tab:
+      /usr/share/zoneinfo/zone1970.tab:
 
-  # "Etc" is meant to provide "timezones" that don't fit with the standard timezones.
-  # As an example, UTC isn't actually a timezone, but a standard. Like Zulu and others,
-  # most of these can be used for time information, but derive from different domains
-  # (like the military). Same for others.
+  # "Etc" is meant to provide "timezones" that don't fit with the standard
+  # timezones.  As an example, UTC isn't actually a timezone, but a standard.
+  # Like Zulu and others, most of these can be used for time information, but
+  # derive from different domains (like the military). Same for others.
   etc:
     contents:
       /usr/share/zoneinfo/Etc/*:
-      /usr/share/zoneinfo/posix/Etc/*:
-      /usr/share/zoneinfo/right/Etc/*:
       /usr/share/zoneinfo/GMT:
       /usr/share/zoneinfo/GMT+0:
       /usr/share/zoneinfo/GMT-0:
       /usr/share/zoneinfo/GMT0:
       /usr/share/zoneinfo/Greenwich:
+      /usr/share/zoneinfo/UCT:
+      /usr/share/zoneinfo/UTC:
+      /usr/share/zoneinfo/Universal:
+      /usr/share/zoneinfo/Zulu:
+      /usr/share/zoneinfo/posix/Etc/*:
       /usr/share/zoneinfo/posix/GMT:
       /usr/share/zoneinfo/posix/GMT+0:
       /usr/share/zoneinfo/posix/GMT-0:
       /usr/share/zoneinfo/posix/GMT0:
       /usr/share/zoneinfo/posix/Greenwich:
+      /usr/share/zoneinfo/posix/UCT:
+      /usr/share/zoneinfo/posix/UTC:
+      /usr/share/zoneinfo/posix/Universal:
+      /usr/share/zoneinfo/posix/Zulu:
+      /usr/share/zoneinfo/right/Etc/*:
       /usr/share/zoneinfo/right/GMT:
       /usr/share/zoneinfo/right/GMT+0:
       /usr/share/zoneinfo/right/GMT-0:
       /usr/share/zoneinfo/right/GMT0:
       /usr/share/zoneinfo/right/Greenwich:
-      /usr/share/zoneinfo/posix/UCT:
-      /usr/share/zoneinfo/posix/Universal:
-      /usr/share/zoneinfo/posix/UTC:
       /usr/share/zoneinfo/right/UCT:
-      /usr/share/zoneinfo/right/Universal:
       /usr/share/zoneinfo/right/UTC:
-      /usr/share/zoneinfo/posix/Zulu:
+      /usr/share/zoneinfo/right/Universal:
       /usr/share/zoneinfo/right/Zulu:
-      /usr/share/zoneinfo/UCT:
-      /usr/share/zoneinfo/Universal:
-      /usr/share/zoneinfo/UTC:
-      /usr/share/zoneinfo/Zulu:
 
   eurasia:
     essential:
@@ -198,12 +199,8 @@ slices:
       - tzdata_config
     contents:
       /usr/share/zoneinfo/Asia/*:
-      /usr/share/zoneinfo/Europe/*:
-      /usr/share/zoneinfo/posix/Asia/*:
-      /usr/share/zoneinfo/posix/Europe/*:
-      /usr/share/zoneinfo/right/Asia/*:
-      /usr/share/zoneinfo/right/Europe/*:
       /usr/share/zoneinfo/Eire:
+      /usr/share/zoneinfo/Europe/*:
       /usr/share/zoneinfo/GB:
       /usr/share/zoneinfo/GB-Eire:
       /usr/share/zoneinfo/Hongkong:
@@ -211,46 +208,50 @@ slices:
       /usr/share/zoneinfo/Iran:
       /usr/share/zoneinfo/Israel:
       /usr/share/zoneinfo/Japan:
+      /usr/share/zoneinfo/PRC:
       /usr/share/zoneinfo/Poland:
       /usr/share/zoneinfo/Portugal:
-      /usr/share/zoneinfo/posix/Eire:
-      /usr/share/zoneinfo/posix/GB:
-      /usr/share/zoneinfo/posix/GB-Eire:
-      /usr/share/zoneinfo/right/Eire:
-      /usr/share/zoneinfo/right/GB:
-      /usr/share/zoneinfo/right/GB-Eire:
-      /usr/share/zoneinfo/posix/Hongkong:
-      /usr/share/zoneinfo/right/Hongkong:
-      /usr/share/zoneinfo/posix/Iceland:
-      /usr/share/zoneinfo/posix/Iran:
-      /usr/share/zoneinfo/posix/Israel:
-      /usr/share/zoneinfo/right/Iran:
-      /usr/share/zoneinfo/right/Iceland:
-      /usr/share/zoneinfo/right/Israel:
-      /usr/share/zoneinfo/posix/Japan:
-      /usr/share/zoneinfo/right/Japan:
-      /usr/share/zoneinfo/posix/Poland:
-      /usr/share/zoneinfo/posix/Portugal:
-      /usr/share/zoneinfo/right/Poland:
-      /usr/share/zoneinfo/right/Portugal:
-      /usr/share/zoneinfo/posix/PRC:
-      /usr/share/zoneinfo/posix/ROC:
-      /usr/share/zoneinfo/posix/ROK:
-      /usr/share/zoneinfo/posix/Singapore:
-      /usr/share/zoneinfo/posix/Turkey:
-      /usr/share/zoneinfo/right/PRC:
-      /usr/share/zoneinfo/right/ROC:
-      /usr/share/zoneinfo/right/ROK:
-      /usr/share/zoneinfo/right/Singapore:
-      /usr/share/zoneinfo/right/Turkey:
-      /usr/share/zoneinfo/posix/W-SU:
-      /usr/share/zoneinfo/right/W-SU:
-      /usr/share/zoneinfo/PRC:
       /usr/share/zoneinfo/ROC:
       /usr/share/zoneinfo/ROK:
       /usr/share/zoneinfo/Singapore:
       /usr/share/zoneinfo/Turkey:
       /usr/share/zoneinfo/W-SU:
+      /usr/share/zoneinfo/posix/Asia/*:
+      /usr/share/zoneinfo/posix/Eire:
+      /usr/share/zoneinfo/posix/Europe/*:
+      /usr/share/zoneinfo/posix/GB:
+      /usr/share/zoneinfo/posix/GB-Eire:
+      /usr/share/zoneinfo/posix/Hongkong:
+      /usr/share/zoneinfo/posix/Iceland:
+      /usr/share/zoneinfo/posix/Iran:
+      /usr/share/zoneinfo/posix/Israel:
+      /usr/share/zoneinfo/posix/Japan:
+      /usr/share/zoneinfo/posix/PRC:
+      /usr/share/zoneinfo/posix/Poland:
+      /usr/share/zoneinfo/posix/Portugal:
+      /usr/share/zoneinfo/posix/ROC:
+      /usr/share/zoneinfo/posix/ROK:
+      /usr/share/zoneinfo/posix/Singapore:
+      /usr/share/zoneinfo/posix/Turkey:
+      /usr/share/zoneinfo/posix/W-SU:
+      /usr/share/zoneinfo/right/Asia/*:
+      /usr/share/zoneinfo/right/Eire:
+      /usr/share/zoneinfo/right/Europe/*:
+      /usr/share/zoneinfo/right/GB:
+      /usr/share/zoneinfo/right/GB-Eire:
+      /usr/share/zoneinfo/right/Hongkong:
+      /usr/share/zoneinfo/right/Iceland:
+      /usr/share/zoneinfo/right/Iran:
+      /usr/share/zoneinfo/right/Israel:
+      /usr/share/zoneinfo/right/Japan:
+      /usr/share/zoneinfo/right/PRC:
+      /usr/share/zoneinfo/right/Poland:
+      /usr/share/zoneinfo/right/Portugal:
+      /usr/share/zoneinfo/right/ROC:
+      /usr/share/zoneinfo/right/ROK:
+      /usr/share/zoneinfo/right/Singapore:
+      /usr/share/zoneinfo/right/Turkey:
+      /usr/share/zoneinfo/right/W-SU:
 
   indian:
     essential:
@@ -275,18 +276,18 @@ slices:
     essential:
       - tzdata_config
     contents:
-      /usr/share/zoneinfo/Pacific/*:
-      /usr/share/zoneinfo/posix/Pacific/*:
-      /usr/share/zoneinfo/right/Pacific/*:
       /usr/share/zoneinfo/Kwajalein:
       /usr/share/zoneinfo/NZ:
       /usr/share/zoneinfo/NZ-CHAT:
+      /usr/share/zoneinfo/Pacific/*:
       /usr/share/zoneinfo/posix/Kwajalein:
-      /usr/share/zoneinfo/right/Kwajalein:
       /usr/share/zoneinfo/posix/NZ:
       /usr/share/zoneinfo/posix/NZ-CHAT:
+      /usr/share/zoneinfo/posix/Pacific/*:
+      /usr/share/zoneinfo/right/Kwajalein:
       /usr/share/zoneinfo/right/NZ:
       /usr/share/zoneinfo/right/NZ-CHAT:
+      /usr/share/zoneinfo/right/Pacific/*:
 
   united-states:
     essential:
@@ -324,4 +325,3 @@ slices:
     contents:
       /usr/share/zoneinfo-icu/44/be/*:
       /usr/share/zoneinfo-icu/44/le/*:
-


### PR DESCRIPTION
This PR adds a "Lint" job to lint the slices and chisel.yaml. It also refactors the existing slice definition files and chisel.yaml for the lint checks to pass.