### PR TITLE
chore(22.04): add pkg-deps job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,3 +19,8 @@ jobs:
   lint:
     name: Lint
     uses: canonical/chisel-releases/.github/workflows/lint.yaml@main
+
+  pkg-deps:
+    if: github.event_name == 'pull_request'
+    name: Package dependencies
+    uses: canonical/chisel-releases/.github/workflows/pkg-deps.yaml@main


### PR DESCRIPTION

# Proposed changes
This PR adds a new pkg-deps job on Pull Request. It checks in changed files if slices of any package A has been listed in "essential" of a slice in package B, but B does not depend on A. If found, the CI will add a comment in the Pull Request with the findings.

## Related issues/PRs
#187

## Testing
See demo at https://github.com/rebornplusplus/chisel-releases/pull/9.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
