### PR TITLE
24.04/add procps

### DIFF
--- a/slices/init-system-helpers.yaml
+++ b/slices/init-system-helpers.yaml
@@ -1,5 +1,8 @@
 package: init-system-helpers
 
+essential:
+  - init-system-helpers_copyright
+
 slices:
   bins:
     contents:
@@ -23,3 +26,6 @@ slices:
   var:
     contents:
       /var/lib/systemd/:
+  copyright:
+    contents:
+      /usr/share/doc/init-system-helpers/copyright:

--- a/slices/init-system-helpers.yaml
+++ b/slices/init-system-helpers.yaml
@@ -1,0 +1,25 @@
+package: init-system-helpers
+
+slices:
+  bins:
+    contents:
+      /usr/bin/deb-systemd-helper:
+      /usr/bin/deb-systemd-invoke:
+      /usr/sbin/invoke-rc.d:
+      /usr/sbin/service:
+      /usr/sbin/update-rc.d:
+  config:
+    contents:
+      /etc/rc0.d/:
+      /etc/rc1.d/:
+      /etc/rc2.d/:
+      /etc/rc3.d/:
+      /etc/rc4.d/:
+      /etc/rc5.d/:
+      /etc/rc6.d/:
+      /etc/rcS.d/:
+      /etc/systemd/system/:
+      /etc/systemd/user/:
+  var:
+    contents:
+      /var/lib/systemd/:

--- a/slices/libcap2.yaml
+++ b/slices/libcap2.yaml
@@ -1,0 +1,15 @@
+package: libcap2
+
+essential:
+  - libcap2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libcap.so.2*:
+      /usr/lib/*-linux-*/libpsx.so.2*:
+  copyright:
+    contents:
+      /usr/share/doc/libcap2/copyright:

--- a/slices/libgcrypt20.yaml
+++ b/slices/libgcrypt20.yaml
@@ -1,0 +1,16 @@
+# LGPL Crypto library - runtime library
+package: libgcrypt20
+
+essential:
+  - libgcrypt20_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgpg-error0_libs
+    contents:
+      /usr/lib/*-linux-*/libgcrypt.so.20*:
+  copyright:
+    contents:
+      /usr/share/doc/libgcrypt20/copyright:

--- a/slices/libgpg-error0.yaml
+++ b/slices/libgpg-error0.yaml
@@ -1,0 +1,16 @@
+# Library that defines common error values, messages, and common
+# runtime functionality for all GnuPG components.
+package: libgpg-error0
+
+essential:
+  - libgpg-error0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libgpg-error.so.0*:
+  copyright:
+    contents:
+      /usr/share/doc/libgpg-error0/copyright:

--- a/slices/liblz4-1.yaml
+++ b/slices/liblz4-1.yaml
@@ -1,0 +1,14 @@
+package: liblz4-1
+
+essential:
+  - liblz4-1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblz4.so.1*:
+  copyright:
+    contents:
+      /usr/share/doc/liblz4-1/copyright:

--- a/slices/libproc2-0.yaml
+++ b/slices/libproc2-0.yaml
@@ -1,0 +1,15 @@
+package: libproc2-0
+
+essential:
+  - libproc2-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libsystemd0_libs
+    contents:
+      /usr/lib/*-linux-*/libproc2.so.0:
+  copyright:
+    contents:
+      /usr/share/doc/libproc2-0/copyright:

--- a/slices/libproc2-0.yaml
+++ b/slices/libproc2-0.yaml
@@ -9,7 +9,7 @@ slices:
       - libc6_libs
       - libsystemd0_libs
     contents:
-      /usr/lib/*-linux-*/libproc2.so.0:
+      /usr/lib/*-linux-*/libproc2.so.0*:
   copyright:
     contents:
       /usr/share/doc/libproc2-0/copyright:

--- a/slices/libsystemd0.yaml
+++ b/slices/libsystemd0.yaml
@@ -1,0 +1,19 @@
+package: libsystemd0
+
+essential:
+  - libsystemd0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcap2_libs
+      - libgcrypt20_libs
+      - liblz4-1_libs
+      - liblzma5_libs
+      - libzstd1_libs
+    contents:
+      /usr/lib/*-linux-*/libsystemd.so.0*:
+  copyright:
+    contents:
+      /usr/share/doc/libsystemd0/copyright:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -28,3 +28,16 @@ slices:
       /usr/bin/w:
       /usr/bin/watch:
       /usr/sbin/sysctl:
