### PR TITLE
chore: add workflow to check package dependencies

### DIFF
--- a/.github/scripts/pkg-deps/pkg-deps
+++ b/.github/scripts/pkg-deps/pkg-deps
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+export LC_COLLATE=C
+
+if [[ -z "$branch" ]]; then
+  echo "error: no branch specified" >&2
+  exit 1
+fi
+
+version=$(echo "$branch" | grep -Eo '[0-9.]+')
+docker run -i -d --rm --name ubuntu ubuntu:"$version" >&2
+
+cleanup() {
+  docker rm -f ubuntu >&2
+}
+trap cleanup EXIT
+
+docker exec ubuntu apt-get update >&2
+
+msg_file="${msg_file:-$(mktemp)}"
+echo "Writing dependencies diff to $msg_file" >&2
+if [[ -n "$GITHUB_OUTPUT" ]]; then
+  echo "msg_file=$msg_file" >> $GITHUB_OUTPUT
+fi
+
+echo "Diff of dependencies:" > "$msg_file"
+for f in $@; do
+  echo "Processing $f.." >&2
+  pkg=$(yq '.package' "$f")
+
+  mapfile -t deps < <(
+    docker exec ubuntu apt depends \
+      --no-recommends --no-suggests --no-conflicts \
+      --no-breaks --no-replaces --no-enhances \
+      "$pkg" 2>/dev/null | \
+    sed -nr 's/.*Depends:\s(\S*).*/\1/p' | \
+    sed 's/<//; s/>//; s/:any//' | \
+    sort | uniq
+  )
+
+  mapfile -t listed < <(
+    yq '.slices.[].essential[]' "$f" | \
+    sed "s/_.*//; /^$pkg$/d" | sort | uniq
+  )
+
+  diffs=()
+  for p in "${listed[@]}"; do
+    if printf '%s\0' "${deps[@]}" | grep -Fxqz -- "$p"; then
+      continue
+    fi
+    diffs+=("$p")
+  done
+
+  if (( "${#diffs[@]}")); then
+    echo "<details>" >> "$msg_file"
+    echo -e "<summary>$f</summary>\n" >> "$msg_file"
+    for e in "${diffs[@]}"; do
+      echo "  - \`$e\` is listed in \`essential\`, but is not a dependency." >> "$msg_file"
+    done
+    echo -e "\n</details>" >> "$msg_file"
+  fi
+done
+
+if ! grep "<summary>" "$msg_file"; then
+  echo -e "\tNone found." >> "$msg_file"
+fi
+
+echo -e "\n---" >> "$msg_file"
+cat "$msg_file"

--- a/.github/scripts/pkg-deps/pkg-deps
+++ b/.github/scripts/pkg-deps/pkg-deps
@@ -25,40 +25,31 @@ if [[ -n "$GITHUB_OUTPUT" ]]; then
   echo "msg_file=$msg_file" >> $GITHUB_OUTPUT
 fi
 
-echo "Diff of dependencies:" > "$msg_file"
+echo -e "Diff of dependencies:\n" > "$msg_file"
 for f in $@; do
   echo "Processing $f.." >&2
   pkg=$(yq '.package' "$f")
 
-  mapfile -t deps < <(
-    docker exec ubuntu apt depends \
-      --no-recommends --no-suggests --no-conflicts \
-      --no-breaks --no-replaces --no-enhances \
-      "$pkg" 2>/dev/null | \
-    sed -nr 's/.*Depends:\s(\S*).*/\1/p' | \
-    sed 's/<//; s/>//; s/:any//' | \
-    sort | uniq
-  )
+  fupstream="$(mktemp)"
+  docker exec ubuntu apt depends \
+    --no-recommends --no-suggests --no-conflicts \
+    --no-breaks --no-replaces --no-enhances \
+    "$pkg" 2>/dev/null | \
+  sed -nr 's/.*Depends:\s(\S*).*/\1/p' | \
+  sed 's/<//; s/>//; s/:any//' | \
+  sort | uniq > "$fupstream"
 
-  mapfile -t listed < <(
-    yq '.slices.[].essential[]' "$f" | \
-    sed "s/_.*//; /^$pkg$/d" | sort | uniq
-  )
+  flocal="$(mktemp)"
+  yq '.slices.[].essential[]' "$f" | \
+  sed "s/_.*//; /^$pkg$/d" | sort | uniq > "$flocal"
 
