### PR TITLE
feat(24.04): add 'copyright' slice to all SDFs

### DIFF
--- a/slices/aspnetcore-runtime-8.0.yaml
+++ b/slices/aspnetcore-runtime-8.0.yaml
@@ -1,8 +1,15 @@
 package: aspnetcore-runtime-8.0
 
+essential:
+  - aspnetcore-runtime-8.0_copyright
+
 slices:
   libs:
     essential:
       - dotnet-runtime-8.0_libs
     contents:
       /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/8.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/aspnetcore-runtime-8.0/copyright:

--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -1,5 +1,8 @@
 package: base-files
 
+essential:
+  - base-files_copyright
+
 slices:
   base:
     essential:
@@ -62,3 +65,7 @@ slices:
       /etc/lsb-release:
       /etc/os-release:
       /usr/lib/os-release:
+
+  copyright:
+    contents:
+      /usr/share/doc/base-files/copyright:

--- a/slices/base-passwd.yaml
+++ b/slices/base-passwd.yaml
@@ -1,5 +1,8 @@
 package: base-passwd
 
+essential:
+  - base-passwd_copyright
+
 slices:
   data:
     contents:
@@ -12,3 +15,7 @@ slices:
       content.write("/etc/group", gr)
       pw = content.read("/usr/share/base-passwd/passwd.master")
       content.write("/etc/passwd", pw)
+
+  copyright:
+    contents:
+      /usr/share/doc/base-passwd/copyright:

--- a/slices/bash.yaml
+++ b/slices/bash.yaml
@@ -1,5 +1,8 @@
 package: bash
 
+essential:
+  - bash_copyright
+
 slices:
   config:
     contents:
@@ -19,3 +22,7 @@ slices:
       /usr/bin/bashbug:
       /usr/bin/clear_console:
       /usr/bin/rbash:
+
+  copyright:
+    contents:
+      /usr/share/doc/bash/copyright:

--- a/slices/ca-certificates.yaml
+++ b/slices/ca-certificates.yaml
@@ -1,5 +1,8 @@
 package: ca-certificates
 
+essential:
+  - ca-certificates_copyright
+
 slices:
   data:
     contents:
@@ -12,3 +15,7 @@ slices:
         content.read(certs_dir + path) for path in content.list(certs_dir)
       ]
       content.write("/etc/ssl/certs/ca-certificates.crt", "".join(certs))
+
+  copyright:
+    contents:
+      /usr/share/doc/ca-certificates/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -1,5 +1,8 @@
 package: coreutils
 
+essential:
+  - coreutils_copyright
+
 slices:
   libs:
     essential:
@@ -125,3 +128,7 @@ slices:
       /usr/bin/whoami:
       /usr/bin/yes:
       /usr/sbin/chroot:
+
+  copyright:
+    contents:
+      /usr/share/doc/coreutils/copyright:

--- a/slices/curl.yaml
+++ b/slices/curl.yaml
@@ -1,5 +1,8 @@
 package: curl
 
+essential:
+  - curl_copyright
+
 slices:
   bins:
     essential:
@@ -8,3 +11,7 @@ slices:
       - zlib1g_libs
     contents:
       /usr/bin/curl:
+
+  copyright:
+    contents:
+      /usr/share/doc/curl/copyright:

--- a/slices/dash.yaml
+++ b/slices/dash.yaml
@@ -1,5 +1,8 @@
 package: dash
 
+essential:
+  - dash_copyright
+
 slices:
   bins:
     essential:
@@ -7,3 +10,7 @@ slices:
     contents:
       /usr/bin/dash:
       /usr/bin/sh:
+
+  copyright:
+    contents:
+      /usr/share/doc/dash/copyright:

--- a/slices/dotnet-host-8.0.yaml
+++ b/slices/dotnet-host-8.0.yaml
@@ -1,5 +1,8 @@
 package: dotnet-host-8.0
 
+essential:
+  - dotnet-host-8.0_copyright
+
 slices:
   bins:
     essential:
@@ -9,3 +12,7 @@ slices:
     contents:
       /usr/bin/dotnet:
       /usr/lib/dotnet/dotnet:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-host-8.0/copyright:

--- a/slices/dotnet-hostfxr-8.0.yaml
+++ b/slices/dotnet-hostfxr-8.0.yaml
@@ -1,5 +1,8 @@
 package: dotnet-hostfxr-8.0
 
+essential:
+  - dotnet-hostfxr-8.0_copyright
+
 slices:
   libs:
     essential:
