### PR TITLE
feat(20.04): add 'data' slice to openssl SDF

### DIFF
--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -23,6 +23,10 @@ slices:
       /usr/lib/ssl/openssl.cnf:
       /usr/lib/ssl/private:
 
+  # Include this slice and `ca-certificates_data` together to use the
+  # certificate bundle from `ca-certificates`.
+  # Missing this slice will cause applications using default certificates
+  # fail to verify local SSL certificates.
   data:
     contents:
       /usr/lib/ssl/cert.pem: {symlink: /etc/ssl/certs/ca-certificates.crt}

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -23,10 +23,9 @@ slices:
       /usr/lib/ssl/openssl.cnf:
       /usr/lib/ssl/private:
 
-  # Include this slice and `ca-certificates_data` together to use the
-  # certificate bundle from `ca-certificates`.
-  # Missing this slice will cause applications using default certificates
-  # fail to verify local SSL certificates.
+  # Use this slice with "ca-certificates_data" as OpenSSL looks at
+  # the following path for the default CA certificates file.
+  # Ref: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
   data:
     contents:
       /usr/lib/ssl/cert.pem: {symlink: /etc/ssl/certs/ca-certificates.crt}

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -23,6 +23,10 @@ slices:
       /usr/lib/ssl/openssl.cnf:
       /usr/lib/ssl/private:
 
+  data:
+    contents:
+      /usr/lib/ssl/cert.pem: {symlink: /etc/ssl/certs/ca-certificates.crt}
+
   copyright:
     contents:
       /usr/share/doc/openssl/copyright:


### PR DESCRIPTION
# Proposed changes

Add `openssl_data` slice for users does not require the "openssl" binaries, but only needs the `pem` bundled certificate at the default `cafile`.

The problem: Programmes in rocks with base focal and jammy cannot get local issuer certificates during an SSL certificate verification.

The cause: The lack of both the symlinks of certificates and rehashed symlinks to the certificates in `/etc/ssl/certs` that point to the certificates introduced by package "ca-certificates" and the symlink pointing to the ca-certificates bundle crt file.

To cope with this problem, we are diverging a bit from the behaviour of the package "openssl" in focal and jammy, providing the symlink `/usr/lib/ssl/cert.pem -> /etc/ssl/certs/ca-certificates.crt` in the slice `openssl_data`. The reasons behind that are: 

1. The SSL library by default reads the local certificates firstly at the bundled certificates `cafile`, which defaults at `/usr/lib/ssl/certs.pem`, and then the single certificates in `capath` which defaults to `/usr/lib/ssl/certs`.

2. In focal and jammy, the "openssl" package does not provide a `capath` symlink `/usr/lib/ssl/certs.pem -> /etc/ssl/certs/ca-certificates.crt`. As a result, the certificates have to be read from the `capath`, which by default is `/usr/lib/ssl/certs -> /etc/ssl/certs`, wheretthe certificates from package "ca-certificates" are symbolically linked to `/etc/ssl/certs` by the script `update-ca-certificates` and rehashed with `openssl rehash` or `c_rehash` (this is automatically triggered with the maintainer scripts of the package "ca-certificates"). However, with the current specification of chisel slice definition files and starlark (the mutation script language in chisel SDF), it's not possible to fully mimic the behaviour of the maintainer scrip and the `update-ca-certificates` script in the package "ca-certificates" to calculate the hashes for the certificates and create symlinks with file name format `HHHHHHHH.D` (`H` for hex, `D` for dec) within the directory `/etc/ssl/certs`. 

3. Such symlink `/usr/lib/ssl/certs.pem -> /etc/ssl/certs/ca-certificates.crt` is provided in the package "openssl" starting from noble. It is verified to work for the same case in a rock built with a noble base.

Therefore, we providing a symlink `/usr/lib/ssl/certs.pem -> /etc/ssl/certs/ca-certificates.crt` is the only solution for now, though it deviates a bit from the behaviour of the package "openssl".

FYI: @letFunny 

## Related issues/PRs

* #257 
* ROCKS-994

### Forward porting

#273 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
