### PR TITLE
feat(22.04): Add python bin symlinks

### DIFF
--- a/slices/python3.11-minimal.yaml
+++ b/slices/python3.11-minimal.yaml
@@ -9,6 +9,8 @@ slices:
       - zlib1g_libs
     contents:
       /usr/bin/python3.11:
+      /usr/bin/python3: {symlink: /usr/bin/python3.11}
+      /usr/bin/python: {symlink: /usr/bin/python3}
       # The next two directories are created to mimic the behaviour in
       # the "postinst" script.
       /usr/local/lib/python3.11/: {make: true, mode: 02775}


### PR DESCRIPTION
# Proposed changes

- Add python bin symlinks. Most applications that reach out to python do so under the `python` or `python3` bin names; these symlinks help maintain that compatibility

Directory structure on `python:slim` image:
<img width="572" alt="image" src="https://github.com/canonical/chisel-releases/assets/10913471/f2b9eb2f-d924-4596-a72d-ce4ef8830f79">

## Related issues/PRs
- #207
- #208
- #209
- #210

### Forward porting

🆘 Please let me know how this works - do I need to open PRs against each branch? 

## Testing
<!-- Provide proof of testing and/or testing instructions, when applicable,
to help speed up the review process. -->

```Dockerfile
ARG UBUNTU_RELEASE=22.04

# Build the chiselled filesystem based on the desired slices.
FROM ubuntu:${UBUNTU_RELEASE} AS builder

ARG ARCH=amd64
ARG CHISEL_VERSION=0.9.1

ADD "https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_${ARCH}.tar.gz" chisel.tar.gz
RUN tar -xvf chisel.tar.gz -C /usr/bin/

WORKDIR /rootfs
COPY . .

# RUN chisel cut --release ubuntu-$UBUNTU_RELEASE --root /rootfs \
RUN chisel cut --release ./ --root /rootfs \
  base-files_base \
  base-files_release-info \
  ca-certificates_data \
  libgcc-s1_libs \
  libc6_libs \
  libssl3_libs \
  # https://github.com/canonical/chiselled-python/blob/main/python3.11/rockcraft.yaml
  openssl_config \
  python3.11_standard

FROM scratch

COPY --from=builder /rootfs /

ENTRYPOINT [ "python", "--version"]
```

```sh
docker build -t test .
docker run test
> Python 3.11.0rc1
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->