@@ -9,3 +12,7 @@ slices:
       - libstdc++6_libs
     contents:
       /usr/lib/dotnet/host/fxr/8.0*/libhostfxr.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-hostfxr-8.0/copyright:

--- a/slices/dotnet-runtime-8.0.yaml
+++ b/slices/dotnet-runtime-8.0.yaml
@@ -1,5 +1,8 @@
 package: dotnet-runtime-8.0
 
+essential:
+  - dotnet-runtime-8.0_copyright
+
 slices:
   libs:
     essential:
@@ -13,3 +16,7 @@ slices:
       - zlib1g_libs
     contents:
       /usr/lib/dotnet/shared/Microsoft.NETCore.App/8.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-runtime-8.0/copyright:

--- a/slices/findutils.yaml
+++ b/slices/findutils.yaml
@@ -1,5 +1,8 @@
 package: findutils
 
+essential:
+  - findutils_copyright
+
 slices:
   bins:
     essential:
@@ -8,3 +11,7 @@ slices:
     contents:
       /usr/bin/find:
       /usr/bin/xargs:
+
+  copyright:
+    contents:
+      /usr/share/doc/findutils/copyright:

--- a/slices/gawk.yaml
+++ b/slices/gawk.yaml
@@ -1,5 +1,8 @@
 package: gawk
 
+essential:
+  - gawk_copyright
+
 slices:
   bins:
     essential:
@@ -25,3 +28,7 @@ slices:
       - libsigsegv2_libs
     contents:
       /usr/lib/*-linux-*/gawk/*.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/gawk/copyright:

--- a/slices/grep.yaml
+++ b/slices/grep.yaml
@@ -1,5 +1,8 @@
 package: grep
 
+essential:
+  - grep_copyright
+
 slices:
   bins:
     essential:
@@ -19,3 +22,7 @@ slices:
       /usr/bin/egrep:
       /usr/bin/fgrep:
       /usr/bin/rgrep:
+
+  copyright:
+    contents:
+      /usr/share/doc/grep/copyright:

--- a/slices/hello.yaml
+++ b/slices/hello.yaml
@@ -1,8 +1,15 @@
 package: hello
 
+essential:
+  - hello_copyright
+
 slices:
   bins:
     essential:
       - libc6_libs
     contents:
       /usr/bin/hello:
+
+  copyright:
+    contents:
+      /usr/share/doc/hello/copyright:

--- a/slices/libacl1.yaml
+++ b/slices/libacl1.yaml
@@ -1,8 +1,15 @@
 package: libacl1
 
+essential:
+  - libacl1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libacl.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libacl1/copyright:

--- a/slices/libattr1.yaml
+++ b/slices/libattr1.yaml
@@ -1,5 +1,8 @@
 package: libattr1
 
+essential:
+  - libattr1_copyright
+
 slices:
   config:
     contents:
@@ -11,3 +14,7 @@ slices:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libattr.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libattr1/copyright:

--- a/slices/libbrotli1.yaml
+++ b/slices/libbrotli1.yaml
@@ -1,5 +1,8 @@
 package: libbrotli1
 
+essential:
+  - libbrotli1_copyright
+
 slices:
   libs:
     essential:
@@ -8,3 +11,7 @@ slices:
       /usr/lib/*-linux-*/libbrotlicommon.so.1*:
       /usr/lib/*-linux-*/libbrotlidec.so.1*:
       /usr/lib/*-linux-*/libbrotlienc.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libbrotli1/copyright:

--- a/slices/libbz2-1.0.yaml
+++ b/slices/libbz2-1.0.yaml
@@ -1,8 +1,15 @@
 package: libbz2-1.0
 
+essential:
+  - libbz2-1.0_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libbz2.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libbz2-1.0/copyright:

--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -1,5 +1,8 @@
 package: libc-bin
 
+essential:
+  - libc-bin_copyright
+
 slices:
   nsswitch:
     contents:
@@ -19,3 +22,7 @@ slices:
       /usr/lib/locale/C.utf8/LC_PAPER:
       /usr/lib/locale/C.utf8/LC_TELEPHONE:
       /usr/lib/locale/C.utf8/LC_TIME:
+
+  copyright:
+    contents:
+      /usr/share/doc/libc-bin/copyright:

--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -1,5 +1,8 @@
 package: libc6
 
+essential:
+  - libc6_copyright
+
 slices:
   config:
     contents:
@@ -28,3 +31,7 @@ slices:
       /usr/lib/*-linux-*/librt.so.*:
       /usr/lib/*-linux-*/libthread_db.so.*:
       /usr/lib/*-linux-*/libutil.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libc6/copyright:

