### PR TITLE
feat(22.04): add sed slices

### DIFF
--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -1,5 +1,8 @@
 package: sed
 
+essential:
+  - sed_copyright
+
 slices:
   bins:
     essential:
@@ -9,3 +12,7 @@ slices:
       - libselinux1_libs
     contents:
       /bin/sed:
+
+  copyright:
+    contents:
+      /usr/share/doc/sed/copyright:

--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -1,0 +1,11 @@
+package: sed
+
+slices:
+  bins:
+    essential:
+      - libacl1_libs
+      - libc6_libs
+      - libpcre2-8-0_libs
+      - libselinux1_libs
+    contents:
+      /bin/sed:


### PR DESCRIPTION
# Proposed changes
Add simple slice for `sed` - we use it in a bunch of our entrypoints.

### Forward porting
#181 
#182 

## Testing
```bash
rm -rf fs && \
mkdir -p fs && \
~/go/bin/chisel cut --root=$(readlink -f fs) --release=$(readlink -f .) sed_bins && \
sudo chroot fs /bin/sed --version
```
Expected output(ish):
```
2024/03/05 20:58:49 Processing /home/lwnexgen/Local-Development/chisel-releases release...
2024/03/05 20:58:49 Selecting slices...
2024/03/05 20:58:49 Fetching ubuntu 22.04 jammy suite details...
2024/03/05 20:58:49 Release date: Thu, 21 Apr 2022 17:16:08 UTC
2024/03/05 20:58:49 Fetching index for ubuntu 22.04 jammy main component...
2024/03/05 20:58:50 Fetching index for ubuntu 22.04 jammy universe component...
2024/03/05 20:58:50 Fetching ubuntu 22.04 jammy-security suite details...
2024/03/05 20:58:50 Release date: Wed, 06 Mar 2024 17:07:10 UTC
2024/03/05 20:58:50 Fetching index for ubuntu 22.04 jammy-security main component...
2024/03/05 20:58:50 Fetching index for ubuntu 22.04 jammy-security universe component...
2024/03/05 20:58:50 Fetching ubuntu 22.04 jammy-updates suite details...
2024/03/05 20:58:50 Release date: Wed, 06 Mar 2024 16:36:16 UTC
2024/03/05 20:58:50 Fetching index for ubuntu 22.04 jammy-updates main component...
2024/03/05 20:58:50 Fetching index for ubuntu 22.04 jammy-updates universe component...
2024/03/05 20:58:50 Fetching pool/main/g/glibc/libc6_2.35-0ubuntu3.6_amd64.deb...
2024/03/05 20:58:50 Fetching pool/main/a/acl/libacl1_2.3.1-1_amd64.deb...
2024/03/05 20:58:50 Fetching pool/main/p/pcre2/libpcre2-8-0_10.39-3ubuntu0.1_amd64.deb...
2024/03/05 20:58:50 Fetching pool/main/libs/libselinux/libselinux1_3.3-1build2_amd64.deb...
2024/03/05 20:58:50 Fetching pool/main/s/sed/sed_4.8-1ubuntu2_amd64.deb...
2024/03/05 20:58:50 Extracting files from package "libc6"...
2024/03/05 20:58:50 Extracting files from package "libacl1"...
2024/03/05 20:58:50 Extracting files from package "libpcre2-8-0"...
2024/03/05 20:58:50 Extracting files from package "libselinux1"...
2024/03/05 20:58:50 Extracting files from package "sed"...
/bin/sed (GNU sed) 4.8
Packaged by Debian
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jay Fenlason, Tom Lord, Ken Pizzini,
Paolo Bonzini, Jim Meyering, and Assaf Gordon.

This sed program was built with SELinux support.
SELinux is disabled on this system.

GNU sed home page: <https://www.gnu.org/software/sed/>.
General help using GNU software: <https://www.gnu.org/gethelp/>.
E-mail bug reports to: <bug-sed@gnu.org>.
```

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)