### PR TITLE
Add lib2to3 as dep of distutils for python 3.11

### DIFF
--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -6,6 +6,7 @@ essential:
 slices:
   python3-11:
     essential:
+      - python3-lib2to3_python3-10
       - python3.11_core
     contents:
       # Due to conflicts with libpython3.11-stdlib_distribution and chisel not being able to


### PR DESCRIPTION
# Proposed changes
2 modules of `python3-distutils` using Python3.11 depends on `python3-lib2to3` even if not used by upstream `python3.11-venv` this could break some usecase.
Therefore I added python3-lib2to3 as dependency for Python3.11 in python3-distutils

## Related issues/PRs
Related to: https://github.com/canonical/chisel-releases/pull/259

### Forward porting
python3-distutils doesn't exists anymore in Python3.12 using by Ubuntu 24.04

## Testing
N/A

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
N/A