--- a/slices/libcares2.yaml
+++ b/slices/libcares2.yaml
@@ -1,8 +1,15 @@
 package: libcares2
 
+essential:
+  - libcares2_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libcares.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcares2/copyright:

--- a/slices/libcares2.yaml
+++ b/slices/libcares2.yaml
@@ -1,4 +1,4 @@
-package: libc-ares2
+package: libcares2
 
 slices:
   libs:

--- a/slices/libcom-err2.yaml
+++ b/slices/libcom-err2.yaml
@@ -1,8 +1,15 @@
 package: libcom-err2
 
+essential:
+  - libcom-err2_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libcom_err.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcom-err2/copyright:

--- a/slices/libcrypt1.yaml
+++ b/slices/libcrypt1.yaml
@@ -1,8 +1,15 @@
 package: libcrypt1
 
+essential:
+  - libcrypt1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libcrypt.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcrypt1/copyright:

--- a/slices/libcurl4t64.yaml
+++ b/slices/libcurl4t64.yaml
@@ -1,6 +1,9 @@
 # Easy-to-use client-side URL transfer library (OpenSSL flavour)
 package: libcurl4t64
 
+essential:
+  - libcurl4t64_copyright
+
 slices:
   libs:
     essential:
@@ -18,3 +21,7 @@ slices:
       - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/libcurl.so.4*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcurl4t64/copyright:

--- a/slices/libdb5.3t64.yaml
+++ b/slices/libdb5.3t64.yaml
@@ -1,8 +1,15 @@
 package: libdb5.3t64
 
+essential:
+  - libdb5.3t64_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libdb-5.3.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdb5.3t64/copyright:

--- a/slices/libexpat1.yaml
+++ b/slices/libexpat1.yaml
@@ -1,5 +1,8 @@
 package: libexpat1
 
+essential:
+  - libexpat1_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libexpat.so.1*:
       /usr/lib/*-linux-*/libexpatw.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libexpat1/copyright:

--- a/slices/libffi8.yaml
+++ b/slices/libffi8.yaml
@@ -1,8 +1,15 @@
 package: libffi8
 
+essential:
+  - libffi8_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libffi.so.8*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libffi8/copyright:

--- a/slices/libgmp10.yaml
+++ b/slices/libgmp10.yaml
@@ -1,8 +1,15 @@
 package: libgmp10
 
+essential:
+  - libgmp10_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libgmp.so.10*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgmp10/copyright:

--- a/slices/libgnutls30t64.yaml
+++ b/slices/libgnutls30t64.yaml
@@ -1,6 +1,9 @@
 # GNU TLS library - main runtime library
 package: libgnutls30t64
 
+essential:
+  - libgnutls30t64_copyright
+
 slices:
   libs:
     essential:
@@ -14,3 +17,7 @@ slices:
       - libunistring5_libs
     contents:
       /usr/lib/*-linux-*/libgnutls.so.30*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgnutls30t64/copyright:

--- a/slices/libgssapi-krb5-2.yaml
+++ b/slices/libgssapi-krb5-2.yaml
@@ -1,5 +1,8 @@
 package: libgssapi-krb5-2
 
+essential:
+  - libgssapi-krb5-2_copyright
+
 slices:
   libs:
     essential:
@@ -10,3 +13,7 @@ slices:
       - libkrb5support0_libs
     contents:
       /usr/lib/*-linux-*/libgssapi_krb5.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgssapi-krb5-2/copyright:

--- a/slices/libhogweed6t64.yaml
+++ b/slices/libhogweed6t64.yaml
@@ -1,6 +1,9 @@
 # Low level cryptographic library (public-key cryptos)
 package: libhogweed6t64
 
+essential:
+  - libhogweed6t64_copyright
+
 slices:
   libs:
     essential:
@@ -9,3 +12,7 @@ slices:
       - libnettle8t64_libs
     contents:
       /usr/lib/*-linux-*/libhogweed.so.6*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libhogweed6t64/copyright:

--- a/slices/libicu74.yaml
+++ b/slices/libicu74.yaml
@@ -1,5 +1,8 @@
 package: libicu74
 
+essential:
+  - libicu74_copyright
+
 slices:
   libs:
     essential:
@@ -13,3 +16,7 @@ slices:
       /usr/lib/*-linux-*/libicutest.so.74*:
       /usr/lib/*-linux-*/libicutu.so.74*:
       /usr/lib/*-linux-*/libicuuc.so.74*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libicu74/copyright:

