### PR TITLE
ci(spread): support slice testing through Spread

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,3 +19,7 @@ jobs:
   lint:
     name: Lint
     uses: canonical/chisel-releases/.github/workflows/lint.yaml@main
+
+  integration-tests:
+    name: Integration tests
+    uses: canonical/chisel-releases/.github/workflows/spread.yaml@main

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# ubuntu-24.04
+
+This is the `ubuntu-24.04` Chisel release.
+
+To learn more about Chisel, Chisel releases and how to contribute to this
+branch, please read
+[this](https://github.com/canonical/chisel-releases/blob/main/README.md).

--- a/slices/libpython3.12-stdlib.yaml
+++ b/slices/libpython3.12-stdlib.yaml
@@ -15,6 +15,13 @@ slices:
     essential:
       - libbz2-1.0_libs
       - libc6_libs
+      # Adding libgcc-s1 here because it is required for the arm arch.
+      # In practice, libc6 should bring it anyway, BUT, there is a circular
+      # dependency in the archives, where libc6 depends on libgcc-s1 and
+      # vice versa. We don't allow that circular dependency to exist in Chisel
+      # and libgcc-s1 already depends on libc6, so we'll have to include this
+      # line here, explicitly.
+      - libgcc-s1_libs
       - liblzma5_libs
       - libpython3.12-minimal_libs
       - media-types_data

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,74 @@
+project: chisel-releases
+
+path: /chisel-releases
+
+environment:
+  PROJECT_PATH: /chisel-releases
+  SHARED_LIBRARIES: $PROJECT_PATH/tests/spread/lib
+  PATH: /snap/bin:$PATH:$SHARED_LIBRARIES
+
+exclude:
+  - .github
+
+backends:
+  docker:
+    type: adhoc
+    allocate: |
+      echo "Allocating $SPREAD_SYSTEM..."
+      docker_image=$(echo $SPREAD_SYSTEM | awk -F '-' '{print $1":"$2}')
+      docker_arch=$(echo $SPREAD_SYSTEM | awk -F '-' '{print $NF}')
+      docker run --rm -e DEBIAN_FRONTEND=noninteractice \
+        -e usr=$SPREAD_SYSTEM_USERNAME -e pass=$SPREAD_SYSTEM_PASSWORD \
+        --name $SPREAD_SYSTEM -d $docker_arch/$docker_image sh -c '
+        set -x
+        apt update
+        apt install -y openssh-server sudo
+        mkdir /run/sshd
+        echo "root:$pass" | chpasswd
+        echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+        /usr/sbin/sshd -D
+      '
+      # The container will be up really fast, but the CMD might take time to
+      # run, and Spread will timeout the SSH op after 5 min. So we wait for the
+      # container during the allocation script.
+      until docker exec $SPREAD_SYSTEM pgrep sshd
+      do
+        sleep 5
+      done
+      ADDRESS `docker inspect $SPREAD_SYSTEM --format '{{.NetworkSettings.Networks.bridge.IPAddress}}'`
+    discard: docker rm -f $SPREAD_SYSTEM
+    systems:
+      - ubuntu-24.04-amd64:
+          password: ubuntu
+      - ubuntu-24.04-arm64v8:
+          password: ubuntu
+      - ubuntu-24.04-arm32v7:
+          password: ubuntu
+      - ubuntu-24.04-ppc64le:
+          password: ubuntu
+      - ubuntu-24.04-s390x:
+          password: ubuntu
+      # Re-enable risvc64 once we have re-enabled this arch for the Ubuntu container
+      # - ubuntu-24.04-riscv64:
+      #     password: ubuntu
+
+prepare: |
+  # Deb arch to GOARCH
+  arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/g' -e 's/ppc64el/ppc64le/g')"
+  chisel_tar="chisel.tar.gz"
+
+  apt install -y curl wget
+  curl -s https://api.github.com/repos/canonical/chisel/releases/latest \
+    | awk "/browser_download_url/ && /chisel_v/ && /$arch/" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | xargs wget -O $chisel_tar
+
+  tar -xf $chisel_tar -C /usr/local/bin
+
+prepare-each:
+  chisel version
+
+suites:
+  tests/spread/integration/:
+    summary: Tests common scenarios

--- a/tests/spread/integration/base-passwd/task.yaml
+++ b/tests/spread/integration/base-passwd/task.yaml
@@ -1,0 +1,13 @@
+summary: Integration tests for base-passwd
+
+execute: |
+  rootfs="$(install-slices base-passwd_data)"
+    
+  test -f ${rootfs}/etc/group
+  ! grep FIXME ${rootfs}/etc/group
+
+  test -f ${rootfs}/etc/passwd
+  ! grep FIXME ${rootfs}/etc/passwd
+
+  test ! -f ${rootfs}/usr/share/base-passwd/group.master
+  test ! -f ${rootfs}/usr/share/base-passwd/passwd.master

--- a/tests/spread/integration/python3.12/task.yaml
+++ b/tests/spread/integration/python3.12/task.yaml
@@ -1,0 +1,14 @@
+summary: Integration tests for Python3.12
+
+environment:
+  SLICE/core: "core"
+  SLICE/standard: "standard"
+
+execute: |
+  # Test different slice installations
+  echo "SLICE=${SLICE}"
+
+  rootfs="$(install-slices python3.12_${SLICE})"
+
+  cp test_${SLICE}.py "${rootfs}/"
+  chroot "$rootfs" python3.12 /test_${SLICE}.py

--- a/tests/spread/integration/python3.12/test_core.py
+++ b/tests/spread/integration/python3.12/test_core.py
@@ -1,0 +1,45 @@
+"""
+Tests some of the core Python functionality
+"""
+
+import sys
+import os
+import socket
+import time
+import urllib
+import urllib.request
+
+
+def hello_world():
+    print("Hello, world!")
+
+
+def check_python_version():
+    print("Checking Python version...")
+    assert sys.version.startswith(
+        "3.12"
+    ), f"Wrong Python version installed: {sys.version}. Expected 3.12."
+
+
+def check_file_operations():
+    print("Checking file operations...")
+    filename = f"/test-file-{int(time.time())}"
+
+    with open(filename, "w") as f:
+        f.write("This is a test file.")
+    with open(filename, "r") as f:
+        content = f.read()
+    os.remove(filename)
+    print(f"File operations are working. Content: {content}")
+
+
+def check_network_operations():
+    print("Checking network operations...")
+    print(socket.gethostname())
+
+
+if __name__ == "__main__":
+    hello_world()
+    check_python_version()
+    check_file_operations()
+    check_network_operations()

--- a/tests/spread/integration/python3.12/test_core.py
+++ b/tests/spread/integration/python3.12/test_core.py
@@ -6,11 +6,12 @@ import sys
 import os
 import socket
 import time
-import urllib
-import urllib.request
 
 
 def hello_world():
+    # Asserting the stdout would require additional modules (like StringIO)
+    # that are not available in the "core" slice. So this test case only tests
+    # the functionality, but not the outcome.
     print("Hello, world!")
 
 
@@ -25,11 +26,14 @@ def check_file_operations():
     print("Checking file operations...")
     filename = f"/test-file-{int(time.time())}"
 
+    original_content = "This is a test file."
     with open(filename, "w") as f:
-        f.write("This is a test file.")
+        f.write(original_content)
     with open(filename, "r") as f:
         content = f.read()
+    assert content == original_content
     os.remove(filename)
+    assert not os.path.exists(filename)
     print(f"File operations are working. Content: {content}")
 
 

--- a/tests/spread/integration/python3.12/test_standard.py
+++ b/tests/spread/integration/python3.12/test_standard.py
@@ -1,0 +1,35 @@
+"""
+Tests some of the standard Python functionality
+"""
+
+import html
+import json
+import urllib
+import uuid
+
+
+def check_json_loading():
+    print("Checking JSON loading...")
+
+    sample = '{"foo": ["bar"]}'
+    assert json.loads(sample) == {"foo": ["bar"]}
+
+
+def check_html_escaping():
+    print("Checking HTML escaping...")
+
+    sample = "Some <sample> & 'text' with \"HTML\" characters"
+    exp = "Some &lt;sample&gt; &amp; &#x27;text&#x27; with &quot;HTML&quot; characters"
+    assert html.escape(sample) == exp
+
+
+def check_uuid_gen():
+    print("Checking UUID generation...")
+
+    assert type(uuid.uuid1().int) == int
+
+
+if __name__ == "__main__":
+    check_json_loading()
+    check_html_escaping()
+    check_uuid_gen()

--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# Installs one or more slices into a dynamically created temporary path.
+# Usage: install-slices [<slice>...]
+# Returns the path of the chiselled rootfs
+
+tmpdir="$(mktemp -d)"
+
+echo "${tmpdir}"
+chisel cut --release "$PROJECT_PATH" --root "$tmpdir" $@


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

needs https://github.com/canonical/chisel-releases/pull/280

This PR adds the Spread configurations to this branch. It also adds a couple of initial tests for existing package slices.

In addition, it also fixes a missing dependency for Python3.12 on armhf (identified via the tests :smile: )

## Related issues/PRs

 https://github.com/canonical/chisel-releases/pull/280

## Testing
Tested the execution of this workflow here:
 - https://github.com/cjdcordeiro/chisel-releases/pull/11 (with additional mock commits to ensure the logic works when filtering the added and modified files)
 - https://github.com/cjdcordeiro/chisel-releases/pull/13

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
