### PR TITLE
chore(23.10): CI does not run on push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,6 @@ name: CI
 run-name: CI for ${{ github.ref }}
 
 on:
-  push:
-    branches:
-      - "ubuntu-*"
   pull_request:
     branches:
       - "ubuntu-*"


### PR DESCRIPTION
# Proposed changes

This PR removes the `on: push` event from the CI. This means that the CIs in `ubuntu-*` branches will not run on `push`.

## Related issues/PRs
<!-- If any -->
* https://github.com/canonical/chisel-releases/pull/157#pullrequestreview-1909130701

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

* #172

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