--- a/slices/libidn2-0.yaml
+++ b/slices/libidn2-0.yaml
@@ -1,5 +1,8 @@
 package: libidn2-0
 
+essential:
+  - libidn2-0_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libunistring5_libs
     contents:
       /usr/lib/*-linux-*/libidn2.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libidn2-0/copyright:

--- a/slices/libk5crypto3.yaml
+++ b/slices/libk5crypto3.yaml
@@ -1,5 +1,8 @@
 package: libk5crypto3
 
+essential:
+  - libk5crypto3_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libkrb5support0_libs
     contents:
       /usr/lib/*-linux-*/libk5crypto.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libk5crypto3/copyright:

--- a/slices/libkeyutils1.yaml
+++ b/slices/libkeyutils1.yaml
@@ -1,8 +1,15 @@
 package: libkeyutils1
 
+essential:
+  - libkeyutils1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libkeyutils.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libkeyutils1/copyright:

--- a/slices/libkrb5-3.yaml
+++ b/slices/libkrb5-3.yaml
@@ -1,5 +1,8 @@
 package: libkrb5-3
 
+essential:
+  - libkrb5-3_copyright
+
 slices:
   libs:
     essential:
@@ -13,3 +16,7 @@ slices:
       /usr/lib/*-linux-*/krb5/plugins/libkrb5/:
       /usr/lib/*-linux-*/krb5/plugins/preauth/spake.so:
       /usr/lib/*-linux-*/libkrb5.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libkrb5-3/copyright:

--- a/slices/libkrb5support0.yaml
+++ b/slices/libkrb5support0.yaml
@@ -1,8 +1,15 @@
 package: libkrb5support0
 
+essential:
+  - libkrb5support0_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libkrb5support.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libkrb5support0/copyright:

--- a/slices/libldap2.yaml
+++ b/slices/libldap2.yaml
@@ -1,5 +1,8 @@
 package: libldap2
 
+essential:
+  - libldap2_copyright
+
 slices:
   libs:
     essential:
@@ -9,3 +12,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/liblber.so.2*:
       /usr/lib/*-linux-*/libldap.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libldap2/copyright:

--- a/slices/liblttng-ust-common1t64.yaml
+++ b/slices/liblttng-ust-common1t64.yaml
@@ -1,7 +1,14 @@
 package: liblttng-ust-common1t64
+essential:
+  - liblttng-ust-common1t64_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/liblttng-ust-common.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblttng-ust-common1t64/copyright:

--- a/slices/liblttng-ust-common1t64.yaml
+++ b/slices/liblttng-ust-common1t64.yaml
@@ -1,4 +1,5 @@
 package: liblttng-ust-common1t64
+
 essential:
   - liblttng-ust-common1t64_copyright
 

--- a/slices/liblttng-ust-ctl5t64.yaml
+++ b/slices/liblttng-ust-ctl5t64.yaml
@@ -1,4 +1,7 @@
 package: liblttng-ust-ctl5t64
+essential:
+  - liblttng-ust-ctl5t64_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libnuma1_libs
     contents:
       /usr/lib/*-linux-*/liblttng-ust-ctl.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblttng-ust-ctl5t64/copyright:

--- a/slices/liblttng-ust-ctl5t64.yaml
+++ b/slices/liblttng-ust-ctl5t64.yaml
@@ -1,4 +1,5 @@
 package: liblttng-ust-ctl5t64
+
 essential:
   - liblttng-ust-ctl5t64_copyright
 

--- a/slices/liblttng-ust1t64.yaml
+++ b/slices/liblttng-ust1t64.yaml
@@ -1,4 +1,7 @@
 package: liblttng-ust1t64
+essential:
+  - liblttng-ust1t64_copyright
+
 slices:
   libs:
     essential:
@@ -16,3 +19,7 @@ slices:
       /usr/lib/*-linux-*/liblttng-ust-pthread-wrapper.so.*:
       /usr/lib/*-linux-*/liblttng-ust-tracepoint.so.*:
       /usr/lib/*-linux-*/liblttng-ust.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblttng-ust1t64/copyright:

--- a/slices/liblttng-ust1t64.yaml
+++ b/slices/liblttng-ust1t64.yaml
@@ -1,4 +1,5 @@
 package: liblttng-ust1t64
+
 essential:
   - liblttng-ust1t64_copyright
 

--- a/slices/liblzma5.yaml
+++ b/slices/liblzma5.yaml
@@ -1,4 +1,5 @@
 package: liblzma5
