### PR TITLE
chore(24.04): add pkg-deps job

### DIFF
--- a/.github/workflows/ci-pr-target.yaml
+++ b/.github/workflows/ci-pr-target.yaml
@@ -1,0 +1,14 @@
+# This workflow supports jobs which needs the on.pull_request_target event
+# instead of the usual on.pull_request event.
+name: CI
+run-name: CI for ${{ github.ref }}
+
+on:
+  pull_request_target:
+    branches:
+      - "ubuntu-*"
+
+jobs:
+  pkg-deps:
+    name: Package dependencies
+    uses: rebornplusplus/chisel-releases/.github/workflows/pkg-deps.yaml@main

--- a/.github/workflows/ci-pr-target.yaml
+++ b/.github/workflows/ci-pr-target.yaml
@@ -1,7 +1,7 @@
 # This workflow supports jobs which needs the on.pull_request_target event
 # instead of the usual on.pull_request event.
-name: CI
-run-name: CI for ${{ github.ref }}
+name: Pkg coverage
+run-name: Pkg coverage for ${{ github.ref }}
 
 on:
   pull_request_target:


### PR DESCRIPTION
# Proposed changes
This PR adds a new pkg-deps job on Pull Request. It checks in changed files if slices of any package A has been listed in "essential" of a slice in package B, but B does not depend on A. If found, the CI will add a comment in the Pull Request with the findings.

### Forward porting
- #199
- #200
- #201 

## Testing
Demo: https://github.com/rebornplusplus/chisel-releases/pull/10

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
