### PR TITLE
chore(22.04): fix pkg-deps job

### DIFF
--- a/.github/workflows/ci-pr-target.yaml
+++ b/.github/workflows/ci-pr-target.yaml
@@ -1,0 +1,14 @@
+# This workflow supports jobs which needs the on.pull_request_target event
+# instead of the usual on.pull_request event.
+name: CI
+run-name: CI for ${{ github.ref }}
+
+on:
+  pull_request_target:
+    branches:
+      - "ubuntu-*"
+
+jobs:
+  pkg-deps:
+    name: Package dependencies
+    uses: rebornplusplus/chisel-releases/.github/workflows/pkg-deps.yaml@main

--- a/.github/workflows/ci-pr-target.yaml
+++ b/.github/workflows/ci-pr-target.yaml
@@ -1,7 +1,7 @@
 # This workflow supports jobs which needs the on.pull_request_target event
 # instead of the usual on.pull_request event.
-name: CI
-run-name: CI for ${{ github.ref }}
+name: Pkg coverage
+run-name: Pkg coverage for ${{ github.ref }}
 
 on:
   pull_request_target:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,3 @@ jobs:
   lint:
     name: Lint
     uses: canonical/chisel-releases/.github/workflows/lint.yaml@main
-
-  pkg-deps:
-    if: github.event_name == 'pull_request'
-    name: Package dependencies
-    uses: canonical/chisel-releases/.github/workflows/pkg-deps.yaml@main


### PR DESCRIPTION
# Proposed changes
This PR fixes the `pkg-deps` job with proper `event` and permissions. The `pkg-deps` job is moved from the `ci.yaml` workflow to a new `ci-pr-target.yaml` workflow which accommodates jobs which need the `pull_request_target` event.

## Related issues/PRs
#198


## Testing
Demo: https://github.com/rebornplusplus/chisel-releases/pull/10

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
