### PR TITLE
chore: fix permissions of pkg-deps job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,5 +22,7 @@ jobs:
 
   pkg-deps:
     if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
     name: Package dependencies
     uses: canonical/chisel-releases/.github/workflows/pkg-deps.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
 
   pkg-deps:
     if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
+    permissions: write-all
     name: Package dependencies
     uses: canonical/chisel-releases/.github/workflows/pkg-deps.yaml@main


### PR DESCRIPTION
This PR adds the permission required to write in PR to the `pkg-deps` job in CI.

There have been some failures like this: https://github.com/canonical/chisel-releases/actions/runs/8268278480/job/22620739872?pr=195.