### PR TITLE
fix(22.04): fix arch specific paths for openjdk-8

### DIFF
--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -29,8 +29,16 @@ slices:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjsig.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjsig.so: {arch: armhf}
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjvm.so: {arch: armhf}
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjsig.so: {arch: [amd64,arm64,ppc64el]}
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjvm.so: {arch: [amd64,arm64,ppc64el]}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjsig.so:
+        arch:
+          - amd64
+          - arm64
+          - ppc64el
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjvm.so:
+        arch:
+          - amd64
+          - arm64
+          - ppc64el
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/hijrah-config-umalqura.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/calendars.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/content-types.properties:

--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -27,8 +27,10 @@ slices:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libverify.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libzip.so:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjsig.so:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjsig.so:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjvm.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjsig.so: {arch: armhf}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjvm.so: {arch: armhf}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjsig.so: {arch: [amd64,arm64,ppc64el]}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjvm.so: {arch: [amd64,arm64,ppc64el]}
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/hijrah-config-umalqura.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/calendars.properties:
       /usr/lib/jvm/java-8-openjdk-*/jre/lib/content-types.properties:
@@ -120,7 +122,7 @@ slices:
     essential:
       - openjdk-8-jre-headless_core
     contents:
-      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jfr.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jfr.jar: {arch: [amd64,arm64,armhf,ppc64el]}
 
   # Shared libraries for supporting heap profilling.
   hprof:


### PR DESCRIPTION
Certain paths were not valid for all architectures. This PR adds the arch-specific constraints.
@vpa1977 can you pls double check if it makes sense?