### PR TITLE
Add python3.11-venv slices to ubuntu-22.04

### DIFF
--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -185,8 +185,8 @@ slices:
       - libpython3.11-stdlib_osx-support
     contents:
       /usr/lib/python3.11/_distutils_system_mod.py:
-      # Due to conflicts with python3-distutils_python3-11 and chisel not able to reconcile 2 slices
-      # doing glob on the same folder, I have to specify the files explicitely
+      # Due to conflicts with python3-distutils_python3-11 and chisel not being able to
+      # reconcile 2 slices with globs on the same folder, I have to specify the files explicitly
       /usr/lib/python3.11/distutils/__init__.py:
       /usr/lib/python3.11/distutils/version.py:
       /usr/lib/python3.11/venv/**:

--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -187,8 +187,8 @@ slices:
       /usr/lib/python3.11/_distutils_system_mod.py:
       # Due to conflicts with python3-distutils_python3-11 and chisel not able to reconcile 2 slices
       # doing glob on the same folder, I have to specify the files explicitely
-      /usr/lib/python3.11/distutils/version.py:
       /usr/lib/python3.11/distutils/__init__.py:
+      /usr/lib/python3.11/distutils/version.py:
       /usr/lib/python3.11/venv/**:
       /usr/lib/python3.11/zipapp.py:
 

--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -185,7 +185,10 @@ slices:
       - libpython3.11-stdlib_osx-support
     contents:
       /usr/lib/python3.11/_distutils_system_mod.py:
-      /usr/lib/python3.11/distutils/**:
+      #Due to conflicts with python3-distutils_python3-11 and chisel not able to reconcile 2 slices
+      #doing glob on the same folder, I have to specify the files explicitely
+      /usr/lib/python3.11/distutils/version.py:
+      /usr/lib/python3.11/distutils/__init__.py:
       /usr/lib/python3.11/venv/**:
       /usr/lib/python3.11/zipapp.py:
 

--- a/slices/libpython3.11-stdlib.yaml
+++ b/slices/libpython3.11-stdlib.yaml
@@ -185,8 +185,8 @@ slices:
       - libpython3.11-stdlib_osx-support
     contents:
       /usr/lib/python3.11/_distutils_system_mod.py:
-      #Due to conflicts with python3-distutils_python3-11 and chisel not able to reconcile 2 slices
-      #doing glob on the same folder, I have to specify the files explicitely
+      # Due to conflicts with python3-distutils_python3-11 and chisel not able to reconcile 2 slices
+      # doing glob on the same folder, I have to specify the files explicitely
       /usr/lib/python3.11/distutils/version.py:
       /usr/lib/python3.11/distutils/__init__.py:
       /usr/lib/python3.11/venv/**:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -61,7 +61,7 @@ slices:
         {copy: /usr/lib/python3.10/distutils/command/install_scripts.py}
       /usr/lib/python3.11/distutils/command/register.py:
         {copy: /usr/lib/python3.10/distutils/command/register.py}
-      /usr/lib/python3.11/distutils/command/sdist.py: 
+      /usr/lib/python3.11/distutils/command/sdist.py:
         {copy: /usr/lib/python3.10/distutils/command/sdist.py}
       /usr/lib/python3.11/distutils/command/upload.py:
         {copy: /usr/lib/python3.10/distutils/command/upload.py}
@@ -86,7 +86,8 @@ slices:
       /usr/lib/python3.11/distutils/unixccompiler.py:
         {copy: /usr/lib/python3.10/distutils/unixccompiler.py}
       /usr/lib/python3.11/distutils/util.py: {copy: /usr/lib/python3.10/distutils/util.py}
-      /usr/lib/python3.11/distutils/versionpredicate.py: {copy: /usr/lib/python3.10/distutils/versionpredicate.py}
+      /usr/lib/python3.11/distutils/versionpredicate.py:
+        {copy: /usr/lib/python3.10/distutils/versionpredicate.py}
 
   python3-10:
     contents:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -6,56 +6,85 @@ essential:
 slices:
   python3-11:
     contents:
-      #Due to conflicts with libpython3.11-stdlib_distribution and chisel not able to reconcile 2 slices
-      #doing glob on the same folder, I have to specify the files explicitely
-      #Also the original package uses hardlink for the common files between python 3.10 and python 3.11
-      #chisel doesn't support hardlinks so I need to use copy
+      # Due to conflicts with libpython3.11-stdlib_distribution and chisel not able to reconcile
+      # 2 slices doing glob on the same folder, I have to specify the files explicitely
+      # Also the original package uses hardlink for the common files between python 3.10 and
+      # python3.11 chisel doesn't support hardlinks so I need to use copy
       /usr/lib/python3.11/distutils/config.py:
       /usr/lib/python3.11/distutils/msvccompiler.py:
       /usr/lib/python3.11/distutils/sysconfig.py:
       /usr/lib/python3.11/distutils/command/bdist.py:
       /usr/lib/python3.11/distutils/command/build_ext.py:
-      /usr/lib/python3.11/distutils/_msvccompiler.py: {copy: /usr/lib/python3.10/distutils/_msvccompiler.py}
-      /usr/lib/python3.11/distutils/archive_util.py: {copy: /usr/lib/python3.10/distutils/archive_util.py}
-      /usr/lib/python3.11/distutils/bcppcompiler.py: {copy: /usr/lib/python3.10/distutils/bcppcompiler.py}
-      /usr/lib/python3.11/distutils/ccompiler.py: {copy: /usr/lib/python3.10/distutils/ccompiler.py}
-      /usr/lib/python3.11/distutils/cmd.py: {copy: /usr/lib/python3.10/distutils/cmd.py}
-      /usr/lib/python3.11/distutils/command/__init__.py: {copy: /usr/lib/python3.10/distutils/command/__init__.py}
-      /usr/lib/python3.11/distutils/command/bdist_dumb.py: {copy: /usr/lib/python3.10/distutils/command/bdist_dumb.py}
-      /usr/lib/python3.11/distutils/command/bdist_rpm.py: {copy: /usr/lib/python3.10/distutils/command/bdist_rpm.py}
-      /usr/lib/python3.11/distutils/command/build.py: {copy: /usr/lib/python3.10/distutils/command/build.py}
-      /usr/lib/python3.11/distutils/command/build_clib.py: {copy: /usr/lib/python3.10/distutils/command/build_clib.py}
-      /usr/lib/python3.11/distutils/command/build_py.py: {copy: /usr/lib/python3.10/distutils/command/build_py.py}
-      /usr/lib/python3.11/distutils/command/build_scripts.py: {copy: /usr/lib/python3.10/distutils/command/build_scripts.py}
-      /usr/lib/python3.11/distutils/command/check.py: {copy: /usr/lib/python3.10/distutils/command/check.py}
-      /usr/lib/python3.11/distutils/command/clean.py: {copy: /usr/lib/python3.10/distutils/command/clean.py}
-      /usr/lib/python3.11/distutils/command/command_template: {copy: /usr/lib/python3.10/distutils/command/command_template}
-      /usr/lib/python3.11/distutils/command/config.py: {copy: /usr/lib/python3.10/distutils/command/config.py}
-      /usr/lib/python3.11/distutils/command/install.py: {copy: /usr/lib/python3.10/distutils/command/install.py}
-      /usr/lib/python3.11/distutils/command/install_data.py: {copy: /usr/lib/python3.10/distutils/command/install_data.py}
-      /usr/lib/python3.11/distutils/command/install_egg_info.py: {copy: /usr/lib/python3.10/distutils/command/install_egg_info.py}
-      /usr/lib/python3.11/distutils/command/install_headers.py: {copy: /usr/lib/python3.10/distutils/command/install_headers.py}
-      /usr/lib/python3.11/distutils/command/install_lib.py: {copy: /usr/lib/python3.10/distutils/command/install_lib.py}
-      /usr/lib/python3.11/distutils/command/install_scripts.py: {copy: /usr/lib/python3.10/distutils/command/install_scripts.py}
-      /usr/lib/python3.11/distutils/command/register.py: {copy: /usr/lib/python3.10/distutils/command/register.py}
-      /usr/lib/python3.11/distutils/command/sdist.py: {copy: /usr/lib/python3.10/distutils/command/sdist.py}
-      /usr/lib/python3.11/distutils/command/upload.py: {copy: /usr/lib/python3.10/distutils/command/upload.py}
+      /usr/lib/python3.11/distutils/_msvccompiler.py:
+        {copy: /usr/lib/python3.10/distutils/_msvccompiler.py}
+      /usr/lib/python3.11/distutils/archive_util.py:
+        {copy: /usr/lib/python3.10/distutils/archive_util.py}
+      /usr/lib/python3.11/distutils/bcppcompiler.py:
+        {copy: /usr/lib/python3.10/distutils/bcppcompiler.py}
+      /usr/lib/python3.11/distutils/ccompiler.py:
+        {copy: /usr/lib/python3.10/distutils/ccompiler.py}
+      /usr/lib/python3.11/distutils/cmd.py:
+        {copy: /usr/lib/python3.10/distutils/cmd.py}
+      /usr/lib/python3.11/distutils/command/__init__.py:
+        {copy: /usr/lib/python3.10/distutils/command/__init__.py}
+      /usr/lib/python3.11/distutils/command/bdist_dumb.py:
+        {copy: /usr/lib/python3.10/distutils/command/bdist_dumb.py}
+      /usr/lib/python3.11/distutils/command/bdist_rpm.py:
+        {copy: /usr/lib/python3.10/distutils/command/bdist_rpm.py}
+      /usr/lib/python3.11/distutils/command/build.py:
+        {copy: /usr/lib/python3.10/distutils/command/build.py}
+      /usr/lib/python3.11/distutils/command/build_clib.py:
+        {copy: /usr/lib/python3.10/distutils/command/build_clib.py}
+      /usr/lib/python3.11/distutils/command/build_py.py:
+        {copy: /usr/lib/python3.10/distutils/command/build_py.py}
+      /usr/lib/python3.11/distutils/command/build_scripts.py:
+        {copy: /usr/lib/python3.10/distutils/command/build_scripts.py}
+      /usr/lib/python3.11/distutils/command/check.py:
+        {copy: /usr/lib/python3.10/distutils/command/check.py}
+      /usr/lib/python3.11/distutils/command/clean.py:
+        {copy: /usr/lib/python3.10/distutils/command/clean.py}
+      /usr/lib/python3.11/distutils/command/command_template:
+        {copy: /usr/lib/python3.10/distutils/command/command_template}
+      /usr/lib/python3.11/distutils/command/config.py:
+        {copy: /usr/lib/python3.10/distutils/command/config.py}
+      /usr/lib/python3.11/distutils/command/install.py:
+        {copy: /usr/lib/python3.10/distutils/command/install.py}
+      /usr/lib/python3.11/distutils/command/install_data.py:
+        {copy: /usr/lib/python3.10/distutils/command/install_data.py}
+      /usr/lib/python3.11/distutils/command/install_egg_info.py:
+        {copy: /usr/lib/python3.10/distutils/command/install_egg_info.py}
+      /usr/lib/python3.11/distutils/command/install_headers.py:
+        {copy: /usr/lib/python3.10/distutils/command/install_headers.py}
+      /usr/lib/python3.11/distutils/command/install_lib.py:
+        {copy: /usr/lib/python3.10/distutils/command/install_lib.py}
+      /usr/lib/python3.11/distutils/command/install_scripts.py:
+        {copy: /usr/lib/python3.10/distutils/command/install_scripts.py}
+      /usr/lib/python3.11/distutils/command/register.py:
+        {copy: /usr/lib/python3.10/distutils/command/register.py}
+      /usr/lib/python3.11/distutils/command/sdist.py: 
+        {copy: /usr/lib/python3.10/distutils/command/sdist.py}
+      /usr/lib/python3.11/distutils/command/upload.py:
+        {copy: /usr/lib/python3.10/distutils/command/upload.py}
       /usr/lib/python3.11/distutils/core.py: {copy: /usr/lib/python3.10/distutils/core.py}
-      /usr/lib/python3.11/distutils/cygwinccompiler.py: {copy: /usr/lib/python3.10/distutils/cygwinccompiler.py}
+      /usr/lib/python3.11/distutils/cygwinccompiler.py:
+        {copy: /usr/lib/python3.10/distutils/cygwinccompiler.py}
       /usr/lib/python3.11/distutils/debug.py: {copy: /usr/lib/python3.10/distutils/debug.py}
       /usr/lib/python3.11/distutils/dep_util.py: {copy: /usr/lib/python3.10/distutils/dep_util.py}
       /usr/lib/python3.11/distutils/dir_util.py: {copy: /usr/lib/python3.10/distutils/dir_util.py}
       /usr/lib/python3.11/distutils/dist.py: {copy: /usr/lib/python3.10/distutils/dist.py}
       /usr/lib/python3.11/distutils/errors.py: {copy: /usr/lib/python3.10/distutils/errors.py}
       /usr/lib/python3.11/distutils/extension.py: {copy: /usr/lib/python3.10/distutils/extension.py}
-      /usr/lib/python3.11/distutils/fancy_getopt.py: {copy: /usr/lib/python3.10/distutils/fancy_getopt.py}
+      /usr/lib/python3.11/distutils/fancy_getopt.py:
+        {copy: /usr/lib/python3.10/distutils/fancy_getopt.py}
       /usr/lib/python3.11/distutils/file_util.py: {copy: /usr/lib/python3.10/distutils/file_util.py}
       /usr/lib/python3.11/distutils/filelist.py: {copy: /usr/lib/python3.10/distutils/filelist.py}
       /usr/lib/python3.11/distutils/log.py: {copy: /usr/lib/python3.10/distutils/log.py}
-      /usr/lib/python3.11/distutils/msvc9compiler.py: {copy: /usr/lib/python3.10/distutils/msvc9compiler.py}
+      /usr/lib/python3.11/distutils/msvc9compiler.py:
+        {copy: /usr/lib/python3.10/distutils/msvc9compiler.py}
       /usr/lib/python3.11/distutils/spawn.py: {copy: /usr/lib/python3.10/distutils/spawn.py}
       /usr/lib/python3.11/distutils/text_file.py: {copy: /usr/lib/python3.10/distutils/text_file.py}
-      /usr/lib/python3.11/distutils/unixccompiler.py: {copy: /usr/lib/python3.10/distutils/unixccompiler.py}
+      /usr/lib/python3.11/distutils/unixccompiler.py:
+        {copy: /usr/lib/python3.10/distutils/unixccompiler.py}
       /usr/lib/python3.11/distutils/util.py: {copy: /usr/lib/python3.10/distutils/util.py}
       /usr/lib/python3.11/distutils/versionpredicate.py: {copy: /usr/lib/python3.10/distutils/versionpredicate.py}
 

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -10,11 +10,6 @@ slices:
       # 2 slices doing glob on the same folder, I have to specify the files explicitely
       # Also the original package uses hardlink for the common files between python 3.10 and
       # python3.11 chisel doesn't support hardlinks so I need to use copy
-      /usr/lib/python3.11/distutils/config.py:
-      /usr/lib/python3.11/distutils/msvccompiler.py:
-      /usr/lib/python3.11/distutils/sysconfig.py:
-      /usr/lib/python3.11/distutils/command/bdist.py:
-      /usr/lib/python3.11/distutils/command/build_ext.py:
       /usr/lib/python3.11/distutils/_msvccompiler.py:
         {copy: /usr/lib/python3.10/distutils/_msvccompiler.py}
       /usr/lib/python3.11/distutils/archive_util.py:
@@ -27,6 +22,7 @@ slices:
         {copy: /usr/lib/python3.10/distutils/cmd.py}
       /usr/lib/python3.11/distutils/command/__init__.py:
         {copy: /usr/lib/python3.10/distutils/command/__init__.py}
+      /usr/lib/python3.11/distutils/command/bdist.py:
       /usr/lib/python3.11/distutils/command/bdist_dumb.py:
         {copy: /usr/lib/python3.10/distutils/command/bdist_dumb.py}
       /usr/lib/python3.11/distutils/command/bdist_rpm.py:
@@ -35,6 +31,7 @@ slices:
         {copy: /usr/lib/python3.10/distutils/command/build.py}
       /usr/lib/python3.11/distutils/command/build_clib.py:
         {copy: /usr/lib/python3.10/distutils/command/build_clib.py}
+      /usr/lib/python3.11/distutils/command/build_ext.py:
       /usr/lib/python3.11/distutils/command/build_py.py:
         {copy: /usr/lib/python3.10/distutils/command/build_py.py}
       /usr/lib/python3.11/distutils/command/build_scripts.py:
@@ -65,6 +62,7 @@ slices:
         {copy: /usr/lib/python3.10/distutils/command/sdist.py}
       /usr/lib/python3.11/distutils/command/upload.py:
         {copy: /usr/lib/python3.10/distutils/command/upload.py}
+      /usr/lib/python3.11/distutils/config.py:
       /usr/lib/python3.11/distutils/core.py: {copy: /usr/lib/python3.10/distutils/core.py}
       /usr/lib/python3.11/distutils/cygwinccompiler.py:
         {copy: /usr/lib/python3.10/distutils/cygwinccompiler.py}
@@ -81,7 +79,9 @@ slices:
       /usr/lib/python3.11/distutils/log.py: {copy: /usr/lib/python3.10/distutils/log.py}
       /usr/lib/python3.11/distutils/msvc9compiler.py:
         {copy: /usr/lib/python3.10/distutils/msvc9compiler.py}
+      /usr/lib/python3.11/distutils/msvccompiler.py:
       /usr/lib/python3.11/distutils/spawn.py: {copy: /usr/lib/python3.10/distutils/spawn.py}
+      /usr/lib/python3.11/distutils/sysconfig.py:
       /usr/lib/python3.11/distutils/text_file.py: {copy: /usr/lib/python3.10/distutils/text_file.py}
       /usr/lib/python3.11/distutils/unixccompiler.py:
         {copy: /usr/lib/python3.10/distutils/unixccompiler.py}

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -8,59 +8,62 @@ slices:
     contents:
       #Due to conflicts with libpython3.11-stdlib_distribution and chisel not able to reconcile 2 slices
       #doing glob on the same folder, I have to specify the files explicitely
-      /usr/lib/python3.11/distutils/_msvccompiler.py:
-      /usr/lib/python3.11/distutils/archive_util.py:
-      /usr/lib/python3.11/distutils/bcppcompiler.py:
-      /usr/lib/python3.11/distutils/ccompiler.py:
-      /usr/lib/python3.11/distutils/cmd.py:
-      /usr/lib/python3.11/distutils/command/__init__.py:
-      /usr/lib/python3.11/distutils/command/bdist.py:
-      /usr/lib/python3.11/distutils/command/bdist_dumb.py:
-      /usr/lib/python3.11/distutils/command/bdist_rpm.py:
-      /usr/lib/python3.11/distutils/command/build.py:
-      /usr/lib/python3.11/distutils/command/build_clib.py:
-      /usr/lib/python3.11/distutils/command/build_ext.py:
-      /usr/lib/python3.11/distutils/command/build_py.py:
-      /usr/lib/python3.11/distutils/command/build_scripts.py:
-      /usr/lib/python3.11/distutils/command/check.py:
-      /usr/lib/python3.11/distutils/command/clean.py:
-      /usr/lib/python3.11/distutils/command/command_template:
-      /usr/lib/python3.11/distutils/command/config.py:
-      /usr/lib/python3.11/distutils/command/install.py:
-      /usr/lib/python3.11/distutils/command/install_data.py:
-      /usr/lib/python3.11/distutils/command/install_egg_info.py:
-      /usr/lib/python3.11/distutils/command/install_headers.py:
-      /usr/lib/python3.11/distutils/command/install_lib.py:
-      /usr/lib/python3.11/distutils/command/install_scripts.py:
-      /usr/lib/python3.11/distutils/command/register.py:
-      /usr/lib/python3.11/distutils/command/sdist.py:
-      /usr/lib/python3.11/distutils/command/upload.py:
+      #Also the original package uses hardlink for the common files between python 3.10 and python 3.11
+      #chisel doesn't support hardlinks so I need to use copy
       /usr/lib/python3.11/distutils/config.py:
-      /usr/lib/python3.11/distutils/core.py:
-      /usr/lib/python3.11/distutils/cygwinccompiler.py:
-      /usr/lib/python3.11/distutils/debug.py:
-      /usr/lib/python3.11/distutils/dep_util.py:
-      /usr/lib/python3.11/distutils/dir_util.py:
-      /usr/lib/python3.11/distutils/dist.py:
-      /usr/lib/python3.11/distutils/errors.py:
-      /usr/lib/python3.11/distutils/extension.py:
-      /usr/lib/python3.11/distutils/fancy_getopt.py:
-      /usr/lib/python3.11/distutils/file_util.py:
-      /usr/lib/python3.11/distutils/filelist.py:
-      /usr/lib/python3.11/distutils/log.py:
-      /usr/lib/python3.11/distutils/msvc9compiler.py:
       /usr/lib/python3.11/distutils/msvccompiler.py:
-      /usr/lib/python3.11/distutils/spawn.py:
       /usr/lib/python3.11/distutils/sysconfig.py:
-      /usr/lib/python3.11/distutils/text_file.py:
-      /usr/lib/python3.11/distutils/unixccompiler.py:
-      /usr/lib/python3.11/distutils/util.py:
-      /usr/lib/python3.11/distutils/versionpredicate.py:
+      /usr/lib/python3.11/distutils/command/bdist.py:
+      /usr/lib/python3.11/distutils/command/build_ext.py:
+      /usr/lib/python3.11/distutils/_msvccompiler.py: {copy: /usr/lib/python3.10/distutils/_msvccompiler.py}
+      /usr/lib/python3.11/distutils/archive_util.py: {copy: /usr/lib/python3.10/distutils/archive_util.py}
+      /usr/lib/python3.11/distutils/bcppcompiler.py: {copy: /usr/lib/python3.10/distutils/bcppcompiler.py}
+      /usr/lib/python3.11/distutils/ccompiler.py: {copy: /usr/lib/python3.10/distutils/ccompiler.py}
+      /usr/lib/python3.11/distutils/cmd.py: {copy: /usr/lib/python3.10/distutils/cmd.py}
+      /usr/lib/python3.11/distutils/command/__init__.py: {copy: /usr/lib/python3.10/distutils/command/__init__.py}
+      /usr/lib/python3.11/distutils/command/bdist_dumb.py: {copy: /usr/lib/python3.10/distutils/command/bdist_dumb.py}
+      /usr/lib/python3.11/distutils/command/bdist_rpm.py: {copy: /usr/lib/python3.10/distutils/command/bdist_rpm.py}
+      /usr/lib/python3.11/distutils/command/build.py: {copy: /usr/lib/python3.10/distutils/command/build.py}
+      /usr/lib/python3.11/distutils/command/build_clib.py: {copy: /usr/lib/python3.10/distutils/command/build_clib.py}
+      /usr/lib/python3.11/distutils/command/build_py.py: {copy: /usr/lib/python3.10/distutils/command/build_py.py}
+      /usr/lib/python3.11/distutils/command/build_scripts.py: {copy: /usr/lib/python3.10/distutils/command/build_scripts.py}
+      /usr/lib/python3.11/distutils/command/check.py: {copy: /usr/lib/python3.10/distutils/command/check.py}
+      /usr/lib/python3.11/distutils/command/clean.py: {copy: /usr/lib/python3.10/distutils/command/clean.py}
+      /usr/lib/python3.11/distutils/command/command_template: {copy: /usr/lib/python3.10/distutils/command/command_template}
+      /usr/lib/python3.11/distutils/command/config.py: {copy: /usr/lib/python3.10/distutils/command/config.py}
+      /usr/lib/python3.11/distutils/command/install.py: {copy: /usr/lib/python3.10/distutils/command/install.py}
+      /usr/lib/python3.11/distutils/command/install_data.py: {copy: /usr/lib/python3.10/distutils/command/install_data.py}
+      /usr/lib/python3.11/distutils/command/install_egg_info.py: {copy: /usr/lib/python3.10/distutils/command/install_egg_info.py}
+      /usr/lib/python3.11/distutils/command/install_headers.py: {copy: /usr/lib/python3.10/distutils/command/install_headers.py}
+      /usr/lib/python3.11/distutils/command/install_lib.py: {copy: /usr/lib/python3.10/distutils/command/install_lib.py}
+      /usr/lib/python3.11/distutils/command/install_scripts.py: {copy: /usr/lib/python3.10/distutils/command/install_scripts.py}
+      /usr/lib/python3.11/distutils/command/register.py: {copy: /usr/lib/python3.10/distutils/command/register.py}
+      /usr/lib/python3.11/distutils/command/sdist.py: {copy: /usr/lib/python3.10/distutils/command/sdist.py}
+      /usr/lib/python3.11/distutils/command/upload.py: {copy: /usr/lib/python3.10/distutils/command/upload.py}
+      /usr/lib/python3.11/distutils/core.py: {copy: /usr/lib/python3.10/distutils/core.py}
+      /usr/lib/python3.11/distutils/cygwinccompiler.py: {copy: /usr/lib/python3.10/distutils/cygwinccompiler.py}
+      /usr/lib/python3.11/distutils/debug.py: {copy: /usr/lib/python3.10/distutils/debug.py}
+      /usr/lib/python3.11/distutils/dep_util.py: {copy: /usr/lib/python3.10/distutils/dep_util.py}
+      /usr/lib/python3.11/distutils/dir_util.py: {copy: /usr/lib/python3.10/distutils/dir_util.py}
+      /usr/lib/python3.11/distutils/dist.py: {copy: /usr/lib/python3.10/distutils/dist.py}
+      /usr/lib/python3.11/distutils/errors.py: {copy: /usr/lib/python3.10/distutils/errors.py}
+      /usr/lib/python3.11/distutils/extension.py: {copy: /usr/lib/python3.10/distutils/extension.py}
+      /usr/lib/python3.11/distutils/fancy_getopt.py: {copy: /usr/lib/python3.10/distutils/fancy_getopt.py}
+      /usr/lib/python3.11/distutils/file_util.py: {copy: /usr/lib/python3.10/distutils/file_util.py}
+      /usr/lib/python3.11/distutils/filelist.py: {copy: /usr/lib/python3.10/distutils/filelist.py}
+      /usr/lib/python3.11/distutils/log.py: {copy: /usr/lib/python3.10/distutils/log.py}
+      /usr/lib/python3.11/distutils/msvc9compiler.py: {copy: /usr/lib/python3.10/distutils/msvc9compiler.py}
+      /usr/lib/python3.11/distutils/spawn.py: {copy: /usr/lib/python3.10/distutils/spawn.py}
+      /usr/lib/python3.11/distutils/text_file.py: {copy: /usr/lib/python3.10/distutils/text_file.py}
+      /usr/lib/python3.11/distutils/unixccompiler.py: {copy: /usr/lib/python3.10/distutils/unixccompiler.py}
+      /usr/lib/python3.11/distutils/util.py: {copy: /usr/lib/python3.10/distutils/util.py}
+      /usr/lib/python3.11/distutils/versionpredicate.py: {copy: /usr/lib/python3.10/distutils/versionpredicate.py}
 
   python3-10:
     contents:
       /usr/lib/python3.10/distutils/*.py:
       /usr/lib/python3.10/distutils/command/*.py:
+
   copyright:
     contents:
       /usr/share/doc/python3-distutils/copyright:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -1,0 +1,66 @@
+package: python3-distutils
+
+essential:
+  - python3-distutils_copyright
+
+slices:
+  python3-11:
+    contents:
+      #Due to conflicts with libpython3.11-stdlib_distribution and chisel not able to reconcile 2 slices
+      #doing glob on the same folder, I have to specify the files explicitely
+      /usr/lib/python3.11/distutils/_msvccompiler.py:
+      /usr/lib/python3.11/distutils/archive_util.py:
+      /usr/lib/python3.11/distutils/bcppcompiler.py:
+      /usr/lib/python3.11/distutils/ccompiler.py:
+      /usr/lib/python3.11/distutils/cmd.py:
+      /usr/lib/python3.11/distutils/command/__init__.py:
+      /usr/lib/python3.11/distutils/command/bdist.py:
+      /usr/lib/python3.11/distutils/command/bdist_dumb.py:
+      /usr/lib/python3.11/distutils/command/bdist_rpm.py:
+      /usr/lib/python3.11/distutils/command/build.py:
+      /usr/lib/python3.11/distutils/command/build_clib.py:
+      /usr/lib/python3.11/distutils/command/build_ext.py:
+      /usr/lib/python3.11/distutils/command/build_py.py:
+      /usr/lib/python3.11/distutils/command/build_scripts.py:
+      /usr/lib/python3.11/distutils/command/check.py:
+      /usr/lib/python3.11/distutils/command/clean.py:
+      /usr/lib/python3.11/distutils/command/command_template:
+      /usr/lib/python3.11/distutils/command/config.py:
+      /usr/lib/python3.11/distutils/command/install.py:
+      /usr/lib/python3.11/distutils/command/install_data.py:
+      /usr/lib/python3.11/distutils/command/install_egg_info.py:
+      /usr/lib/python3.11/distutils/command/install_headers.py:
+      /usr/lib/python3.11/distutils/command/install_lib.py:
+      /usr/lib/python3.11/distutils/command/install_scripts.py:
+      /usr/lib/python3.11/distutils/command/register.py:
+      /usr/lib/python3.11/distutils/command/sdist.py:
+      /usr/lib/python3.11/distutils/command/upload.py:
+      /usr/lib/python3.11/distutils/config.py:
+      /usr/lib/python3.11/distutils/core.py:
+      /usr/lib/python3.11/distutils/cygwinccompiler.py:
+      /usr/lib/python3.11/distutils/debug.py:
+      /usr/lib/python3.11/distutils/dep_util.py:
+      /usr/lib/python3.11/distutils/dir_util.py:
+      /usr/lib/python3.11/distutils/dist.py:
+      /usr/lib/python3.11/distutils/errors.py:
+      /usr/lib/python3.11/distutils/extension.py:
+      /usr/lib/python3.11/distutils/fancy_getopt.py:
+      /usr/lib/python3.11/distutils/file_util.py:
+      /usr/lib/python3.11/distutils/filelist.py:
+      /usr/lib/python3.11/distutils/log.py:
+      /usr/lib/python3.11/distutils/msvc9compiler.py:
+      /usr/lib/python3.11/distutils/msvccompiler.py:
+      /usr/lib/python3.11/distutils/spawn.py:
+      /usr/lib/python3.11/distutils/sysconfig.py:
+      /usr/lib/python3.11/distutils/text_file.py:
+      /usr/lib/python3.11/distutils/unixccompiler.py:
+      /usr/lib/python3.11/distutils/util.py:
+      /usr/lib/python3.11/distutils/versionpredicate.py:
+
+  python3-10:
+    contents:
+      /usr/lib/python3.10/distutils/*.py:
+      /usr/lib/python3.10/distutils/command/*.py:
+  copyright:
+    contents:
+      /usr/share/doc/python3-distutils/copyright:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -5,6 +5,8 @@ essential:
 
 slices:
   python3-11:
+    essential:
+      - python3.11_core
     contents:
       # Due to conflicts with libpython3.11-stdlib_distribution and chisel not being able to
       # reconcile 2 slices with globs on the same folder, I have to specify the files explicitly.
@@ -90,6 +92,8 @@ slices:
         {copy: /usr/lib/python3.10/distutils/versionpredicate.py}
 
   python3-10:
+    essential:
+      - python3-lib2to3_libs
     contents:
       /usr/lib/python3.10/distutils/*.py:
       /usr/lib/python3.10/distutils/command/*.py:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -6,10 +6,10 @@ essential:
 slices:
   python3-11:
     contents:
-      # Due to conflicts with libpython3.11-stdlib_distribution and chisel not able to reconcile
-      # 2 slices doing glob on the same folder, I have to specify the files explicitely
-      # Also the original package uses hardlink for the common files between python 3.10 and
-      # python3.11 chisel doesn't support hardlinks so I need to use copy
+      # Due to conflicts with libpython3.11-stdlib_distribution and chisel not being able to
+      # reconcile 2 slices with globs on the same folder, I have to specify the files explicitly.
+      # Also the original package uses hardlink for the common files between python3.10 and
+      # python3.11. Chisel doesn't seem to support hardlinks so I need to use copy as a workaround
       /usr/lib/python3.11/distutils/_msvccompiler.py:
         {copy: /usr/lib/python3.10/distutils/_msvccompiler.py}
       /usr/lib/python3.11/distutils/archive_util.py:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -93,7 +93,7 @@ slices:
 
   python3-10:
     essential:
-      - python3-lib2to3_libs
+      - python3-lib2to3_python3-10
     contents:
       /usr/lib/python3.10/distutils/*.py:
       /usr/lib/python3.10/distutils/command/*.py:

--- a/slices/python3-lib2to3.yaml
+++ b/slices/python3-lib2to3.yaml
@@ -12,6 +12,7 @@ slices:
     essential:
       - python3.11_core
     contents:
+      # TODO: Replace with globing once chisel supports hardlinks.
       /usr/lib/python3.11/lib2to3/Grammar.txt: {copy: /usr/lib/python3.10/lib2to3/Grammar.txt}
       /usr/lib/python3.11/lib2to3/PatternGrammar.txt:
         {copy: /usr/lib/python3.10/lib2to3/PatternGrammar.txt}

--- a/slices/python3-lib2to3.yaml
+++ b/slices/python3-lib2to3.yaml
@@ -13,77 +13,139 @@ slices:
       - python3.11_core
     contents:
       /usr/lib/python3.11/lib2to3/Grammar.txt: {copy: /usr/lib/python3.10/lib2to3/Grammar.txt}
-      /usr/lib/python3.11/lib2to3/PatternGrammar.txt: {copy: /usr/lib/python3.10/lib2to3/PatternGrammar.txt}
+      /usr/lib/python3.11/lib2to3/PatternGrammar.txt:
+        {copy: /usr/lib/python3.10/lib2to3/PatternGrammar.txt}
       /usr/lib/python3.11/lib2to3/__init__.py:
       /usr/lib/python3.11/lib2to3/__main__.py: {copy: /usr/lib/python3.10/lib2to3/__main__.py}
-      /usr/lib/python3.11/lib2to3/btm_matcher.py: {copy: /usr/lib/python3.10/lib2to3/btm_matcher.py}
+      /usr/lib/python3.11/lib2to3/btm_matcher.py:
+        {copy: /usr/lib/python3.10/lib2to3/btm_matcher.py}
       /usr/lib/python3.11/lib2to3/btm_utils.py:
       /usr/lib/python3.11/lib2to3/fixer_base.py: {copy: /usr/lib/python3.10/lib2to3/fixer_base.py}
       /usr/lib/python3.11/lib2to3/fixer_util.py: {copy: /usr/lib/python3.10/lib2to3/fixer_util.py}
-      /usr/lib/python3.11/lib2to3/fixes/__init__.py: {copy: /usr/lib/python3.10/lib2to3/fixes/__init__.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_apply.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_apply.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_asserts.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_asserts.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_basestring.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_basestring.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_buffer.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_buffer.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_dict.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_dict.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_except.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_except.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_exec.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_exec.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_execfile.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_execfile.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_exitfunc.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_exitfunc.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_filter.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_filter.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_funcattrs.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_funcattrs.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_future.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_future.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_getcwdu.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_getcwdu.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_has_key.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_has_key.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_idioms.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_idioms.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_import.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_import.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_imports.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_imports.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_imports2.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_imports2.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_input.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_input.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_intern.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_intern.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_isinstance.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_isinstance.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_itertools.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_itertools.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_itertools_imports.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_itertools_imports.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_long.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_long.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_map.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_map.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_metaclass.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_metaclass.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_methodattrs.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_methodattrs.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_ne.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_ne.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_next.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_next.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_nonzero.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_nonzero.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_numliterals.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_numliterals.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_operator.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_operator.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_paren.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_paren.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_print.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_print.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_raise.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_raise.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_raw_input.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_raw_input.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_reduce.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_reduce.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_reload.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_reload.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_renames.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_renames.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_repr.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_repr.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_set_literal.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_set_literal.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_standarderror.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_standarderror.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_sys_exc.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_sys_exc.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_throw.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_throw.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_tuple_params.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_tuple_params.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_types.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_types.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_unicode.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_unicode.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_urllib.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_urllib.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_ws_comma.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_ws_comma.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_xrange.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_xrange.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_xreadlines.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_xreadlines.py}
-      /usr/lib/python3.11/lib2to3/fixes/fix_zip.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_zip.py}
+      /usr/lib/python3.11/lib2to3/fixes/__init__.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/__init__.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_apply.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_apply.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_asserts.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_asserts.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_basestring.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_basestring.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_buffer.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_buffer.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_dict.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_dict.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_except.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_except.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_exec.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_exec.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_execfile.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_execfile.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_exitfunc.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_exitfunc.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_filter.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_filter.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_funcattrs.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_funcattrs.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_future.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_future.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_getcwdu.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_getcwdu.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_has_key.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_has_key.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_idioms.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_idioms.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_import.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_import.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_imports.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_imports.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_imports2.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_imports2.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_input.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_input.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_intern.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_intern.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_isinstance.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_isinstance.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_itertools.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_itertools.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_itertools_imports.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_itertools_imports.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_long.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_long.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_map.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_map.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_metaclass.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_metaclass.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_methodattrs.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_methodattrs.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_ne.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_ne.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_next.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_next.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_nonzero.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_nonzero.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_numliterals.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_numliterals.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_operator.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_operator.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_paren.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_paren.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_print.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_print.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_raise.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_raise.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_raw_input.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_raw_input.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_reduce.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_reduce.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_reload.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_reload.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_renames.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_renames.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_repr.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_repr.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_set_literal.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_set_literal.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_standarderror.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_standarderror.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_sys_exc.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_sys_exc.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_throw.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_throw.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_tuple_params.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_tuple_params.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_types.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_types.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_unicode.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_unicode.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_urllib.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_urllib.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_ws_comma.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_ws_comma.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_xrange.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_xrange.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_xreadlines.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_xreadlines.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_zip.py:
+        {copy: /usr/lib/python3.10/lib2to3/fixes/fix_zip.py}
       /usr/lib/python3.11/lib2to3/main.py: {copy: /usr/lib/python3.10/lib2to3/main.py}
       /usr/lib/python3.11/lib2to3/patcomp.py: {copy: /usr/lib/python3.10/lib2to3/patcomp.py}
-      /usr/lib/python3.11/lib2to3/pgen2/__init__.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/__init__.py}
-      /usr/lib/python3.11/lib2to3/pgen2/conv.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/conv.py}
-      /usr/lib/python3.11/lib2to3/pgen2/driver.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/driver.py}
+      /usr/lib/python3.11/lib2to3/pgen2/__init__.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/__init__.py}
+      /usr/lib/python3.11/lib2to3/pgen2/conv.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/conv.py}
+      /usr/lib/python3.11/lib2to3/pgen2/driver.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/driver.py}
       /usr/lib/python3.11/lib2to3/pgen2/grammar.py:
-      /usr/lib/python3.11/lib2to3/pgen2/literals.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/literals.py}
-      /usr/lib/python3.11/lib2to3/pgen2/parse.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/parse.py}
+      /usr/lib/python3.11/lib2to3/pgen2/literals.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/literals.py}
+      /usr/lib/python3.11/lib2to3/pgen2/parse.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/parse.py}
       /usr/lib/python3.11/lib2to3/pgen2/pgen.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/pgen.py}
-      /usr/lib/python3.11/lib2to3/pgen2/token.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/token.py}
-      /usr/lib/python3.11/lib2to3/pgen2/tokenize.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/tokenize.py}
+      /usr/lib/python3.11/lib2to3/pgen2/token.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/token.py}
+      /usr/lib/python3.11/lib2to3/pgen2/tokenize.py:
+        {copy: /usr/lib/python3.10/lib2to3/pgen2/tokenize.py}
       /usr/lib/python3.11/lib2to3/pygram.py: {copy: /usr/lib/python3.10/lib2to3/pygram.py}
       /usr/lib/python3.11/lib2to3/pytree.py: {copy: /usr/lib/python3.10/lib2to3/pytree.py}
       /usr/lib/python3.11/lib2to3/refactor.py: {copy: /usr/lib/python3.10/lib2to3/refactor.py}

--- a/slices/python3-lib2to3.yaml
+++ b/slices/python3-lib2to3.yaml
@@ -7,11 +7,86 @@ slices:
   python3-10:
     contents:
       /usr/lib/python3.10/lib2to3/**:
+
   python3-11:
     essential:
       - python3.11_core
     contents:
-      /usr/lib/python3.11/lib2to3/**:
+      /usr/lib/python3.11/lib2to3/Grammar.txt: {copy: /usr/lib/python3.10/lib2to3/Grammar.txt}
+      /usr/lib/python3.11/lib2to3/PatternGrammar.txt: {copy: /usr/lib/python3.10/lib2to3/PatternGrammar.txt}
+      /usr/lib/python3.11/lib2to3/__init__.py:
+      /usr/lib/python3.11/lib2to3/__main__.py: {copy: /usr/lib/python3.10/lib2to3/__main__.py}
+      /usr/lib/python3.11/lib2to3/btm_matcher.py: {copy: /usr/lib/python3.10/lib2to3/btm_matcher.py}
+      /usr/lib/python3.11/lib2to3/btm_utils.py:
+      /usr/lib/python3.11/lib2to3/fixer_base.py: {copy: /usr/lib/python3.10/lib2to3/fixer_base.py}
+      /usr/lib/python3.11/lib2to3/fixer_util.py: {copy: /usr/lib/python3.10/lib2to3/fixer_util.py}
+      /usr/lib/python3.11/lib2to3/fixes/__init__.py: {copy: /usr/lib/python3.10/lib2to3/fixes/__init__.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_apply.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_apply.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_asserts.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_asserts.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_basestring.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_basestring.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_buffer.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_buffer.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_dict.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_dict.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_except.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_except.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_exec.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_exec.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_execfile.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_execfile.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_exitfunc.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_exitfunc.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_filter.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_filter.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_funcattrs.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_funcattrs.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_future.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_future.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_getcwdu.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_getcwdu.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_has_key.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_has_key.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_idioms.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_idioms.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_import.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_import.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_imports.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_imports.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_imports2.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_imports2.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_input.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_input.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_intern.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_intern.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_isinstance.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_isinstance.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_itertools.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_itertools.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_itertools_imports.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_itertools_imports.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_long.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_long.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_map.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_map.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_metaclass.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_metaclass.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_methodattrs.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_methodattrs.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_ne.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_ne.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_next.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_next.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_nonzero.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_nonzero.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_numliterals.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_numliterals.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_operator.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_operator.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_paren.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_paren.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_print.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_print.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_raise.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_raise.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_raw_input.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_raw_input.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_reduce.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_reduce.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_reload.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_reload.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_renames.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_renames.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_repr.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_repr.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_set_literal.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_set_literal.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_standarderror.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_standarderror.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_sys_exc.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_sys_exc.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_throw.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_throw.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_tuple_params.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_tuple_params.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_types.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_types.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_unicode.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_unicode.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_urllib.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_urllib.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_ws_comma.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_ws_comma.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_xrange.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_xrange.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_xreadlines.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_xreadlines.py}
+      /usr/lib/python3.11/lib2to3/fixes/fix_zip.py: {copy: /usr/lib/python3.10/lib2to3/fixes/fix_zip.py}
+      /usr/lib/python3.11/lib2to3/main.py: {copy: /usr/lib/python3.10/lib2to3/main.py}
+      /usr/lib/python3.11/lib2to3/patcomp.py: {copy: /usr/lib/python3.10/lib2to3/patcomp.py}
+      /usr/lib/python3.11/lib2to3/pgen2/__init__.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/__init__.py}
+      /usr/lib/python3.11/lib2to3/pgen2/conv.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/conv.py}
+      /usr/lib/python3.11/lib2to3/pgen2/driver.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/driver.py}
+      /usr/lib/python3.11/lib2to3/pgen2/grammar.py:
+      /usr/lib/python3.11/lib2to3/pgen2/literals.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/literals.py}
+      /usr/lib/python3.11/lib2to3/pgen2/parse.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/parse.py}
+      /usr/lib/python3.11/lib2to3/pgen2/pgen.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/pgen.py}
+      /usr/lib/python3.11/lib2to3/pgen2/token.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/token.py}
+      /usr/lib/python3.11/lib2to3/pgen2/tokenize.py: {copy: /usr/lib/python3.10/lib2to3/pgen2/tokenize.py}
+      /usr/lib/python3.11/lib2to3/pygram.py: {copy: /usr/lib/python3.10/lib2to3/pygram.py}
+      /usr/lib/python3.11/lib2to3/pytree.py: {copy: /usr/lib/python3.10/lib2to3/pytree.py}
+      /usr/lib/python3.11/lib2to3/refactor.py: {copy: /usr/lib/python3.10/lib2to3/refactor.py}
 
   copyright:
     contents:

--- a/slices/python3-lib2to3.yaml
+++ b/slices/python3-lib2to3.yaml
@@ -1,0 +1,13 @@
+package: python3-lib2to3
+
+essential:
+  - python3-lib2to3_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/python3.10/lib2to3/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-lib2to3/copyright:

--- a/slices/python3-lib2to3.yaml
+++ b/slices/python3-lib2to3.yaml
@@ -4,9 +4,14 @@ essential:
   - python3-lib2to3_copyright
 
 slices:
-  libs:
+  python3-10:
     contents:
       /usr/lib/python3.10/lib2to3/**:
+  python3-11:
+    essential:
+      - python3.11_core
+    contents:
+      /usr/lib/python3.11/lib2to3/**:
 
   copyright:
     contents:

--- a/slices/python3-pip-whl.yaml
+++ b/slices/python3-pip-whl.yaml
@@ -4,7 +4,9 @@ essential:
   - python3-pip-whl_copyright
 
 slices:
-  bins:
+  wheels:
+    essential:
+      - ca-certificates_data
     contents:
       /usr/share/python-wheels/pip-*-py3-none-any.whl:
 

--- a/slices/python3-pip-whl.yaml
+++ b/slices/python3-pip-whl.yaml
@@ -1,0 +1,13 @@
+package: python3-pip-whl
+
+essential:
+  - python3-pip-whl_copyright
+
+slices:
+  bins:
+    contents:
+      /usr/share/python-wheels/pip-*-py3-none-any.whl:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-pip-whl/copyright:

--- a/slices/python3-setuptools-whl.yaml
+++ b/slices/python3-setuptools-whl.yaml
@@ -1,0 +1,13 @@
+package: python3-setuptools-whl
+
+essential:
+  - python3-setuptools-whl_copyright
+
+slices:
+  bins:
+    contents:
+      /usr/share/python-wheels/setuptools-*-py3-none-any.whl:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-setuptools-whl/copyright:

--- a/slices/python3-setuptools-whl.yaml
+++ b/slices/python3-setuptools-whl.yaml
@@ -4,7 +4,7 @@ essential:
   - python3-setuptools-whl_copyright
 
 slices:
-  bins:
+  wheels:
     contents:
       /usr/share/python-wheels/setuptools-*-py3-none-any.whl:
 

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -5,7 +5,7 @@ slices:
     contents:
       /usr/lib/python3.11/ensurepip/*.py:
 
-  core:
+  libs:
     essential:
       - python3-distutils_python3-11
       - python3-pip-whl_bins

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -12,4 +12,3 @@ slices:
       - python3-setuptools-whl_bins
       - python3-distutils_python3-11
       - python3.11-venv_ensurepip
-

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -8,7 +8,7 @@ slices:
   libs:
     essential:
       - python3-distutils_python3-11
-      - python3-pip-whl_bins
-      - python3-setuptools-whl_bins
+      - python3-pip-whl_wheels
+      - python3-setuptools-whl_wheels
       - python3.11-venv_ensurepip
       - python3.11_standard

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -10,5 +10,5 @@ slices:
       - python3-distutils_python3-11
       - python3-pip-whl_bins
       - python3-setuptools-whl_bins
-      - python3.11_standard
       - python3.11-venv_ensurepip
+      - python3.11_standard

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -1,0 +1,15 @@
+package: python3.11-venv
+
+slices:
+  ensurepip:
+    contents:
+      /usr/lib/python3.11/ensurepip/*.py:
+
+  core:
+    essential:
+      - python3.11_standard
+      - python3-pip-whl_bins
+      - python3-setuptools-whl_bins
+      - python3-distutils_python3-11
+      - python3.11-venv_ensurepip
+

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -7,8 +7,8 @@ slices:
 
   core:
     essential:
-      - python3.11_standard
-      - python3.11-venv_ensurepip
       - python3-distutils_python3-11
       - python3-pip-whl_bins
       - python3-setuptools-whl_bins
+      - python3.11_standard
+      - python3.11-venv_ensurepip

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -8,7 +8,7 @@ slices:
   core:
     essential:
       - python3.11_standard
+      - python3.11-venv_ensurepip
+      - python3-distutils_python3-11
       - python3-pip-whl_bins
       - python3-setuptools-whl_bins
-      - python3-distutils_python3-11
-      - python3.11-venv_ensurepip

--- a/slices/python3.11-venv.yaml
+++ b/slices/python3.11-venv.yaml
@@ -2,13 +2,10 @@ package: python3.11-venv
 
 slices:
   ensurepip:
-    contents:
-      /usr/lib/python3.11/ensurepip/*.py:
-
-  libs:
     essential:
       - python3-distutils_python3-11
       - python3-pip-whl_wheels
       - python3-setuptools-whl_wheels
-      - python3.11-venv_ensurepip
       - python3.11_standard
+    contents:
+      /usr/lib/python3.11/ensurepip/*.py:


### PR DESCRIPTION
# Proposed changes
Adding `python3.11-venv` chiseled package and its dependency.
The aim is to be able to use the python plugin on `rockcraft` entirely with chiseled packages, allowing very small OCI images for python applications.

## Related issues/PRs
N/A

### Forward porting
N/A

## Testing
To test in a VM, start an `ubuntu-22.04`, copy this branch into `/home/chisel` folder (or mount it):
```bash
apt update && apt install -y golang-1.22 ca-certificates
update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 0
go install github.com/canonical/chisel/cmd/chisel@latest
/root/go/bin/chisel cut --release /home/chisel/ --root / python3.11-venv_libs
cd ~
mkdir test
cd test
python3.11 -m venv env
echo "flask" > requirements.txt
source env/bin/activate
pip install -r requirements.txt
```

To test using rockcraft use the following `rockcraft.yaml` at the root of this repository folder
```yaml
name: python-venv
title: python-venv
version: '0.1'
summary: Testing python3.11-venv slice in bare
description: |
  Testing python3.11-venv slice in bare
base: bare
build-base: ubuntu@22.04
platforms:
  amd64:
  #license: GPL-3.0
parts:
  chisel:
    plugin: dump
    source: .
    override-build: |
      chisel cut --release ./ --root ${CRAFT_PART_INSTALL} python3.11-venv_libs
  slices:
    plugin: nil
    override-build: mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp
    stage-packages:
    - bash_bins
    - coreutils_bins
    - ca-certificates_data
run-user: _daemon_
```
You'll need `rockcraft` snap installed, and `docker` installed:
```bash
rockcraft pack
rockcraft.skopeo copy --insecure-policy oci-archive:python-venv_0.1_amd64.rock docker-daemon:python-venv:test
docker run --name test -d python-venv:test
docker exec -ti test bash
cd ~
mkdir test
cd test
python3.11 -m venv env
echo "flask" > requirements.txt
source env/bin/activate
pip install -r requirements.txt
```

Expected output:
```
gschiano@charm-dev:/src/Canonical/chisel-releases$ cat rockcraft.yaml
name: python-venv
title: python-venv
version: '0.1'
summary: Testing python3.11-venv slice in bare
description: |
  Testing python3.11-venv slice in bare
base: bare
build-base: ubuntu@22.04
platforms:
  amd64:
  #license: GPL-3.0
parts:
  chisel:
    plugin: dump
    source: .
    override-build: |
      chisel cut --release ./ --root ${CRAFT_PART_INSTALL} python3.11-venv_libs
  slices:
    plugin: nil
    override-build: mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp
    stage-packages:
    - bash_bins
    - coreutils_bins
    - ca-certificates_data
run-user: _daemon_
gschiano@charm-dev:/src/Canonical/chisel-releases$ rockcraft pack
Packed python-venv_0.1_amd64.rock
gschiano@charm-dev:/src/Canonical/chisel-releases$ rockcraft.skopeo copy --insecure-policy oci-archive:python-venv_0.1_amd64.rock docker-daemon:python-venv:test
Getting image source signatures
Copying blob bbbb607b1c35 done   |
Copying blob b6f7014439c9 done   |
Copying blob 0a4832dfd157 done   |
Copying config 5dfb1d9f5a done   |
Writing manifest to image destination
gschiano@charm-dev:/src/Canonical/chisel-releases$ docker run --name test -d python-venv:test
0c386bdf67835c30b8be6262dbaabb94bd1e347a7d95305cc0452ed7e089cb0d
gschiano@charm-dev:/src/Canonical/chisel-releases$ docker exec -ti test bash
_daemon_@0c386bdf6783:/$ cd ~
_daemon_@0c386bdf6783:~$ mkdir test
_daemon_@0c386bdf6783:~$ cd test
_daemon_@0c386bdf6783:~/test$ python3.11 -m venv env
_daemon_@0c386bdf6783:~/test$ ls
env
_daemon_@0c386bdf6783:~/test$ echo "flask" > requirements.txt
_daemon_@0c386bdf6783:~/test$ source env/bin/activate
(env) _daemon_@0c386bdf6783:~/test$ pip install -r requirements.txt
Collecting flask
  Downloading flask-3.0.3-py3-none-any.whl (101 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 101.7/101.7 KB 2.1 MB/s eta 0:00:00
Collecting blinker>=1.6.2
  Downloading blinker-1.8.2-py3-none-any.whl (9.5 kB)
Collecting click>=8.1.3
  Downloading click-8.1.7-py3-none-any.whl (97 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 97.9/97.9 KB 6.7 MB/s eta 0:00:00
Collecting itsdangerous>=2.1.2
  Downloading itsdangerous-2.2.0-py3-none-any.whl (16 kB)
Collecting Jinja2>=3.1.2
  Downloading jinja2-3.1.4-py3-none-any.whl (133 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.3/133.3 KB 10.7 MB/s eta 0:00:00
Collecting Werkzeug>=3.0.0
  Downloading werkzeug-3.0.3-py3-none-any.whl (227 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 227.3/227.3 KB 16.8 MB/s eta 0:00:00
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (28 kB)
Installing collected packages: MarkupSafe, itsdangerous, click, blinker, Werkzeug, Jinja2, flask
Successfully installed Jinja2-3.1.4 MarkupSafe-2.1.5 Werkzeug-3.0.3 blinker-1.8.2 click-8.1.7 flask-3.0.3 itsdangerous-2.2.0
```

## Checklist
* [X] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [X] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
N/A