+
 essential:
   - liblzma5_copyright
 

--- a/slices/liblzma5.yaml
+++ b/slices/liblzma5.yaml
@@ -1,7 +1,14 @@
 package: liblzma5
+essential:
+  - liblzma5_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/liblzma.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblzma5/copyright:

--- a/slices/libmpfr6.yaml
+++ b/slices/libmpfr6.yaml
@@ -1,5 +1,8 @@
 package: libmpfr6
 
+essential:
+  - libmpfr6_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libgmp10_libs
     contents:
       /usr/lib/*-linux-*/libmpfr.so.6*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libmpfr6/copyright:

--- a/slices/libnettle8t64.yaml
+++ b/slices/libnettle8t64.yaml
@@ -1,8 +1,15 @@
 ﻿package: libnettle8t64
 
+essential:
+  - libnettle8t64_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libnettle.so.8*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnettle8t64/copyright:

--- a/slices/libnghttp2-14.yaml
+++ b/slices/libnghttp2-14.yaml
@@ -1,8 +1,15 @@
 package: libnghttp2-14
 
+essential:
+  - libnghttp2-14_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libnghttp2.so.14*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnghttp2-14/copyright:

--- a/slices/libnode109.yaml
+++ b/slices/libnode109.yaml
@@ -7,8 +7,8 @@ slices:
       # libatomic1 is only required on mips* and riscv64
       # - libatomic1_libs
       - libbrotli1_libs
-      - libc-ares2_libs
       - libc6_libs
+      - libcares2_libs
       - libgcc-s1_libs
       - libicu74_libs
       - libnghttp2-14_libs

--- a/slices/libnode109.yaml
+++ b/slices/libnode109.yaml
@@ -1,5 +1,8 @@
 package: libnode109
 
+essential:
+  - libnode109_copyright
+
 slices:
   libs:
     essential:
@@ -21,3 +24,7 @@ slices:
       - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/libnode.so.109:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnode109/copyright:

--- a/slices/libnsl2.yaml
+++ b/slices/libnsl2.yaml
@@ -1,5 +1,8 @@
 package: libnsl2
 
+essential:
+  - libnsl2_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libtirpc3t64_libs
     contents:
       /usr/lib/*-linux-*/libnsl.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnsl2/copyright:

--- a/slices/libnuma1.yaml
+++ b/slices/libnuma1.yaml
@@ -1,4 +1,5 @@
 package: libnuma1
+
 essential:
   - libnuma1_copyright
 

--- a/slices/libnuma1.yaml
+++ b/slices/libnuma1.yaml
@@ -1,7 +1,14 @@
 package: libnuma1
+essential:
+  - libnuma1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libnuma.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnuma1/copyright:

--- a/slices/libp11-kit0.yaml
+++ b/slices/libp11-kit0.yaml
@@ -1,5 +1,8 @@
 package: libp11-kit0
 
+essential:
+  - libp11-kit0_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libffi8_libs
     contents:
       /usr/lib/*-linux-*/libp11-kit.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libp11-kit0/copyright:

--- a/slices/libpcre2-8-0.yaml
+++ b/slices/libpcre2-8-0.yaml
@@ -1,8 +1,15 @@
 package: libpcre2-8-0
 
+essential:
+  - libpcre2-8-0_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libpcre2-8.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpcre2-8-0/copyright:

--- a/slices/libpsl5t64.yaml
+++ b/slices/libpsl5t64.yaml
@@ -3,6 +3,9 @@
 # for domain highlighting purposes sorting domain lists by site and more.
 package: libpsl5t64
 
+essential:
+  - libpsl5t64_copyright
+
 slices:
   libs:
     essential:
@@ -11,3 +14,7 @@ slices:
       - libunistring5_libs
     contents:
       /usr/lib/*-linux-*/libpsl.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpsl5t64/copyright:

--- a/slices/libpython3.12-minimal.yaml
+++ b/slices/libpython3.12-minimal.yaml
@@ -8,6 +8,9 @@ package: libpython3.12-minimal
 # into granular slices, the same hasn't been done for this package.
 # The reason is simple, the libraries in this package are tightly
 # dependent upon each other.
+essential:
+  - libpython3.12-minimal_copyright
+
 slices:
   config:
     contents:
