### PR TITLE
chore: ignore missing packages for PRs, Push

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -142,5 +142,7 @@ jobs:
           elif [[ "${{ steps.changed-paths.outputs.slices }}" == "true" ]]; then
             # Install slices from changed files.
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
+              --ensure-existence \
+              --ignore-missing \
               ${{ steps.changed-paths.outputs.slices_files }}
           fi


### PR DESCRIPTION
This PR adds changes which ensure that in a PR or Push where all files are not installed, missing packages for one or more architectures will be ignored if they exist for at least one arch.

Relevant: https://github.com/canonical/chisel-releases/pull/149#issuecomment-1961757405