### PR TITLE
ci(spread): fix checkout ref

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Check changed paths
         id: changed-slices


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

The Spread workflow was using the head repo at checkout time, which means the files diff was being calculated against the forked repository instead of the upstream `chisel-releases`. The consequence of that is that we could get:
 - bad Spread diffs and executions if the fork is out of date
 - Spread CI errors if the fork does not have the base branch (e.g.: https://github.com/canonical/chisel-releases/actions/runs/10076017309/job/27855492015)

This PR fixes the Spread CI checkout.

## Testing
<!-- Provide proof of testing and/or testing instructions, when applicable,
to help speed up the review process. -->
Tested:
 - https://github.com/cjdcordeiro/chisel-releases/actions/runs/10076340176/job/27856511632?pr=15 and
 - https://github.com/cjdcordeiro/chisel-releases/actions/runs/10076339238/job/27856507877?pr=16

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
