### PR TITLE
Slicing libpq5 required in python to access a posgres database

### DIFF
--- a/slices/libpq5.yaml
+++ b/slices/libpq5.yaml
@@ -1,0 +1,18 @@
+package: libpq5
+
+essential:
+  - libpq5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgssapi-krb5-2_libs
+      - libldap-2.5-0_libs
+      - libssl3_libs
+    contents:
+      /lib/*-linux-*/libpq.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpq5/copyright:

--- a/slices/libpq5.yaml
+++ b/slices/libpq5.yaml
@@ -11,7 +11,7 @@ slices:
       - libldap-2.5-0_libs
       - libssl3_libs
     contents:
-      /lib/*-linux-*/libpq.so.5*:
+      /usr/lib/*-linux-*/libpq.so.5*:
 
   copyright:
     contents:


### PR DESCRIPTION
# Proposed changes
Slicing `libpq5` used to access posgres databases

## Related issues/PRs
N/A

### Forward porting
N/A

## Testing
Start a docker container running ubuntu-22.04 while being in this repository folder and a postgres database
```
docker run --name postgres -e POSTGRES_PASSWORD=secret -d postgres:15
#Get this container IP address using docker inspect postgres and note it
docker run -d --name flask -v $(pwd):/home/chisel ubuntu:22.04 sleep 3600
docker exec -ti flask bash
apt update && apt install -y golang-1.22 ca-certificates curl python3-venv git
update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 0
go install github.com/canonical/chisel/cmd/chisel@latest
/root/go/bin/chisel cut --release /home/chisel/ --root / libpq5_libs
cd /home
git clone https://github.com/canonical/sample-flask.git
cd sample-flask
git checkout feat-database
python3 -m venv env
source env/bin/activate
pip install -r requirements.txt
#Use the IP address noted earlier here
POSTGRESQL_DB_CONNECT_STRING="postgresql://postgres:secret@172.17.0.3:5432/postgres" flask run -p 8000 &
#Press enter, you'll have some output from the previous command put in background
watch -n 2 curl localhost:8000
#You'll see the visitor counter incrementing
```

## Checklist
* [X] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [X] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
N/A