+  config:
+    contents:
+      /etc/init.d/procps:
+      /etc/sysctl.conf:
+      /etc/sysctl.d/10-console-messages.conf:
+      /etc/sysctl.d/10-ipv6-privacy.conf:
+      /etc/sysctl.d/10-kernel-hardening.conf:
+      /etc/sysctl.d/10-magic-sysrq.conf:
+      /etc/sysctl.d/10-map-count.conf:
+      /etc/sysctl.d/10-network-security.conf:
+      /etc/sysctl.d/10-ptrace.conf:
+      /etc/sysctl.d/10-zeropage.conf:
+      /usr/lib/sysctl.d/99-protect-links.conf:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -1,5 +1,8 @@
 package: procps
 
+essential:
+  - procps_copyright
+
 slices:
   bins:
     essential:
@@ -41,3 +44,6 @@ slices:
       /etc/sysctl.d/10-ptrace.conf:
       /etc/sysctl.d/10-zeropage.conf:
       /usr/lib/sysctl.d/99-protect-links.conf:
+  copyright:
+    contents:
+      /usr/share/doc/procps/copyright:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -6,7 +6,6 @@ essential:
 slices:
   bins:
     essential:
-      - init-system-helpers_bins
       - libc6_libs
       - libncursesw6_libs
       - libproc2-0_libs

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -3,24 +3,24 @@ package: procps
 slices:
   bins:
     essential:
+      - init-system-helpers_bins
       - libc6_libs
       - libncursesw6_libs
       - libproc2-0_libs
       - libsystemd0_libs
       - libtinfo6_libs
-      - init-system-helpers_bins
     contents:
       /usr/bin/free:
       /usr/bin/kill:
       /usr/bin/pgrep:
-      /usr/bin/pkill: {symlink: pgrep}
       /usr/bin/pidwait:
+      /usr/bin/pkill: {symlink: pgrep}
       /usr/bin/pmap:
       /usr/bin/ps:
       /usr/bin/pwdx:
       /usr/bin/skill:
-      /usr/bin/snice: {symlink: skill}
       /usr/bin/slabtop:
+      /usr/bin/snice: {symlink: skill}
       /usr/bin/tload:
       /usr/bin/top:
       /usr/bin/uptime:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -8,6 +8,7 @@ slices:
       - libproc2-0_libs
       - libsystemd0_libs
       - libtinfo6_libs
+      - init-system-helpers_bins
     contents:
       /usr/bin/free:
       /usr/bin/kill:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -16,7 +16,7 @@ slices:
       /usr/bin/kill:
       /usr/bin/pgrep:
       /usr/bin/pidwait:
-      /usr/bin/pkill: {symlink: pgrep}
+      /usr/bin/pkill:
       /usr/bin/pmap:
       /usr/bin/ps:
       /usr/bin/pwdx:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -22,7 +22,7 @@ slices:
       /usr/bin/pwdx:
       /usr/bin/skill:
       /usr/bin/slabtop:
-      /usr/bin/snice: {symlink: skill}
+      /usr/bin/snice:
       /usr/bin/tload:
       /usr/bin/top:
       /usr/bin/uptime:

--- a/slices/procps.yaml
+++ b/slices/procps.yaml
@@ -1,0 +1,29 @@
+package: procps
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libncursesw6_libs
+      - libproc2-0_libs
+      - libsystemd0_libs
+      - libtinfo6_libs
+    contents:
+      /usr/bin/free:
+      /usr/bin/kill:
+      /usr/bin/pgrep:
+      /usr/bin/pkill: {symlink: pgrep}
+      /usr/bin/pidwait:
+      /usr/bin/pmap:
+      /usr/bin/ps:
+      /usr/bin/pwdx:
+      /usr/bin/skill:
+      /usr/bin/snice: {symlink: skill}
+      /usr/bin/slabtop:
+      /usr/bin/tload:
+      /usr/bin/top:
+      /usr/bin/uptime:
+      /usr/bin/vmstat:
+      /usr/bin/w:
+      /usr/bin/watch:
+      /usr/sbin/sysctl:


### PR DESCRIPTION
# Proposed changes

Add procps slice and dependencies.

I'm not sure what to do with this content for `procps`:

```shell
/usr/lib/sysctl.d/99-protect-links.conf
/etc/init.d/procps
/etc/sysctl.conf
/etc/sysctl.d/10-console-messages.conf
/etc/sysctl.d/10-ipv6-privacy.conf
/etc/sysctl.d/10-kernel-hardening.conf
/etc/sysctl.d/10-magic-sysrq.conf
/etc/sysctl.d/10-map-count.conf
/etc/sysctl.d/10-network-security.conf
/etc/sysctl.d/10-ptrace.conf
/etc/sysctl.d/10-zeropage.conf
```

Not sure if I should add a `config:` slice, any guidance is appreciated.

## Related issues/PRs

/closes #236 

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
