### PR TITLE
chore(main): pkg-deps workflow supports pull_request_target

### DIFF
--- a/.github/scripts/pkg-deps/pkg-deps
+++ b/.github/scripts/pkg-deps/pkg-deps
@@ -25,7 +25,7 @@ if [[ -n "$GITHUB_OUTPUT" ]]; then
   echo "msg_file=$msg_file" >> $GITHUB_OUTPUT
 fi
 
-echo -e "Diff of dependencies:\n" > "$msg_file"
+echo -e "Diff of dependencies:" > "$msg_file"
 for f in $@; do
   echo "Processing $f.." >&2
   pkg=$(yq '.package' "$f")
@@ -45,7 +45,7 @@ for f in $@; do
 
   fdiff="$(mktemp)"
   if ! diff -u "$fupstream" "$flocal" > "$fdiff"; then
-    echo "<details>" >> "$msg_file"
+    echo -e "\n<details>" >> "$msg_file"
     echo -e "<summary>$f</summary>\n" >> "$msg_file"
     echo "\`\`\`diff" >> "$msg_file"
     cat "$fdiff" | tail -n +3 >> "$msg_file"

--- a/.github/workflows/pkg-deps.yaml
+++ b/.github/workflows/pkg-deps.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Check dependency
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'pull_request' &&
+      startswith(github.event_name, 'pull_request') &&
       startswith(github.base_ref, 'ubuntu-')
     env:
       branch: ${{ github.base_ref }}
@@ -17,6 +17,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Check changed paths
         id: changed-paths


### PR DESCRIPTION
# Proposed changes

This PR amends the `pkg-deps` workflow to support `pull_request_target` events, which is what we will be needing from the caller workflow.

## Related issues/PRs
22.04: #199 

## Testing
Demo: https://github.com/rebornplusplus/chisel-releases/pull/10

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)