@@ -110,3 +113,7 @@ slices:
       /usr/lib/python3.12/weakref.py:
       /usr/lib/python3.12/zipfile/**:
       /usr/lib/python3.12/zipimport.py:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpython3.12-minimal/copyright:

--- a/slices/libreadline8t64.yaml
+++ b/slices/libreadline8t64.yaml
@@ -1,5 +1,8 @@
 package: libreadline8t64
 
+essential:
+  - libreadline8t64_copyright
+
 slices:
   libs:
     essential:
@@ -9,3 +12,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libhistory.so.8*:
       /usr/lib/*-linux-*/libreadline.so.8*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libreadline8t64/copyright:

--- a/slices/librtmp1.yaml
+++ b/slices/librtmp1.yaml
@@ -1,6 +1,9 @@
 # Toolkit for RTMP streams
 package: librtmp1
 
+essential:
+  - librtmp1_copyright
+
 slices:
   libs:
     essential:
@@ -12,3 +15,7 @@ slices:
       - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/librtmp.so.1:
+
+  copyright:
+    contents:
+      /usr/share/doc/librtmp1/copyright:

--- a/slices/libsasl2-2.yaml
+++ b/slices/libsasl2-2.yaml
@@ -1,5 +1,8 @@
 ﻿package: libsasl2-2
 
+essential:
+  - libsasl2-2_copyright
+
 slices:
   libs:
     essential:
@@ -8,3 +11,7 @@ slices:
       - libssl3t64_libs
     contents:
       /usr/lib/*-linux-*/libsasl2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsasl2-2/copyright:

--- a/slices/libsasl2-modules-db.yaml
+++ b/slices/libsasl2-modules-db.yaml
@@ -1,5 +1,8 @@
 package: libsasl2-modules-db
 
+essential:
+  - libsasl2-modules-db_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libdb5.3t64_libs
     contents:
       /usr/lib/*-linux-*/sasl2/libsasldb.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsasl2-modules-db/copyright:

--- a/slices/libselinux1.yaml
+++ b/slices/libselinux1.yaml
@@ -1,5 +1,8 @@
 package: libselinux1
 
+essential:
+  - libselinux1_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
       - libpcre2-8-0_libs
     contents:
       /usr/lib/*-linux-*/libselinux.so.1:
+
+  copyright:
+    contents:
+      /usr/share/doc/libselinux1/copyright:

--- a/slices/libsigsegv2.yaml
+++ b/slices/libsigsegv2.yaml
@@ -1,8 +1,15 @@
 package: libsigsegv2
 
+essential:
+  - libsigsegv2_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libsigsegv.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsigsegv2/copyright:

--- a/slices/libsqlite3-0.yaml
+++ b/slices/libsqlite3-0.yaml
@@ -1,8 +1,15 @@
 package: libsqlite3-0
 
+essential:
+  - libsqlite3-0_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libsqlite3.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsqlite3-0/copyright:

--- a/slices/libssh-4.yaml
+++ b/slices/libssh-4.yaml
@@ -1,5 +1,8 @@
 package: libssh-4
 
+essential:
+  - libssh-4_copyright
+
 slices:
   libs:
     essential:
@@ -9,3 +12,7 @@ slices:
       - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/libssh.so.4*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libssh-4/copyright:

--- a/slices/libssl3t64.yaml
+++ b/slices/libssl3t64.yaml
@@ -1,5 +1,8 @@
 package: libssl3t64
 
+essential:
+  - libssl3t64_copyright
+
 slices:
   libs:
     essential:
@@ -11,3 +14,7 @@ slices:
       /usr/lib/*-linux-*/libcrypto.so.*:
       /usr/lib/*-linux-*/libssl.so.*:
       /usr/lib/*-linux-*/ossl-modules/legacy.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libssl3t64/copyright:

--- a/slices/libtasn1-6.yaml
+++ b/slices/libtasn1-6.yaml
@@ -1,8 +1,15 @@
 package: libtasn1-6
 
+essential:
+  - libtasn1-6_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libtasn1.so.6*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtasn1-6/copyright:

--- a/slices/libtinfo6.yaml
+++ b/slices/libtinfo6.yaml
@@ -1,5 +1,8 @@
 package: libtinfo6
 
+essential:
+  - libtinfo6_copyright
+
 slices:
   libs:
     essential:
@@ -7,3 +10,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libtic.so.6*:
       /usr/lib/*-linux-*/libtinfo.so.6*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtinfo6/copyright:

--- a/slices/libtirpc-common.yaml
+++ b/slices/libtirpc-common.yaml
@@ -1,6 +1,13 @@
 package: libtirpc-common
 
+essential:
+  - libtirpc-common_copyright
+
 slices:
   config:
     contents:
       /etc/netconfig:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtirpc-common/copyright:

