### PR TITLE
Draft: feat(22.04): Slicing python3.10-venv and python3.10

### DIFF
--- a/slices/libpython3.10-minimal.yaml
+++ b/slices/libpython3.10-minimal.yaml
@@ -1,0 +1,121 @@
+package: libpython3.10-minimal
+
+# Most of the python3.10 standard libraries are split into
+# two major packages:
+# - libpython3.10-minimal (this one)
+# - libpython3.10-stdlib
+# While the libpython3.10-stdlib package has been chiselled logically
+# into granular slices, the same hasn't been done for this package.
+# The reason is simple, the libraries in this package are tightly
+# dependent upon each other.
+essential:
+  - libpython3.10-minimal_copyright
+
+slices:
+  config:
+    contents:
+      /etc/python3.10/sitecustomize.py:
+
+  libs:
+    essential:
+      - libc6_libs
+      - libpython3.10-minimal_config
+      - libssl3_libs
+    contents:
+      /usr/lib/python3.10/__future__.py:
+      /usr/lib/python3.10/_collections_abc.py:
+      /usr/lib/python3.10/_compat_pickle.py:
+      /usr/lib/python3.10/_py_abc.py:
+      /usr/lib/python3.10/_sitebuiltins.py:
+      /usr/lib/python3.10/_strptime.py:
+      /usr/lib/python3.10/_sysconfigdata__*-linux-*.py:
+      /usr/lib/python3.10/_threading_local.py:
+      /usr/lib/python3.10/_weakrefset.py:
+      /usr/lib/python3.10/abc.py:
+      /usr/lib/python3.10/argparse.py:
+      /usr/lib/python3.10/ast.py:
+      /usr/lib/python3.10/base64.py:
+      /usr/lib/python3.10/bisect.py:
+      /usr/lib/python3.10/calendar.py:
+      /usr/lib/python3.10/codecs.py:
+      /usr/lib/python3.10/collections/**:
+      /usr/lib/python3.10/compileall.py:
+      /usr/lib/python3.10/configparser.py:
+      /usr/lib/python3.10/contextlib.py:
+      /usr/lib/python3.10/copy.py:
+      /usr/lib/python3.10/copyreg.py:
+      /usr/lib/python3.10/csv.py:
+      /usr/lib/python3.10/datetime.py:
+      /usr/lib/python3.10/dis.py:
+      /usr/lib/python3.10/email/**:
+      /usr/lib/python3.10/encodings/**:
+      /usr/lib/python3.10/enum.py:
+      /usr/lib/python3.10/filecmp.py:
+      /usr/lib/python3.10/fnmatch.py:
+      /usr/lib/python3.10/functools.py:
+      /usr/lib/python3.10/genericpath.py:
+      /usr/lib/python3.10/getopt.py:
+      /usr/lib/python3.10/glob.py:
+      /usr/lib/python3.10/hashlib.py:
+      /usr/lib/python3.10/heapq.py:
+      /usr/lib/python3.10/imp.py:
+      /usr/lib/python3.10/importlib/**:
+      /usr/lib/python3.10/inspect.py:
+      /usr/lib/python3.10/io.py:
+      /usr/lib/python3.10/ipaddress.py:
+      /usr/lib/python3.10/keyword.py:
+      /usr/lib/python3.10/lib-dynload/_hashlib.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_opcode.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_ssl.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/linecache.py:
+      /usr/lib/python3.10/locale.py:
+      /usr/lib/python3.10/logging/**:
+      /usr/lib/python3.10/opcode.py:
+      /usr/lib/python3.10/operator.py:
+      /usr/lib/python3.10/optparse.py:
+      /usr/lib/python3.10/os.py:
+      /usr/lib/python3.10/pathlib.py:
+      /usr/lib/python3.10/pickle.py:
+      /usr/lib/python3.10/pkgutil.py:
+      /usr/lib/python3.10/platform.py:
+      /usr/lib/python3.10/posixpath.py:
+      /usr/lib/python3.10/py_compile.py:
+      /usr/lib/python3.10/quopri.py:
+      /usr/lib/python3.10/random.py:
+      /usr/lib/python3.10/re.py:
+      /usr/lib/python3.10/reprlib.py:
+      /usr/lib/python3.10/runpy.py:
+      /usr/lib/python3.10/selectors.py:
+      /usr/lib/python3.10/signal.py:
+      /usr/lib/python3.10/site.py:
+      /usr/lib/python3.10/sitecustomize.py:
+      /usr/lib/python3.10/socket.py:
+      /usr/lib/python3.10/sre_compile.py:
+      /usr/lib/python3.10/sre_constants.py:
+      /usr/lib/python3.10/sre_parse.py:
+      /usr/lib/python3.10/ssl.py:
+      /usr/lib/python3.10/stat.py:
+      /usr/lib/python3.10/string.py:
+      /usr/lib/python3.10/stringprep.py:
+      /usr/lib/python3.10/struct.py:
+      /usr/lib/python3.10/subprocess.py:
+      /usr/lib/python3.10/sysconfig.py:
+      /usr/lib/python3.10/tempfile.py:
+      /usr/lib/python3.10/textwrap.py:
+      /usr/lib/python3.10/threading.py:
+      /usr/lib/python3.10/token.py:
+      /usr/lib/python3.10/tokenize.py:
+      /usr/lib/python3.10/traceback.py:
+      /usr/lib/python3.10/tracemalloc.py:
+      /usr/lib/python3.10/types.py:
+      /usr/lib/python3.10/typing.py:
+      /usr/lib/python3.10/urllib/**:
+      /usr/lib/python3.10/uu.py:
+      /usr/lib/python3.10/warnings.py:
+      /usr/lib/python3.10/weakref.py:
+      /usr/lib/python3.10/zipfile.py:
+      /usr/lib/python3.10/zipimport.py:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpython3.10-minimal/copyright:

--- a/slices/libpython3.10-stdlib.yaml
+++ b/slices/libpython3.10-stdlib.yaml
@@ -166,6 +166,7 @@ slices:
       /usr/lib/python3.10/doctest.py:
       /usr/lib/python3.10/lib-dynload/_testbuffer.cpython-310-*-linux-*.so:
       /usr/lib/python3.10/lib-dynload/_testcapi.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_testclinic.cpython-310-*-linux-*.so:
       /usr/lib/python3.10/lib-dynload/_testimportmultiple.cpython-310-*-linux-*.so:
       /usr/lib/python3.10/lib-dynload/_testinternalcapi.cpython-310-*-linux-*.so:
       /usr/lib/python3.10/lib-dynload/_testmultiphase.cpython-310-*-linux-*.so:

--- a/slices/libpython3.10-stdlib.yaml
+++ b/slices/libpython3.10-stdlib.yaml
@@ -1,0 +1,396 @@
+package: libpython3.10-stdlib
+
+# The slices in this package have been grouped with inspiration from the
+# Python 3.10 Standard Library
+# (https://docs.python.org/3.10/library/index.html).
+#
+# Aside from the "core" slice which contains the minimal libraries that
+# should come from this package and the "extra" slice which contains
+# miscellaneous libraries, all the other slice definitions are sorted by
+# their names. The "core" slice is placed at the very beginning and the
+# "extra" slice at the very end.
+slices:
+  # The "core" slice provides a very minimal libpython3.10-stdlib
+  core:
+    essential:
+      - libbz2-1.0_libs
+      - libc6_libs
+      - liblzma5_libs
+      - libpython3.10-minimal_libs
+      - media-types_data
+    contents:
+      /usr/lib/python3.10/_bootsubprocess.py:
+      /usr/lib/python3.10/_compression.py:
+      /usr/lib/python3.10/bz2.py:
+      /usr/lib/python3.10/contextvars.py:
+      /usr/lib/python3.10/dataclasses.py:
+      /usr/lib/python3.10/gettext.py:
+      /usr/lib/python3.10/gzip.py:
+      /usr/lib/python3.10/http/__init__.py:
+      /usr/lib/python3.10/http/client.py:
+      /usr/lib/python3.10/lib-dynload/_bz2.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_codecs_*.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_contextvars.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_lzma.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_multibytecodec.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_queue.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/mmap.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lzma.py:
+      /usr/lib/python3.10/mimetypes.py:
+      /usr/lib/python3.10/ntpath.py:
+      /usr/lib/python3.10/queue.py:
+      /usr/lib/python3.10/shutil.py:
+      /usr/lib/python3.10/socketserver.py:
+      /usr/lib/python3.10/tarfile.py:
+
+  # Shared AIX (IBM) support functions
+  aix-support:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/_aix_support.py:
+
+  # Generic Operating System Services
+  # https://docs.python.org/3.10/library/allos.html
+  all-os:
+    essential:
+      - libffi8_libs
+      - libncursesw6_libs
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_unix
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.10/_pyio.py:
+      /usr/lib/python3.10/ctypes/**:
+      /usr/lib/python3.10/curses/**:
+      /usr/lib/python3.10/getpass.py:
+      /usr/lib/python3.10/lib-dynload/_ctypes*.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_curses*.cpython-310-*-linux-*.so:
+
+  # Concurrent Execution
+  # https://docs.python.org/3.10/library/concurrency.html
+  concurrency:
+    essential:
+      - libpython3.10-stdlib_all-os
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_crypto
+    contents:
+      /usr/lib/python3.10/concurrent/**:
+      /usr/lib/python3.10/lib-dynload/_multiprocessing.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_posixshmem.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/multiprocessing/**:
+      /usr/lib/python3.10/sched.py:
+
+  # Cryptographic Services
+  # https://docs.python.org/3.10/library/crypto.html
+  crypto:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/hmac.py:
+      /usr/lib/python3.10/secrets.py:
+
+  # Custom Python Interpreters
+  # https://docs.python.org/3.10/library/custominterp.html
+  custom-interpreters:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_text
+    contents:
+      /usr/lib/python3.10/code.py:
+      /usr/lib/python3.10/codeop.py:
+
+  # Data Persistence
+  # https://docs.python.org/3.10/library/persistence.html
+  data-persistence:
+    essential:
+      - libdb5.3_libs
+      - libpython3.10-stdlib_core
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/python3.10/dbm/**:
+      /usr/lib/python3.10/lib-dynload/_dbm.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_sqlite3.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/shelve.py:
+      /usr/lib/python3.10/sqlite3/**:
+
+  # Data Types
+  # https://docs.python.org/3.10/library/datatypes.html
+  data-types:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/graphlib.py:
+      /usr/lib/python3.10/lib-dynload/_zoneinfo.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/pprint.py:
+      /usr/lib/python3.10/zoneinfo/**:
+
+  # Debugging and Profiling
+  # https://docs.python.org/3.10/library/debug.html
+  debug:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_custom-interpreters
+      - libpython3.10-stdlib_data-types
+      - libpython3.10-stdlib_frameworks
+      - libpython3.10-stdlib_text
+    contents:
+      /usr/lib/python3.10/bdb.py:
+      /usr/lib/python3.10/cProfile.py:
+      /usr/lib/python3.10/lib-dynload/_lsprof.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/pdb.py:
+      /usr/lib/python3.10/profile.py:
+      /usr/lib/python3.10/pstats.py:
+      /usr/lib/python3.10/timeit.py:
+      /usr/lib/python3.10/trace.py:
+
+  # Development Tools
+  # https://docs.python.org/3.10/library/development.html
+  development-tools:
+    essential:
+      - libpython3.10-stdlib_all-os
+      - libpython3.10-stdlib_concurrency
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_data-types
+      - libpython3.10-stdlib_debug
+      - libpython3.10-stdlib_distribution
+      - libpython3.10-stdlib_internet
+      - libpython3.10-stdlib_ipc
+      - libpython3.10-stdlib_markup-tools
+      - libpython3.10-stdlib_net-data
+      - libpython3.10-stdlib_numeric
+      - libpython3.10-stdlib_text
+      - libpython3.10-stdlib_unix
+    contents:
+      /usr/lib/python3.10/__phello__.foo.py:
+      /usr/lib/python3.10/doctest.py:
+      /usr/lib/python3.10/lib-dynload/_testbuffer.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_testcapi.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_testimportmultiple.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_testinternalcapi.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_testmultiphase.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_xxsubinterpreters.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/_xxtestfuzz.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/xxlimited.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/xxlimited_35.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/test/**:
+      /usr/lib/python3.10/unittest/**:
+
+  # Software Packaging and Distribution
+  # https://docs.python.org/3.10/library/distribution.html
+  distribution:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_osx-support
+    contents:
+      /usr/lib/python3.10/_distutils_system_mod.py:
+      # Due to conflicts with python3-distutils_python3.10 and chisel not being able to
+      # reconcile 2 slices with globs on the same folder, I have to specify the files explicitly
+      /usr/lib/python3.10/distutils/__init__.py:
+      /usr/lib/python3.10/distutils/version.py:
+      /usr/lib/python3.10/venv/**:
+      /usr/lib/python3.10/zipapp.py:
+
+  # File Formats
+  # https://docs.python.org/3.10/library/fileformats.html
+  file-formats:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_frameworks
+      - libpython3.10-stdlib_markup-tools
+    contents:
+      /usr/lib/python3.10/netrc.py:
+      /usr/lib/python3.10/plistlib.py:
+      /usr/lib/python3.10/xdrlib.py:
+
+  # File and Directory Access
+  # https://docs.python.org/3.10/library/filesys.html
+  filesys:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/fileinput.py:
+
+  # Program Frameworks
+  # https://docs.python.org/3.10/library/frameworks.html
+  frameworks:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_text
+    contents:
+      /usr/lib/python3.10/cmd.py:
+      /usr/lib/python3.10/shlex.py:
+      /usr/lib/python3.10/turtle.py:
+
+  # Importing Modules
+  # https://docs.python.org/3.10/library/modules.html
+  importing:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/modulefinder.py:
+
+  # Internet Protocols and Support
+  # https://docs.python.org/3.10/library/internet.html
+  internet:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_crypto
+      - libpython3.10-stdlib_file-formats
+      - libpython3.10-stdlib_frameworks
+      - libpython3.10-stdlib_ipc
+      - libpython3.10-stdlib_markup-tools
+      - libpython3.10-stdlib_numeric
+      - libpython3.10-stdlib_pydoc
+      - libuuid1_libs
+    contents:
+      /usr/lib/python3.10/cgi.py:
+      /usr/lib/python3.10/cgitb.py:
+      /usr/lib/python3.10/ftplib.py:
+      /usr/lib/python3.10/http/cookiejar.py:
+      /usr/lib/python3.10/http/cookies.py:
+      /usr/lib/python3.10/http/server.py:
+      /usr/lib/python3.10/imaplib.py:
+      /usr/lib/python3.10/lib-dynload/_uuid.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/nntplib.py:
+      /usr/lib/python3.10/nturl2path.py:
+      /usr/lib/python3.10/poplib.py:
+      /usr/lib/python3.10/smtpd.py:
+      /usr/lib/python3.10/smtplib.py:
+      /usr/lib/python3.10/telnetlib.py:
+      /usr/lib/python3.10/uuid.py:
+      /usr/lib/python3.10/webbrowser.py:
+      /usr/lib/python3.10/wsgiref/**:
+      /usr/lib/python3.10/xmlrpc/**:
+
+  # Networking and Interprocess Communication
+  # https://docs.python.org/3.10/library/ipc.html
+  ipc:
+    essential:
+      - libpython3.10-stdlib_concurrency
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/asynchat.py:
+      /usr/lib/python3.10/asyncio/**:
+      /usr/lib/python3.10/asyncore.py:
+      /usr/lib/python3.10/lib-dynload/_asyncio.cpython-310-*-linux-*.so:
+
+  # Python Language Services
+  # https://docs.python.org/3.10/library/language.html
+  language:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/pickletools.py:
+      /usr/lib/python3.10/pyclbr.py:
+      /usr/lib/python3.10/symtable.py:
+      /usr/lib/python3.10/tabnanny.py:
+
+  # Structured Markup Processing Tools (HTML, XML)
+  # https://docs.python.org/3.10/library/markup.html
+  markup-tools:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/_markupbase.py:
+      /usr/lib/python3.10/html/**:
+      /usr/lib/python3.10/xml/**:
+
+  # Multimedia Services
+  # https://docs.python.org/3.10/library/mm.html
+  multimedia:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/aifc.py:
+      /usr/lib/python3.10/chunk.py:
+      /usr/lib/python3.10/colorsys.py:
+      /usr/lib/python3.10/imghdr.py:
+      /usr/lib/python3.10/lib-dynload/audioop.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/ossaudiodev.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/sndhdr.py:
+      /usr/lib/python3.10/sunau.py:
+      /usr/lib/python3.10/wave.py:
+
+  # Internet Data Handling
+  # https://docs.python.org/3.10/library/netdata.html
+  net-data:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/json/**:
+      /usr/lib/python3.10/lib-dynload/_json.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/mailbox.py:
+      /usr/lib/python3.10/mailcap.py:
+
+  # Numeric and Mathematical Modules
+  # https://docs.python.org/3.10/library/numeric.html
+  numeric:
+    essential:
+      - libmpdec3_libs
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/_pydecimal.py:
+      /usr/lib/python3.10/decimal.py:
+      /usr/lib/python3.10/fractions.py:
+      /usr/lib/python3.10/lib-dynload/_decimal.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/numbers.py:
+      /usr/lib/python3.10/statistics.py:
+
+  # Shared OS X support functions
+  osx-support:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/_osx_support.py:
+      /usr/lib/python3.10/binhex.py:
+
+  # pydoc - Documentation generator and online help system
+  # https://docs.python.org/3.10/library/pydoc.html
+  pydoc:
+    essential:
+      - libpython3.10-stdlib_core
+    contents:
+      /usr/lib/python3.10/pydoc.py:
+      /usr/lib/python3.10/pydoc_data/**:
+
+  # Text Processing Services
+  # https://docs.python.org/3.10/library/text.html
+  text:
+    essential:
+      - libpython3.10-stdlib_core
+      - libreadline8_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.10/difflib.py:
+      /usr/lib/python3.10/lib-dynload/readline.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/rlcompleter.py:
+
+  # Unix Specific Services
+  # https://docs.python.org/3.10/library/unix.html
+  unix:
+    essential:
+      - libcrypt1_libs
+      - libnsl2_libs
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_frameworks
+      - libtirpc3_libs
+    contents:
+      /usr/lib/python3.10/crypt.py:
+      /usr/lib/python3.10/lib-dynload/_crypt.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/nis.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/resource.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/lib-dynload/termios.cpython-310-*-linux-*.so:
+      /usr/lib/python3.10/pipes.py:
+      /usr/lib/python3.10/pty.py:
+      /usr/lib/python3.10/tty.py:
+
+  # Outliers and Deprecated Modules
+  # The "extra" slice consists of easter-eggs and deprecated modules
+  extras:
+    essential:
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_internet
+    contents:
+      /usr/lib/python3.10/antigravity.py:
+      /usr/lib/python3.10/this.py:

--- a/slices/python3-distutils.yaml
+++ b/slices/python3-distutils.yaml
@@ -95,9 +95,58 @@ slices:
   python3-10:
     essential:
       - python3-lib2to3_python3-10
+      - python3.10_core
     contents:
-      /usr/lib/python3.10/distutils/*.py:
-      /usr/lib/python3.10/distutils/command/*.py:
+      # Due to conflicts with libpython3.10-stdlib_distribution and chisel not being able to
+      # reconcile 2 slices with globs on the same folder, I have to specify the files explicitly.
+      /usr/lib/python3.10/distutils/_msvccompiler.py:
+      /usr/lib/python3.10/distutils/archive_util.py:
+      /usr/lib/python3.10/distutils/bcppcompiler.py:
+      /usr/lib/python3.10/distutils/ccompiler.py:
+      /usr/lib/python3.10/distutils/cmd.py:
+      /usr/lib/python3.10/distutils/command/__init__.py:
+      /usr/lib/python3.10/distutils/command/bdist.py:
+      /usr/lib/python3.10/distutils/command/bdist_dumb.py:
+      /usr/lib/python3.10/distutils/command/bdist_rpm.py:
+      /usr/lib/python3.10/distutils/command/build.py:
+      /usr/lib/python3.10/distutils/command/build_clib.py:
+      /usr/lib/python3.10/distutils/command/build_ext.py:
+      /usr/lib/python3.10/distutils/command/build_py.py:
+      /usr/lib/python3.10/distutils/command/build_scripts.py:
+      /usr/lib/python3.10/distutils/command/check.py:
+      /usr/lib/python3.10/distutils/command/clean.py:
+      /usr/lib/python3.10/distutils/command/command_template:
+      /usr/lib/python3.10/distutils/command/config.py:
+      /usr/lib/python3.10/distutils/command/install.py:
+      /usr/lib/python3.10/distutils/command/install_data.py:
+      /usr/lib/python3.10/distutils/command/install_egg_info.py:
+      /usr/lib/python3.10/distutils/command/install_headers.py:
+      /usr/lib/python3.10/distutils/command/install_lib.py:
+      /usr/lib/python3.10/distutils/command/install_scripts.py:
+      /usr/lib/python3.10/distutils/command/register.py:
+      /usr/lib/python3.10/distutils/command/sdist.py:
+      /usr/lib/python3.10/distutils/command/upload.py:
+      /usr/lib/python3.10/distutils/config.py:
+      /usr/lib/python3.10/distutils/core.py:
+      /usr/lib/python3.10/distutils/cygwinccompiler.py:
+      /usr/lib/python3.10/distutils/debug.py:
+      /usr/lib/python3.10/distutils/dep_util.py:
+      /usr/lib/python3.10/distutils/dir_util.py:
+      /usr/lib/python3.10/distutils/dist.py:
+      /usr/lib/python3.10/distutils/errors.py:
+      /usr/lib/python3.10/distutils/extension.py:
+      /usr/lib/python3.10/distutils/fancy_getopt.py:
+      /usr/lib/python3.10/distutils/file_util.py:
+      /usr/lib/python3.10/distutils/filelist.py:
+      /usr/lib/python3.10/distutils/log.py:
+      /usr/lib/python3.10/distutils/msvc9compiler.py:
+      /usr/lib/python3.10/distutils/msvccompiler.py:
+      /usr/lib/python3.10/distutils/spawn.py:
+      /usr/lib/python3.10/distutils/sysconfig.py:
+      /usr/lib/python3.10/distutils/text_file.py:
+      /usr/lib/python3.10/distutils/unixccompiler.py:
+      /usr/lib/python3.10/distutils/util.py:
+      /usr/lib/python3.10/distutils/versionpredicate.py:
 
   copyright:
     contents:

--- a/slices/python3.10-minimal.yaml
+++ b/slices/python3.10-minimal.yaml
@@ -1,0 +1,22 @@
+package: python3.10-minimal
+
+essential:
+  - python3.10-minimal_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libexpat1_libs
+      - libpython3.10-minimal_libs
+      - zlib1g_libs
+    contents:
+      /usr/bin/python3.10:
+      # The next two directories are created to mimic the behaviour in
+      # the "postinst" script.
+      /usr/local/lib/python3.10/: {make: true, mode: 02775}
+      /usr/local/lib/python3.10/dist-packages/: {make: true, mode: 02775}
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.10-minimal/copyright:

--- a/slices/python3.10-venv.yaml
+++ b/slices/python3.10-venv.yaml
@@ -1,0 +1,11 @@
+package: python3.10-venv
+
+slices:
+  ensurepip:
+    essential:
+      - python3-distutils_python3-10
+      - python3-pip-whl_wheels
+      - python3-setuptools-whl_wheels
+      - python3.10_standard
+    contents:
+      /usr/lib/python3.10/ensurepip/*.py:

--- a/slices/python3.10.yaml
+++ b/slices/python3.10.yaml
@@ -1,0 +1,61 @@
+package: python3.10
+
+essential:
+  - python3.10_copyright
+
+slices:
+  # The "core" slice provides a very minimal, yet functioning python3.10.
+  # It includes very few modules from the libpython3.10-stdlib package.
+  core:
+    essential:
+      - libpython3.10-stdlib_core
+      - media-types_data
+      - python3.10-minimal_bins
+
+  # The "standard" slice extends "core" with all the Python
+  # modules from the libpython3.10-stdlib package.
+  standard:
+    essential:
+      - libpython3.10-stdlib_aix-support
+      - libpython3.10-stdlib_all-os
+      - libpython3.10-stdlib_concurrency
+      - libpython3.10-stdlib_core
+      - libpython3.10-stdlib_crypto
+      - libpython3.10-stdlib_custom-interpreters
+      - libpython3.10-stdlib_data-persistence
+      - libpython3.10-stdlib_data-types
+      - libpython3.10-stdlib_debug
+      - libpython3.10-stdlib_development-tools
+      - libpython3.10-stdlib_distribution
+      - libpython3.10-stdlib_extras
+      - libpython3.10-stdlib_file-formats
+      - libpython3.10-stdlib_filesys
+      - libpython3.10-stdlib_frameworks
+      - libpython3.10-stdlib_importing
+      - libpython3.10-stdlib_internet
+      - libpython3.10-stdlib_ipc
+      - libpython3.10-stdlib_language
+      - libpython3.10-stdlib_markup-tools
+      - libpython3.10-stdlib_multimedia
+      - libpython3.10-stdlib_net-data
+      - libpython3.10-stdlib_numeric
+      - libpython3.10-stdlib_osx-support
+      - libpython3.10-stdlib_pydoc
+      - libpython3.10-stdlib_text
+      - libpython3.10-stdlib_unix
+      - python3.10_core
+
+  # The "utlis" slice extends "core" with various tools.
+  utils:
+    essential:
+      - libpython3.10-stdlib_debug
+      - libpython3.10-stdlib_pydoc
+      - python3.10_core
+    contents:
+      /usr/bin/pdb3.10:
+      /usr/bin/pydoc3.10:
+      /usr/bin/pygettext3.10:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.10/copyright:


### PR DESCRIPTION
# Proposed changes
Adding python3.10-venv chiseled package and its dependency, including python3.10
The aim is to be able to use the python plugin on rockcraft entirely with chiseled packages, allowing very small OCI images for python applications.

## Related issues/PRs
N/A

### Forward porting
Python3.12 is available on Noble and is the default Python version for noble

## Testing
To test in a VM, start an `ubuntu-22.04`, copy this branch into `/home/chisel` folder (or mount it):
```bash
apt update && apt install -y golang-1.22 ca-certificates
update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 0
go install github.com/canonical/chisel/cmd/chisel@latest
/root/go/bin/chisel cut --release /home/chisel/ --root / python3.10-venv_ensurepip
cd ~
mkdir test
cd test
python3.10 -m venv env
echo "flask" > requirements.txt
source env/bin/activate
pip install -r requirements.txt
```

To test using rockcraft use the following `rockcraft.yaml` at the root of this repository folder
```yaml
name: python-venv
title: python-venv
version: '0.1'
summary: Testing python3.10-venv slice in bare
description: |
  Testing python3.10-venv slice in bare
base: bare
build-base: ubuntu@22.04
platforms:
  amd64:
parts:
  chisel:
    plugin: dump
    source: .
    override-build: |
      chisel cut --release ./ --root ${CRAFT_PART_INSTALL} python3.10-venv_ensurepip
  slices:
    plugin: nil
    override-build: mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp
    stage-packages:
    - bash_bins
    - coreutils_bins
    - ca-certificates_data
run-user: _daemon_
```
You'll need `rockcraft` snap installed, and `docker` installed:
```bash
rockcraft pack
rockcraft.skopeo copy --insecure-policy oci-archive:python-venv_0.1_amd64.rock docker-daemon:python-venv:test
docker run --name test -d python-venv:test
docker exec -ti test bash
cd ~
mkdir test
cd test
python3.10 -m venv env
echo "flask" > requirements.txt
source env/bin/activate
pip install -r requirements.txt
```

## Checklist
* [X] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [X] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
This a followup PR of https://github.com/canonical/chisel-releases/pull/259 as Python3.11 is a `universe` package, running a release candidate of Python3.11. We wanted to have a sliced Python version relying on a maintained package.