### PR TITLE
chore(23.04): Fix minor typo in "countries"

### DIFF
--- a/slices/tzdata.yaml
+++ b/slices/tzdata.yaml
@@ -71,7 +71,7 @@ slices:
     contents:
       /usr/share/zoneinfo/Australia/*:
 
-  # Some counties, although geographically belonging to a continent, are kept
+  # Some countries, although geographically belonging to a continent, are kept
   # in their own slice since that is how they are structured in the tzdata deb.
   brazil:
     essential:


### PR DESCRIPTION
# Proposed changes

This PR fixes a minor typo in the tzdata slice.

## Related issues/PRs
n/a

### Forward porting

It only fixes the typo for the two versions with the tzdata slices (22.04 and 23.04).

## Testing

n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
n/a