### PR TITLE
fix(24.04): slice name non-exist in comment

### DIFF
--- a/slices/ca-certificates.yaml
+++ b/slices/ca-certificates.yaml
@@ -50,8 +50,8 @@ slices:
       - sed_bins
     contents:
       # To run update-ca-certificates without breaking the default certificates
-      # at /etc/ssl/certs/ca-certificates.crt, the `_data-with-certs` slice should
-      # also be included. For details, see the `update-ca-certificates` script.
+      # at /etc/ssl/certs/ca-certificates.crt, the `_data` slice should also be
+      # included. For details, see the `update-ca-certificates` script.
       /usr/sbin/update-ca-certificates:
 
   copyright:


### PR DESCRIPTION
# Proposed changes

Fix non-existing slice name in the slice definition file of `ca-certificates`.

## Related issues/PRs
#285 

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)