--- a/slices/libtirpc3t64.yaml
+++ b/slices/libtirpc3t64.yaml
@@ -1,5 +1,8 @@
 package: libtirpc3t64
 
+essential:
+  - libtirpc3t64_copyright
+
 slices:
   libs:
     essential:
@@ -8,3 +11,7 @@ slices:
       - libtirpc-common_config
     contents:
       /usr/lib/*-linux-*/libtirpc.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtirpc3t64/copyright:

--- a/slices/libunistring5.yaml
+++ b/slices/libunistring5.yaml
@@ -1,8 +1,15 @@
 package: libunistring5
 
+essential:
+  - libunistring5_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libunistring.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libunistring5/copyright:

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -1,4 +1,5 @@
 package: libunwind8
+
 essential:
   - libunwind8_copyright
 

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -1,4 +1,7 @@
 package: libunwind8
+essential:
+  - libunwind8_copyright
+
 slices:
   libs:
     essential:
@@ -8,3 +11,7 @@ slices:
       /usr/lib/*-linux-*/libunwind-*.so.*:
       /usr/lib/*-linux-*/libunwind.so.8:
       /usr/lib/*-linux-*/libunwind.so.8.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libunwind8/copyright:

--- a/slices/libuuid1.yaml
+++ b/slices/libuuid1.yaml
@@ -1,8 +1,15 @@
 package: libuuid1
 
+essential:
+  - libuuid1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libuuid.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libuuid1/copyright:

--- a/slices/libuv1t64.yaml
+++ b/slices/libuv1t64.yaml
@@ -1,8 +1,15 @@
 package: libuv1t64
 
+essential:
+  - libuv1t64_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libuv.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libuv1t64/copyright:

--- a/slices/libzstd1.yaml
+++ b/slices/libzstd1.yaml
@@ -1,8 +1,15 @@
 package: libzstd1
 
+essential:
+  - libzstd1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libzstd.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libzstd1/copyright:

--- a/slices/media-types.yaml
+++ b/slices/media-types.yaml
@@ -1,6 +1,13 @@
 package: media-types
 
+essential:
+  - media-types_copyright
+
 slices:
   data:
     contents:
       /etc/mime.types:
+
+  copyright:
+    contents:
+      /usr/share/doc/media-types/copyright:

--- a/slices/netbase.yaml
+++ b/slices/netbase.yaml
@@ -1,5 +1,8 @@
 package: netbase
 
+essential:
+  - netbase_copyright
+
 slices:
   config:
     contents:
@@ -33,3 +36,7 @@ slices:
           default		0.0.0.0
           loopback	127.0.0.0
           link-local	169.254.0.0
+
+  copyright:
+    contents:
+      /usr/share/doc/netbase/copyright:

--- a/slices/node-acorn.yaml
+++ b/slices/node-acorn.yaml
@@ -1,5 +1,8 @@
 package: node-acorn
 
+essential:
+  - node-acorn_copyright
+
 slices:
   libs:
     essential:
@@ -35,3 +38,7 @@ slices:
       /usr/share/nodejs/acorn/dist/acorn.js:
       /usr/share/nodejs/acorn/dist/acorn.mjs:
       /usr/share/nodejs/acorn/package.json:
+
+  copyright:
+    contents:
+      /usr/share/doc/node-acorn/copyright:

--- a/slices/node-busboy.yaml
+++ b/slices/node-busboy.yaml
@@ -1,8 +1,15 @@
 package: node-busboy
 
