### PR TITLE
chore(main): check paths diff within same branch on push

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -82,6 +82,20 @@ jobs:
               - '.github/**'
             slices:
               - added|modified: 'slices/**/*.yaml'
+          # Branch, tag, or commit SHA against which the changes will be
+          # detected. If it references the same branch it was pushed to, changes
+          # are detected against the most recent commit before the push.
+          # Otherwise, it uses git merge-base to find the best common ancestor
+          # between current branch (HEAD) and base.  When merge-base is found,
+          # it's used for change detection - only changes introduced by the
+          # current branch are considered. All files are considered as added if
+          # there is no common ancestor with base branch or no previous commit.
+          # This option is ignored if action is triggered by pull_request event.
+          # Default: repository default branch (e.g. master)
+          #
+          # Only add this value on "push" events and compare with the SHA of the
+          # most recent commit on "ref" before the push.
+          base: ${{ github.event_name == 'push' && github.event.before }}
           # Space delimited list usable as command-line argument list in
           # Linux shell. If needed, it uses single or double quotes to
           # wrap filename with unsafe characters.


### PR DESCRIPTION
# Proposed changes
On "push" events, specify the "base" value of dorny/paths-filter action. This ensures that the comparison is made against the recent commit on that particular branch before pushing the new commits.

Previously, it was left empty, resulting in the default value which is the default branch "ubuntu-22.04". Thus pushed to the "ubuntu-24.04" branch would be compared with "ubuntu-22.04" which is a bug. [1]

This commit fixes said bug.

[1] https://github.com/canonical/chisel-releases/actions/runs/8092571514/job/22113523205#step:3:52

## Testing

Expected behaviour on Push:
* Changes will be computed between recent commits before push and after push: https://github.com/rebornplusplus/chisel-releases/actions/runs/8094448190/job/22119167199 (Check the logs of  "Check changed paths" step)
  
  > Changes will be detected between 52fd99dd9f36ce9f6d7889faf615b2294f93b664 and ubuntu-24.04

Expected behaviour on PRs:
* Nothing changes: https://github.com/rebornplusplus/chisel-releases/actions/runs/8094398023/job/22119019184

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
