### PR TITLE
Ubuntu 24.04 add p11 kit

### DIFF
--- a/slices/p11-kit-modules.yaml
+++ b/slices/p11-kit-modules.yaml
@@ -4,10 +4,10 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libp11-kit0_libs
       - libffi8_libs
+      - libp11-kit0_libs
       - libtasn1-6_libs
     contents:
+      /usr/lib/*-linux-*/p11-kit-proxy.so:
       /usr/lib/*-linux-*/pkcs11/p11-kit-client.so:
       /usr/lib/*-linux-*/pkcs11/p11-kit-trust.so:
-      /usr/lib/*-linux-*/p11-kit-proxy.so:

--- a/slices/p11-kit-modules.yaml
+++ b/slices/p11-kit-modules.yaml
@@ -1,0 +1,13 @@
+package: p11-kit-modules
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libp11-kit0_libs
+      - libffi8_libs
+      - libtasn1-6_libs
+    contents:
+      /usr/lib/*-linux-*/pkcs11/p11-kit-client.so:
+      /usr/lib/*-linux-*/pkcs11/p11-kit-trust.so:
+      /usr/lib/*-linux-*/p11-kit-proxy.so:

--- a/slices/p11-kit.yaml
+++ b/slices/p11-kit.yaml
@@ -1,0 +1,18 @@
+package: p11-kit
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libp11-kit0_libs
+      - libtasn1-6_libs
+      - p11-kit-modules_libs
+      - p11-kit_config
+    contents:
+      /usr/bin/p11-kit:
+      /usr/bin/trust:
+      /usr/libexec/p11-kit/p11-kit-remote:
+      /usr/libexec/p11-kit/p11-kit-server:
+  config:
+    contents:
+      /usr/share/p11-kit/modules/p11-kit-trust.module:


### PR DESCRIPTION
# Proposed changes
Add [p11-kit](https://packages.ubuntu.com/mantic/p11-kit) and [p11-kit-modules](https://packages.ubuntu.com/mantic/p11-kit-modules) slices.

## Testing
```bash
rm -rf fs && mkdir -p fs && ~/go/bin/chisel cut --root=$(readlink -f fs) --release=$(readlink -f .) p11-kit_bins && sudo chroot fs /usr/bin/p11-kit list-modules
```

Output should be similar to other PRs ; I don't have a stable enough 24.04 system to test on.

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
These are deps of `update-ca-certificates`