### PR TITLE
chore: run installability tests only on relevance

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - "main"
     paths:
-      - ".github/**"
+      - ".github/scripts/install-slices/**"
+      - ".github/workflows/install-slices.yaml"
   pull_request:
     branches:
       - "main"
     paths:
-      - ".github/**"
+      - ".github/scripts/install-slices/**"
+      - ".github/workflows/install-slices.yaml"
   schedule:
     # Run at 00:00 every day.
     # Ref: https://man7.org/linux/man-pages/man5/crontab.5.html


### PR DESCRIPTION
Currently we are running Installability Tests whenever a file inside ".github" directory is added or modified. We do not always need this. Instead, checking whether the relevant workflow file and scripts have changed is enough.