### PR TITLE
feat(24.04): add ffmpeg dependencies slices

### DIFF
--- a/slices/libcodec2-1.2.yaml
+++ b/slices/libcodec2-1.2.yaml
@@ -1,0 +1,15 @@
+package: libcodec2-1.2
+
+essential:
+  - libcodec2-1.2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libcodec2.so.1.2:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcodec2-1.2/copyright:

--- a/slices/libdatrie1.yaml
+++ b/slices/libdatrie1.yaml
@@ -1,0 +1,15 @@
+package: libdatrie1
+
+essential:
+  - libdatrie1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libdatrie.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdatrie1/copyright:

--- a/slices/libdav1d7.yaml
+++ b/slices/libdav1d7.yaml
@@ -1,0 +1,15 @@
+package: libdav1d7
+
+essential:
+  - libdav1d7_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libdav1d.so.7*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdav1d7/copyright:

--- a/slices/libfribidi0.yaml
+++ b/slices/libfribidi0.yaml
@@ -1,0 +1,15 @@
+package: libfribidi0
+
+essential:
+  - libfribidi0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libfribidi.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfribidi0/copyright:

--- a/slices/libgraphite2-3.yaml
+++ b/slices/libgraphite2-3.yaml
@@ -1,0 +1,16 @@
+package: libgraphite2-3
+
+essential:
+  - libgraphite2-3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libgraphite2.so.2.0.0:
+      /usr/lib/*-linux-*/libgraphite2.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgraphite2-3/copyright:

--- a/slices/libgsm1.yaml
+++ b/slices/libgsm1.yaml
@@ -1,0 +1,15 @@
+package: libgsm1
+
+essential:
+  - libgsm1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libgsm.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgsm1/copyright:

--- a/slices/liblcms2-2.yaml
+++ b/slices/liblcms2-2.yaml
@@ -1,0 +1,15 @@
+package: liblcms2-2
+
+essential:
+  - liblcms2-2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblcms2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblcms2-2/copyright:

--- a/slices/libmbedcrypto7t64.yaml
+++ b/slices/libmbedcrypto7t64.yaml
@@ -1,0 +1,16 @@
+package: libmbedcrypto7t64
+
+essential:
+  - libmbedcrypto7t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libmbedcrypto.so.2.28.8:
+      /usr/lib/*-linux-*/libmbedcrypto.so.7:
+
+  copyright:
+    contents:
+      /usr/share/doc/libmbedcrypto7t64/copyright:

--- a/slices/libmpg123-0t64.yaml
+++ b/slices/libmpg123-0t64.yaml
@@ -1,0 +1,15 @@
+package: libmpg123-0t64
+
+essential:
+  - libmpg123-0t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libmpg123.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libmpg123-0t64/copyright:

--- a/slices/libogg0.yaml
+++ b/slices/libogg0.yaml
@@ -1,0 +1,15 @@
+package: libogg0
+
+essential:
+  - libogg0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libogg.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libogg0/copyright:

--- a/slices/libopenjp2-7.yaml
+++ b/slices/libopenjp2-7.yaml
@@ -1,0 +1,16 @@
+package: libopenjp2-7
+
+essential:
+  - libopenjp2-7_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libopenjp2.so.2.5.0:
+      /usr/lib/*-linux-*/libopenjp2.so.7:
+
+  copyright:
+    contents:
+      /usr/share/doc/libopenjp2-7/copyright:

--- a/slices/libserd-0-0.yaml
+++ b/slices/libserd-0-0.yaml
@@ -1,0 +1,15 @@
+package: libserd-0-0
+
+essential:
+  - libserd-0-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libserd-0.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libserd-0-0/copyright:

--- a/slices/libshine3.yaml
+++ b/slices/libshine3.yaml
@@ -1,0 +1,15 @@
+package: libshine3
+
+essential:
+  - libshine3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libshine.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libshine3/copyright:

--- a/slices/libslang2.yaml
+++ b/slices/libslang2.yaml
@@ -1,0 +1,15 @@
+package: libslang2
+
+essential:
+  - libslang2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libslang.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libslang2/copyright:

--- a/slices/libsodium23.yaml
+++ b/slices/libsodium23.yaml
@@ -1,0 +1,15 @@
+package: libsodium23
+
+essential:
+  - libsodium23_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libsodium.so.23*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsodium23/copyright:

--- a/slices/libspeex1.yaml
+++ b/slices/libspeex1.yaml
@@ -1,0 +1,15 @@
+package: libspeex1
+
+essential:
+  - libspeex1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libspeex.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libspeex1/copyright:

--- a/slices/libsvtav1enc1d1.yaml
+++ b/slices/libsvtav1enc1d1.yaml
@@ -1,0 +1,15 @@
+package: libsvtav1enc1d1
+
+essential:
+  - libsvtav1enc1d1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libSvtAv1Enc.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsvtav1enc1d1/copyright:

--- a/slices/libtwolame0.yaml
+++ b/slices/libtwolame0.yaml
@@ -1,0 +1,15 @@
+package: libtwolame0
+
+essential:
+  - libtwolame0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libtwolame.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtwolame0/copyright:


### PR DESCRIPTION
# Proposed changes

The overall goal is to create a slice for ffmpeg. Since ffmpeg has a pretty deep dependency tree, this will be broken up in a series of smaller PRs. This second PR adds SDF for the following packages that are all transitive dependencies of ffmpeg:
* libcodec2-1.2
* libdatrie1
* libdav1d7
* libfribidi0
* ibgraphite2-3
* libgsm1
* liblcms2-2
* libmbedcrypto7t64
* libmpg123-0t64
* libogg0
* libopenjp2-7
* libserd-0-0
* libshine3
* libslang2
* libsodium23
* libspeex1
* libsvtav1enc1d1
* libtwolame0

## Related issues/PRs

Followup of #252

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

## Testing
<!-- Provide proof of testing and/or testing instructions, when applicable,
to help speed up the review process. -->

```bash
# Example:
#  chisel cut ... --root <path> <pkg>_<proposed-slice>
#  sudo chroot <path> <app>
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->