### PR TITLE
docs: mark mantic as EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the moment, the officially supported Chisel releases are:
 - [ubuntu-23.04](https://github.com/canonical/chisel-releases/tree/ubuntu-23.04)
 \- Lunar (EOL)
 - [ubuntu-23.10](https://github.com/canonical/chisel-releases/tree/ubuntu-23.10)
-\- Mantic
+\- Mantic (EOL)
 - [ubuntu-24.04](https://github.com/canonical/chisel-releases/tree/ubuntu-24.04)
 \- Noble
 


### PR DESCRIPTION
# Proposed changes

Update README on main branch to mark mantic as EOL

## Related issues/PRs

#284

### Forward porting

Does not apply

## Testing

Does not apply

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

https://fridge.ubuntu.com/2024/06/05/ubuntu-23-10-mantic-minotaur-reaches-end-of-life-on-july-11-2024/

> Ubuntu 23.10 will reach end of life on July 11, 2024.