-  diffs=()
-  for p in "${listed[@]}"; do
-    if printf '%s\0' "${deps[@]}" | grep -Fxqz -- "$p"; then
-      continue
-    fi
-    diffs+=("$p")
-  done
-
-  if (( "${#diffs[@]}")); then
+  fdiff="$(mktemp)"
+  if ! diff -u "$fupstream" "$flocal" > "$fdiff"; then
     echo "<details>" >> "$msg_file"
     echo -e "<summary>$f</summary>\n" >> "$msg_file"
-    for e in "${diffs[@]}"; do
-      echo "  - \`$e\` is listed in \`essential\`, but is not a dependency." >> "$msg_file"
-    done
+    echo "\`\`\`diff" >> "$msg_file"
+    cat "$fdiff" | tail -n +3 >> "$msg_file"
+    echo "\`\`\`" >> "$msg_file"
     echo -e "\n</details>" >> "$msg_file"
   fi
 done

--- a/.github/workflows/pkg-deps.yaml
+++ b/.github/workflows/pkg-deps.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Check dependencies
         id: check-deps
         env:
-          script-dir: "${{ env.main-branch-path }}/.github/scripts/install_slices"
+          script-dir: "${{ env.main-branch-path }}/.github/scripts/pkg-deps"
         run: |
           set -ex
           ./${{ env.script-dir }}/pkg-deps \

--- a/.github/workflows/pkg-deps.yaml
+++ b/.github/workflows/pkg-deps.yaml
@@ -1,0 +1,102 @@
+name: Package dependencies
+
+on:
+  workflow_call:
+
+jobs:
+  check-dependency:
+    name: Check dependency
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      startswith(github.base_ref, 'ubuntu-')
+    env:
+      branch: ${{ github.base_ref }}
+      msg_file: dependencies.message
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check changed paths
+        id: changed-paths
+        uses: dorny/paths-filter@v3
+        with:
+          # ref: https://github.com/marketplace/actions/paths-changes-filter
+          filters: |
+            slices:
+              - added|modified: 'slices/**/*.yaml'
+          # Space delimited list usable as command-line argument list in
+          # Linux shell. If needed, it uses single or double quotes to
+          # wrap filename with unsafe characters.
+          list-files: shell
+
+      - name: Check dependencies
+        id: check-deps
+        if: steps.changed-paths.outputs.slices == 'true'
+        run: |
+          set -e
+
+          export LC_COLLATE=C
+
+          version=$(echo "$branch" | grep -Eo '[0-9.]+')
+          docker run -i -d --rm --name ubuntu ubuntu:"$version"
+          docker exec ubuntu apt-get update
+
+          cleanup() {
+            docker stop ubuntu
+          }
+          trap cleanup EXIT
+
+          echo "Slice package dependency issues:" > "$msg_file"
+          for f in ${{ steps.changed-paths.outputs.slices_files }}; do
+            echo "Processing $f.." >&2
+            pkg=$(yq '.package' "$f")
+
+            mapfile -t deps < <(
+              docker exec ubuntu apt depends \
+                --no-recommends --no-suggests --no-conflicts \
+                --no-breaks --no-replaces --no-enhances \
+                "$pkg" 2>/dev/null | \
+              sed -nr 's/.*Depends:\s(\S*).*/\1/p' | \
+              sed 's/<//; s/>//; s/:any//' | \
+              sort | uniq
+            )
+
+            mapfile -t listed < <(
+              yq '.slices.[].essential[]' "$f" | \
+              sed "s/_.*//; /^$pkg$/d" | sort | uniq
+            )
+
+            errs=()
+            for p in "${listed[@]}"; do
+              if printf '%s\0' "${deps[@]}" | grep -Fxqz -- "$p"; then
+                continue
+              fi
+              errs+=("$p")
+            done
+
+            if (( "${#errs[@]}")); then
+              echo "<details>" >> "$msg_file"
+              echo -e "<summary>$f</summary>\n" >> "$msg_file"
+              for e in "${errs[@]}"; do
+                echo "  - \`$e\` is listed in \`essential\`, but is not a dependency." >> "$msg_file"
+              done
+              echo -e "\n</details>" >> "$msg_file"
+            fi
+          done
+          echo -e "\n---" >> "$msg_file"
+          cat "$msg_file"
+
+      - name: Craft default message if no errors
+        run: |
+          set -e
+          if [[ ! -f "$msg_file" ]]; then
+            echo "Slice package dependency issues:" > "$msg_file"
+            echo -e "\tNone found." >> "$msg_file"
+          fi
+
+      - name: Post messages to PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-path: ${{ env.msg_file }}

