### PR TITLE
ci(spread): add reusable workflow for Spread tests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -1,0 +1,69 @@
+name: Spread
+run-name: Spread for ${{ github.ref }}
+
+on:
+  workflow_call:
+
+jobs:
+  spread-tests:
+    name: Run Spread tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Check changed paths
+        id: changed-slices
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            slices:
+              - added|modified: 'slices/**/*.yaml'
+          list-files: shell
+      
+      - name: Check changed test directories
+        uses: tj-actions/changed-files@v35
+        id: changed-tests
+        with:
+          separator: " "
+          dir_names: "true"
+          files: |
+            tests/spread/integration/**
+
+      - uses: actions/checkout@v4
+        with:
+          repository: snapcore/spread
+          path: _spread
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Prepare Spread suites
+        id: spread-suites
+        env:
+          integration-tests: "tests/spread/integration"
+        run: |
+          set -ex
+          spread_tasks=""
+          for file in ${{ steps.changed-slices.outputs.slices_files }} ${{ steps.changed-tests.outputs.all_changed_files }}
+          do
+            pkg_name=$(basename $file | sed 's/\.yaml//g')
+            pkg_tests="${{ env.integration-tests }}/${pkg_name}"
+            if [ -f "${pkg_tests}/task.yaml" ] && [[ $spread_tasks != *"${pkg_tests}"* ]]
+            then
+              spread_tasks="${spread_tasks} ${pkg_tests}"
+            fi
+          done
+
+          echo "run-tasks=$(echo ${spread_tasks} | awk '{$1=$1};1')" >> $GITHUB_OUTPUT
+
+      - name: Build and run spread
+        run: |
+          (cd _spread/cmd/spread && go build)
+          _spread/cmd/spread/spread -v ${{ steps.spread-suites.outputs.run-tasks }}


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR introduces a new reusable GitHub workflow for running Spread tests. 

Each branch will have its own `spread.yaml` configuration, and this workflow will be called from the branches, on every PR. 

The tests shall only run for:
 - the SDFs which are added or modified
 - the tests which are added or modified 

## Testing

Tested the execution of this workflow here:
 - https://github.com/cjdcordeiro/chisel-releases/pull/11 (with additional mock commits to ensure the logic works when filtering the added and modified files)
 - https://github.com/cjdcordeiro/chisel-releases/pull/13

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

