### PR TITLE
Update t64 dotnet dependencies

### DIFF
--- a/slices/dotnet-runtime-8.0.yaml
+++ b/slices/dotnet-runtime-8.0.yaml
@@ -7,8 +7,8 @@ slices:
       - libc6_libs
       - libgcc-s1_libs
       - libicu74_libs
-      - liblttng-ust1_libs
-      - libssl3_libs
+      - liblttng-ust1t64_libs
+      - libssl3t64_libs
       - libstdc++6_libs
       - zlib1g_libs
     contents:

--- a/slices/liblttng-ust-common1t64.yaml
+++ b/slices/liblttng-ust-common1t64.yaml
@@ -1,0 +1,7 @@
+package: liblttng-ust-common1t64
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-common.so.*:

--- a/slices/liblttng-ust-ctl5t64.yaml
+++ b/slices/liblttng-ust-ctl5t64.yaml
@@ -1,0 +1,9 @@
+package: liblttng-ust-ctl5t64
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblttng-ust-common1t64_libs
+      - libnuma1_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-ctl.so.*:

--- a/slices/liblttng-ust1t64.yaml
+++ b/slices/liblttng-ust1t64.yaml
@@ -1,0 +1,18 @@
+package: liblttng-ust1t64
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - liblttng-ust-common1t64_libs
+      - liblttng-ust-ctl5t64_libs
+      - libnuma1_libs
+    contents:
+      /usr/lib/*-linux-*/liblttng-ust-cyg-profile-fast.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-cyg-profile.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-dl.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-fd.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-fork.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-libc-wrapper.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-pthread-wrapper.so.*:
+      /usr/lib/*-linux-*/liblttng-ust-tracepoint.so.*:
+      /usr/lib/*-linux-*/liblttng-ust.so.*:

--- a/slices/libssl3t64.yaml
+++ b/slices/libssl3t64.yaml
@@ -1,0 +1,13 @@
+package: libssl3t64
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/engines-3/afalg.so:
+      /usr/lib/*-linux-*/engines-3/loader_attic.so:
+      /usr/lib/*-linux-*/engines-3/padlock.so:
+      /usr/lib/*-linux-*/libcrypto.so.*:
+      /usr/lib/*-linux-*/libssl.so.*:
+      /usr/lib/*-linux-*/ossl-modules/legacy.so:


### PR DESCRIPTION
# Proposed changes

The dependencies for the [dotnet-runtime-8.0](https://packages.ubuntu.com/noble/dotnet-runtime-8.0) package have changed leading to the following error:
```
error: slice package "liblttng-ust-common1" missing from archive
```
The [liblttng-ust1](https://packages.ubuntu.com/noble/liblttng-ust1) package has been replaced with its [t64](https://wiki.debian.org/ReleaseGoals/64bit-time) variant [liblttng-ust1t64](https://packages.ubuntu.com/noble/liblttng-ust1t64).

This PR introduces slices for the t64 versions of related transitive dependencies:
* [liblttng-ust1t64](https://packages.ubuntu.com/noble/liblttng-ust1t64)
* [liblttng-ust-common1t64](https://packages.ubuntu.com/noble/liblttng-ust-common1t64)
* [liblttng-ust-ctl5t64](https://packages.ubuntu.com/noble/liblttng-ust-ctl5t64)



## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

## Testing
<!-- Provide proof of testing and/or testing instructions, when applicable,
to help speed up the review process. -->

```bash
# Example:
#  chisel cut ... --root <path> <pkg>_<proposed-slice>
#  sudo chroot <path> <app>
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->