### PR TITLE
feat(24.04): bump format to v1

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,13 +1,13 @@
-format: chisel-v1
+format: v1
 
 archives:
   ubuntu:
     version: 24.04
     components: [main, universe]
     suites: [noble, noble-security, noble-updates]
-    v1-public-keys: [ubuntu-archive-key-2018]
+    public-keys: [ubuntu-archive-key-2018]
 
-v1-public-keys:
+public-keys:
   # Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>
   # rsa4096/f6ecb3762474eda9d21b7022871920d1991bc93c 2018-09-17T15:01:46Z
   ubuntu-archive-key-2018:


### PR DESCRIPTION
# Proposed changes
Bumps the `format` to **v1**, in line with the announced schema changes in https://discourse.ubuntu.com/t/chisel-v0-9-0-is-out/41759.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
