### PR TITLE
chore: remove 23.10 from CI (EOL)

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -22,7 +22,7 @@ on:
 env:
   # Package architectures and chisel-releases branches to test on.
   ARCHES: ${{ toJson('["amd64","arm64","armhf","i386","ppc64el","riscv64","s390x"]') }}
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-23.10","ubuntu-24.04"]') }}
+  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04"]') }}
 
 jobs:
   prepare-install:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   # chisel-releases branches to lint on.
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-23.10","ubuntu-24.04"]') }}
+  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04"]') }}
 
 jobs:
   prepare-lint:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

Mantic has reached its EOL and as such its archives are no longer available for Chisel. This PR removes 23.10 from the scheduled CI tests.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
