### PR TITLE
fix(ci): wrong repo for reusable workflow

### DIFF
--- a/.github/workflows/ci-pr-target.yaml
+++ b/.github/workflows/ci-pr-target.yaml
@@ -11,4 +11,4 @@ on:
 jobs:
   pkg-deps:
     name: Package dependencies
-    uses: rebornplusplus/chisel-releases/.github/workflows/pkg-deps.yaml@main
+    uses: canonical/chisel-releases/.github/workflows/pkg-deps.yaml@main


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->
This fixes the bad repo (typo) for calling reusable workflow.


## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

## Testing
<!-- Provide proof of testing and/or testing instructions, when applicable,
to help speed up the review process. -->

```bash
# Example:
#  chisel cut ... --root <path> <pkg>_<proposed-slice>
#  sudo chroot <path> <app>
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->