### PR TITLE
feat(23.10): add sed slices

### DIFF
--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -1,5 +1,8 @@
 package: sed
 
+essential:
+  - sed_copyright
+
 slices:
   bins:
     essential:
@@ -9,3 +12,7 @@ slices:
       - libselinux1_libs
     contents:
       /bin/sed:
+
+  copyright:
+    contents:
+      /usr/share/doc/sed/copyright:

--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -1,0 +1,11 @@
+package: sed
+
+slices:
+  bins:
+    essential:
+      - libacl1_libs
+      - libc6_libs
+      - libpcre2-8-0_libs
+      - libselinux1_libs
+    contents:
+      /bin/sed:


### PR DESCRIPTION
# Proposed changes
Add simple slice for `sed` - we use it in a bunch of our entrypoints.

### Forward porting
#182 

## Testing
```bash
rm -rf fs && \
mkdir -p fs && \
~/go/bin/chisel cut --root=$(readlink -f fs) --release=$(readlink -f .) sed_bins && \
sudo chroot fs /bin/sed --version
```
Expected output(ish):
```
2024/03/05 21:04:16 Processing /home/lwnexgen/Local-Development/chisel-releases release...
2024/03/05 21:04:16 Selecting slices...
2024/03/05 21:04:16 Fetching ubuntu 23.10 mantic suite details...
2024/03/05 21:04:16 Release date: Mon, 16 Oct 2023 21:12:12 UTC
2024/03/05 21:04:16 Fetching index for ubuntu 23.10 mantic main component...
2024/03/05 21:04:16 Fetching index for ubuntu 23.10 mantic universe component...
2024/03/05 21:04:17 Fetching ubuntu 23.10 mantic-security suite details...
2024/03/05 21:04:17 Release date: Wed, 06 Mar 2024 17:06:55 UTC
2024/03/05 21:04:17 Fetching index for ubuntu 23.10 mantic-security main component...
2024/03/05 21:04:17 Fetching index for ubuntu 23.10 mantic-security universe component...
2024/03/05 21:04:17 Fetching ubuntu 23.10 mantic-updates suite details...
2024/03/05 21:04:17 Release date: Wed, 06 Mar 2024 16:34:40 UTC
2024/03/05 21:04:17 Fetching index for ubuntu 23.10 mantic-updates main component...
2024/03/05 21:04:17 Fetching index for ubuntu 23.10 mantic-updates universe component...
2024/03/05 21:04:17 Fetching pool/main/g/glibc/libc6_2.38-1ubuntu6.1_amd64.deb...
2024/03/05 21:04:17 Fetching pool/main/a/acl/libacl1_2.3.1-3_amd64.deb...
2024/03/05 21:04:17 Fetching pool/main/p/pcre2/libpcre2-8-0_10.42-4_amd64.deb...
2024/03/05 21:04:17 Fetching pool/main/libs/libselinux/libselinux1_3.5-1_amd64.deb...
2024/03/05 21:04:17 Fetching pool/main/s/sed/sed_4.9-1_amd64.deb...
2024/03/05 21:04:17 Extracting files from package "libc6"...
2024/03/05 21:04:17 Extracting files from package "libacl1"...
2024/03/05 21:04:17 Extracting files from package "libpcre2-8-0"...
2024/03/05 21:04:17 Extracting files from package "libselinux1"...
2024/03/05 21:04:17 Extracting files from package "sed"...
/bin/sed (GNU sed) 4.9
Packaged by Debian
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jay Fenlason, Tom Lord, Ken Pizzini,
Paolo Bonzini, Jim Meyering, and Assaf Gordon.

This sed program was built with SELinux support.
SELinux is disabled on this system.

GNU sed home page: <https://www.gnu.org/software/sed/>.
General help using GNU software: <https://www.gnu.org/gethelp/>.
E-mail bug reports to: <bug-sed@gnu.org>.
```

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)