--- a/.github/workflows/pkg-deps.yaml
+++ b/.github/workflows/pkg-deps.yaml
@@ -12,7 +12,7 @@ jobs:
       startswith(github.base_ref, 'ubuntu-')
     env:
       branch: ${{ github.base_ref }}
-      msg_file: dependencies.message
+      main-branch-path: files-from-main
     permissions:
       pull-requests: write
     steps:
@@ -31,72 +31,22 @@ jobs:
           # wrap filename with unsafe characters.
           list-files: shell
 
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: ${{ env.main-branch-path }}
+
       - name: Check dependencies
         id: check-deps
-        if: steps.changed-paths.outputs.slices == 'true'
+        env:
+          script-dir: "${{ env.main-branch-path }}/.github/scripts/install_slices"
         run: |
-          set -e
-
-          export LC_COLLATE=C
-
-          version=$(echo "$branch" | grep -Eo '[0-9.]+')
-          docker run -i -d --rm --name ubuntu ubuntu:"$version"
-          docker exec ubuntu apt-get update
-
-          cleanup() {
-            docker stop ubuntu
-          }
-          trap cleanup EXIT
-
-          echo "Slice package dependency issues:" > "$msg_file"
-          for f in ${{ steps.changed-paths.outputs.slices_files }}; do
-            echo "Processing $f.." >&2
-            pkg=$(yq '.package' "$f")
-
-            mapfile -t deps < <(
-              docker exec ubuntu apt depends \
-                --no-recommends --no-suggests --no-conflicts \
-                --no-breaks --no-replaces --no-enhances \
-                "$pkg" 2>/dev/null | \
-              sed -nr 's/.*Depends:\s(\S*).*/\1/p' | \
-              sed 's/<//; s/>//; s/:any//' | \
-              sort | uniq
-            )
-
-            mapfile -t listed < <(
-              yq '.slices.[].essential[]' "$f" | \
-              sed "s/_.*//; /^$pkg$/d" | sort | uniq
-            )
-
-            errs=()
-            for p in "${listed[@]}"; do
-              if printf '%s\0' "${deps[@]}" | grep -Fxqz -- "$p"; then
-                continue
-              fi
-              errs+=("$p")
-            done
-
-            if (( "${#errs[@]}")); then
-              echo "<details>" >> "$msg_file"
-              echo -e "<summary>$f</summary>\n" >> "$msg_file"
-              for e in "${errs[@]}"; do
-                echo "  - \`$e\` is listed in \`essential\`, but is not a dependency." >> "$msg_file"
-              done
-              echo -e "\n</details>" >> "$msg_file"
-            fi
-          done
-          echo -e "\n---" >> "$msg_file"
-          cat "$msg_file"
-
-      - name: Craft default message if no errors
-        run: |
-          set -e
-          if [[ ! -f "$msg_file" ]]; then
-            echo "Slice package dependency issues:" > "$msg_file"
-            echo -e "\tNone found." >> "$msg_file"
-          fi
+          set -ex
+          ./${{ env.script-dir }}/pkg-deps \
+            ${{ steps.changed-paths.outputs.slices_files }}
 
       - name: Post messages to PR
         uses: mshick/add-pr-comment@v2
         with:
-          message-path: ${{ env.msg_file }}
+          message-path: ${{ steps.check-deps.outputs.msg_file }}


### PR DESCRIPTION
# Proposed changes

This PR adds a new reusable workflow which can be run on Pull Requests to see if the packages listed in "essential" of a slice are the true dependencies of the slice package. This workflow will add a PR comment if it finds any errors.

## Related issues/PRs
https://github.com/canonical/chisel-releases/pull/188

## Testing
See demo at https://github.com/rebornplusplus/chisel-releases/pull/9.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

