### PR TITLE
feat(24.04): add sed slices

### DIFF
--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -8,4 +8,4 @@ slices:
       - libpcre2-8-0_libs
       - libselinux1_libs
     contents:
-      /bin/sed:
+      /usr/bin/sed:

--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -1,0 +1,11 @@
+package: sed
+
+slices:
+  bins:
+    essential:
+      - libacl1_libs
+      - libc6_libs
+      - libpcre2-8-0_libs
+      - libselinux1_libs
+    contents:
+      /bin/sed:

--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -5,7 +5,6 @@ slices:
     essential:
       - libacl1_libs
       - libc6_libs
-      - libpcre2-8-0_libs
       - libselinux1_libs
     contents:
       /usr/bin/sed:


### PR DESCRIPTION
# Proposed changes
Add simple slice for `sed` - we use it in a bunch of our entrypoints.

No forward ports necessary

## Testing
```bash
rm -rf fs && \
mkdir -p fs && \
~/go/bin/chisel cut --root=$(readlink -f fs) --release=$(readlink -f .) sed_bins && \
sudo chroot fs /usr/bin/sed --version
```

Should show similar output to other PRs, but I don't have a 24.04 system that will play nice with my build infrastructure to test right now.

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)