+essential:
+  - node-busboy_copyright
+
 slices:
   libs:
     contents:
       /usr/share/nodejs/busboy/lib/**:
       /usr/share/nodejs/busboy/package.json:
       /usr/share/nodejs/streamsearch/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/node-busboy/copyright:

--- a/slices/node-cjs-module-lexer.yaml
+++ b/slices/node-cjs-module-lexer.yaml
@@ -1,8 +1,15 @@
 package: node-cjs-module-lexer
 
+essential:
+  - node-cjs-module-lexer_copyright
+
 slices:
   libs:
     contents:
       /usr/share/nodejs/cjs-module-lexer/*.js:
       /usr/share/nodejs/cjs-module-lexer/*.json:
       /usr/share/nodejs/cjs-module-lexer/dist/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/node-cjs-module-lexer/copyright:

--- a/slices/node-undici.yaml
+++ b/slices/node-undici.yaml
@@ -1,5 +1,8 @@
 package: node-undici
 
+essential:
+  - node-undici_copyright
+
 slices:
   libs:
     essential:
@@ -11,3 +14,7 @@ slices:
       /usr/share/nodejs/undici/lib/**.js:
       /usr/share/nodejs/undici/package.json:
       /usr/share/nodejs/undici/undici-fetch.js:
+
+  copyright:
+    contents:
+      /usr/share/doc/node-undici/copyright:

--- a/slices/node-xtend.yaml
+++ b/slices/node-xtend.yaml
@@ -1,6 +1,13 @@
 package: node-xtend
 
+essential:
+  - node-xtend_copyright
+
 slices:
   libs:
     contents:
       /usr/share/nodejs/xtend/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/node-xtend/copyright:

--- a/slices/nodejs.yaml
+++ b/slices/nodejs.yaml
@@ -1,5 +1,8 @@
 package: nodejs
 
+essential:
+  - nodejs_copyright
+
 slices:
   bins:
     essential:
@@ -12,3 +15,7 @@ slices:
       /usr/bin/js: {symlink: /usr/bin/nodejs}
       /usr/bin/node:
       /usr/bin/nodejs:
+
+  copyright:
+    contents:
+      /usr/share/doc/nodejs/copyright:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -1,5 +1,8 @@
 package: openssl
 
+essential:
+  - openssl_copyright
+
 slices:
   bins:
     essential:
@@ -24,3 +27,7 @@ slices:
   data:
     contents:
       /usr/lib/ssl/cert.pem:
+
+  copyright:
+    contents:
+      /usr/share/doc/openssl/copyright:

--- a/slices/python3.12-minimal.yaml
+++ b/slices/python3.12-minimal.yaml
@@ -1,5 +1,8 @@
 package: python3.12-minimal
 
+essential:
+  - python3.12-minimal_copyright
+
 slices:
   bins:
     essential:
@@ -13,3 +16,7 @@ slices:
       # the "postinst" script.
       /usr/local/lib/python3.12/: {make: true, mode: 02775}
       /usr/local/lib/python3.12/dist-packages/: {make: true, mode: 02775}
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.12-minimal/copyright:

--- a/slices/python3.12.yaml
+++ b/slices/python3.12.yaml
@@ -1,5 +1,8 @@
 package: python3.12
 
+essential:
+  - python3.12_copyright
+
 slices:
   # The "core" slice provides a very minimal, yet functioning python3.12.
   # It includes very few modules from the libpython3.12-stdlib package.
@@ -52,3 +55,7 @@ slices:
       /usr/bin/pdb3.12:
       /usr/bin/pydoc3.12:
       /usr/bin/pygettext3.12:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.12/copyright:

--- a/slices/readline-common.yaml
+++ b/slices/readline-common.yaml
@@ -1,6 +1,13 @@
 package: readline-common
 
+essential:
+  - readline-common_copyright
+
 slices:
   config:
     contents:
       /etc/inputrc: { copy: /usr/share/readline/inputrc }
+
+  copyright:
+    contents:
+      /usr/share/doc/readline-common/copyright:

--- a/slices/sed.yaml
+++ b/slices/sed.yaml
@@ -1,5 +1,8 @@
 package: sed
 
+essential:
+  - sed_copyright
+
 slices:
   bins:
     essential:
@@ -8,3 +11,7 @@ slices:
       - libselinux1_libs
     contents:
       /usr/bin/sed:
+
+  copyright:
+    contents:
+      /usr/share/doc/sed/copyright:

--- a/slices/tzdata.yaml
+++ b/slices/tzdata.yaml
@@ -1,5 +1,8 @@
 package: tzdata
 
+essential:
+  - tzdata_copyright
+
 slices:
   # The "base" slice contains Canonical timezone abbreviations. These are
   # primary, preferred zone names that are often used as abbreviations for
@@ -116,3 +119,7 @@ slices:
       - tzdata_eurasia
       - tzdata_indian
       - tzdata_pacific
+
+  copyright:
+    contents:
+      /usr/share/doc/tzdata/copyright:

--- a/slices/zlib1g.yaml
+++ b/slices/zlib1g.yaml
@@ -1,8 +1,15 @@
 package: zlib1g
 
+essential:
+  - zlib1g_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libz.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/zlib1g/copyright:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

A new `copyright` slice is being added to all Slice Definitions Files, for packages that actually install a copyright file.
In addition, this copyright file now becomes a global dependency (`essential`) for all slices within the SDF, via the top-level `essential` field.

## Related issues/PRs
<!-- If any -->

https://github.com/canonical/chisel/pull/127

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->