### PR TITLE
feat(24.04): add openjdk slices

### DIFF
--- a/slices/ca-certificates-java.yaml
+++ b/slices/ca-certificates-java.yaml
@@ -1,0 +1,19 @@
+package: ca-certificates-java
+
+essential:
+  - ca-certificates-java_copyright
+
+slices:
+  data:
+    essential:
+      - ca-certificates_data
+      - libnss3_libs
+    contents:
+      /etc/default/cacerts:
+      /etc/ssl/certs/java/:
+      # we need to run `keytool` in postinst, but we can't yet do
+      # this from a mutation script
+
+  copyright:
+    contents:
+      /usr/share/doc/ca-certificates-java/copyright:

--- a/slices/fontconfig-config.yaml
+++ b/slices/fontconfig-config.yaml
@@ -1,0 +1,74 @@
+package: fontconfig-config
+
+essential:
+  - fontconfig-config_copyright
+
+slices:
+  config:
+    essential:
+      - fonts-dejavu-core_config
+      - fonts-dejavu-core_fonts
+    contents:
+      /etc/fonts/conf.avail/10-antialias.conf:
+      /etc/fonts/conf.avail/10-autohint.conf:
+      /etc/fonts/conf.avail/10-hinting-full.conf:
+      /etc/fonts/conf.avail/10-hinting-medium.conf:
+      /etc/fonts/conf.avail/10-hinting-none.conf:
+      /etc/fonts/conf.avail/10-hinting-slight.conf:
+      /etc/fonts/conf.avail/10-no-sub-pixel.conf:
+      /etc/fonts/conf.avail/10-scale-bitmap-fonts.conf:
+      /etc/fonts/conf.avail/10-sub-pixel-bgr.conf:
+      /etc/fonts/conf.avail/10-sub-pixel-rgb.conf:
+      /etc/fonts/conf.avail/10-sub-pixel-vbgr.conf:
+      /etc/fonts/conf.avail/10-sub-pixel-vrgb.conf:
+      /etc/fonts/conf.avail/10-unhinted.conf:
+      /etc/fonts/conf.avail/11-lcdfilter-default.conf:
+      /etc/fonts/conf.avail/11-lcdfilter-legacy.conf:
+      /etc/fonts/conf.avail/11-lcdfilter-light.conf:
+      /etc/fonts/conf.avail/20-unhint-small-vera.conf:
+      /etc/fonts/conf.avail/25-unhint-nonlatin.conf:
+      /etc/fonts/conf.avail/30-metric-aliases.conf:
+      /etc/fonts/conf.avail/40-nonlatin.conf:
+      /etc/fonts/conf.avail/45-generic.conf:
+      /etc/fonts/conf.avail/45-latin.conf:
+      /etc/fonts/conf.avail/49-sansserif.conf:
+      /etc/fonts/conf.avail/50-user.conf:
+      /etc/fonts/conf.avail/51-local.conf:
+      /etc/fonts/conf.avail/53-monospace-lcd-filter.conf:
+      /etc/fonts/conf.avail/60-generic.conf:
+      /etc/fonts/conf.avail/60-latin.conf:
+      /etc/fonts/conf.avail/65-fonts-persian.conf:
+      /etc/fonts/conf.avail/65-khmer.conf:
+      /etc/fonts/conf.avail/65-nonlatin.conf:
+      /etc/fonts/conf.avail/69-unifont.conf:
+      /etc/fonts/conf.avail/70-force-bitmaps.conf:
+      /etc/fonts/conf.avail/70-no-bitmaps.conf:
+      /etc/fonts/conf.avail/70-yes-bitmaps.conf:
+      /etc/fonts/conf.avail/80-delicious.conf:
+      /etc/fonts/conf.avail/90-synthetic.conf:
+      /etc/fonts/conf.d/10-antialias.conf:
+      /etc/fonts/conf.d/10-hinting-slight.conf:
+      /etc/fonts/conf.d/10-scale-bitmap-fonts.conf:
+      /etc/fonts/conf.d/11-lcdfilter-default.conf:
+      /etc/fonts/conf.d/20-unhint-small-vera.conf:
+      /etc/fonts/conf.d/30-metric-aliases.conf:
+      /etc/fonts/conf.d/40-nonlatin.conf:
+      /etc/fonts/conf.d/45-generic.conf:
+      /etc/fonts/conf.d/45-latin.conf:
+      /etc/fonts/conf.d/49-sansserif.conf:
+      /etc/fonts/conf.d/50-user.conf:
+      /etc/fonts/conf.d/51-local.conf:
+      /etc/fonts/conf.d/60-generic.conf:
+      /etc/fonts/conf.d/60-latin.conf:
+      /etc/fonts/conf.d/65-fonts-persian.conf:
+      /etc/fonts/conf.d/65-nonlatin.conf:
+      /etc/fonts/conf.d/69-unifont.conf:
+      /etc/fonts/conf.d/70-no-bitmaps.conf:
+      /etc/fonts/conf.d/80-delicious.conf:
+      /etc/fonts/conf.d/90-synthetic.conf:
+      /etc/fonts/fonts.conf:
+      /usr/share/xml/fontconfig/fonts.dtd:
+
+  copyright:
+    contents:
+      /usr/share/doc/fontconfig-config/copyright:

--- a/slices/fonts-dejavu-core.yaml
+++ b/slices/fonts-dejavu-core.yaml
@@ -1,0 +1,45 @@
+package: fonts-dejavu-core
+
+essential:
+  - fonts-dejavu-core_copyright
+
+slices:
+  fonts:
+    contents:
+      /usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf:
+      /usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf:
+
+  config:
+    contents:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-sans-mono.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-lgc-serif.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-sans-mono.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-sans.conf:
+      /etc/fonts/conf.avail/20-unhint-small-dejavu-serif.conf:
+      /etc/fonts/conf.avail/57-dejavu-sans-mono.conf:
+      /etc/fonts/conf.avail/57-dejavu-sans.conf:
+      /etc/fonts/conf.avail/57-dejavu-serif.conf:
+      /etc/fonts/conf.avail/58-dejavu-lgc-sans-mono.conf:
+      /etc/fonts/conf.avail/58-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.avail/58-dejavu-lgc-serif.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-lgc-sans-mono.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-lgc-serif.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-sans-mono.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-sans.conf:
+      /etc/fonts/conf.d/20-unhint-small-dejavu-serif.conf:
+      /etc/fonts/conf.d/57-dejavu-sans-mono.conf:
+      /etc/fonts/conf.d/57-dejavu-sans.conf:
+      /etc/fonts/conf.d/57-dejavu-serif.conf:
+      /etc/fonts/conf.d/58-dejavu-lgc-sans-mono.conf:
+      /etc/fonts/conf.d/58-dejavu-lgc-sans.conf:
+      /etc/fonts/conf.d/58-dejavu-lgc-serif.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/fonts-dejavu-core/copyright:

--- a/slices/libfontconfig1.yaml
+++ b/slices/libfontconfig1.yaml
@@ -1,0 +1,19 @@
+package: libfontconfig1
+
+essential:
+  - libfontconfig1_copyright
+
+slices:
+  libs:
+    essential:
+      - fontconfig-config_config
+      - libc6_libs
+      - libexpat1_libs
+      - libfreetype6_libs
+      - libuuid1_libs
+    contents:
+      /usr/lib/*-linux-*/libfontconfig.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfontconfig1/copyright:

--- a/slices/libfreetype6.yaml
+++ b/slices/libfreetype6.yaml
@@ -1,0 +1,18 @@
+package: libfreetype6
+
+essential:
+  - libfreetype6_copyright
+
+slices:
+  libs:
+    essential:
+      - libbrotli1_libs
+      - libc6_libs
+      - libpng16-16_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libfreetype.so.6*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfreetype6/copyright:

--- a/slices/libglib2.0-0.yaml
+++ b/slices/libglib2.0-0.yaml
@@ -1,0 +1,29 @@
+package: libglib2.0-0
+
+essential:
+  - libglib2.0-0_copyright
+
+slices:
+  core:
+    essential:
+      - libc6_libs
+      - libpcre3_libs
+    contents:
+      /usr/lib/*-linux-*/libglib-2.0.so.0*:
+
+  libs:
+    essential:
+      - libffi8_libs
+      - libglib2.0-0_core
+      - libmount1_libs
+      - libselinux1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libgio-2.0.so.0*:
+      /usr/lib/*-linux-*/libgmodule-2.0.so.0*:
+      /usr/lib/*-linux-*/libgobject-2.0.so.0*:
+      /usr/lib/*-linux-*/libgthread-2.0.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglib2.0-0/copyright:

--- a/slices/libgraphite2-3.yaml
+++ b/slices/libgraphite2-3.yaml
@@ -1,0 +1,15 @@
+package: libgraphite2-3
+
+essential:
+  - libgraphite2-3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libgraphite2.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgraphite2-3/copyright:

--- a/slices/liblcms2-2.yaml
+++ b/slices/liblcms2-2.yaml
@@ -1,0 +1,15 @@
+package: liblcms2-2
+
+essential:
+  - liblcms2-2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/liblcms2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblcms2-2/copyright:

--- a/slices/libmount1.yaml
+++ b/slices/libmount1.yaml
@@ -1,0 +1,17 @@
+package: libmount1
+
+essential:
+  - libmount1_copyright
+
+slices:
+  libs:
+    essential:
+      - libblkid1_libs
+      - libc6_libs
+      - libselinux1_libs
+    contents:
+      /usr/lib/*-linux-*/libmount.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libmount1/copyright:

--- a/slices/libnspr4.yaml
+++ b/slices/libnspr4.yaml
@@ -1,0 +1,17 @@
+package: libnspr4
+
+essential:
+  - libnspr4_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnspr4.so:
+      /usr/lib/*-linux-*/libplc4.so:
+      /usr/lib/*-linux-*/libplds4.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnspr4/copyright:

--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -1,0 +1,18 @@
+package: libnss3
+
+essential:
+  - libnss3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnspr4_libs
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/*-linux-*/libnss3.so:
+      /usr/lib/*-linux-*/libnssutil3.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnss3/copyright:

--- a/slices/libpcre3.yaml
+++ b/slices/libpcre3.yaml
@@ -1,0 +1,16 @@
+package: libpcre3
+
+essential:
+  - libpcre3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /lib/*-linux-*/libpcre.so.3*:
+      /usr/lib/*-linux-*/libpcreposix.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpcre3/copyright:

--- a/slices/libpcsclite1.yaml
+++ b/slices/libpcsclite1.yaml
@@ -1,0 +1,15 @@
+package: libpcsclite1
+
+essential:
+  - libpcsclite1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpcsclite.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpcsclite1/copyright:

--- a/slices/libpng16-16.yaml
+++ b/slices/libpng16-16.yaml
@@ -1,0 +1,15 @@
+package: libpng16-16
+
+essential:
+  - libpng16-16_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpng16.so.16*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpng16-16/copyright:

--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -1,0 +1,199 @@
+package: openjdk-8-jre-headless
+
+essential:
+  - openjdk-8-jre-headless_copyright
+
+slices:
+  # The "core" slice provides a minimal, yet functional JRE8.
+  core:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+    contents:
+      /etc/java-8-openjdk/calendars.properties:
+      /etc/java-8-openjdk/content-types.properties:
+      /etc/java-8-openjdk/logging.properties:
+      /etc/java-8-openjdk/net.properties:
+      # This security path is also in "core" as it describes permissions for
+      # various classes and how they can interact with the system.
+      /etc/java-8-openjdk/security/java.policy:
+      /usr/lib/jvm/java-8-openjdk-*/jre/bin/java:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjsig.so: {arch: armhf}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/client/libjvm.so: {arch: armhf}
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/jli/libjli.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/jvm.cfg-default:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjava.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjsig.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libnet.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libnio.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libverify.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libzip.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjsig.so:
+        arch:
+          - amd64
+          - arm64
+          - ppc64el
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/server/libjvm.so:
+        arch:
+          - amd64
+          - arm64
+          - ppc64el
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/calendars.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/content-types.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/currency.data:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/hijrah-config-umalqura.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/logging.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/meta-index:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/net.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/resources.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/rt.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/java.policy:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/tzdb.dat:
+
+  locale:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/cldrdata.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/localedata.jar:
+
+  security:
+    essential:
+      - ca-certificates-java_data
+      - libpcsclite1_libs
+      - openjdk-8-jre-headless_core
+    contents:
+      /etc/java-8-openjdk/security/blacklisted.certs:
+      /etc/java-8-openjdk/security/java.security:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libj2gss.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libj2pcsc.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libj2pkcs11.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjaas_unix.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libsunec.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/sunec.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/sunjce_provider.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/sunpkcs11.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jce.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jsse.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/blacklisted.certs:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/cacerts:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/java.security:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/limited/US_export_policy.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/limited/local_policy.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/unlimited/US_export_policy.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/security/policy/unlimited/local_policy.jar:
+
+  # Abstract Window Toolkit.
+  # Classes and components for creating GUI elements (windows, graphics, etc.).
+  awt:
+    essential:
+      - libfontconfig1_libs
+      - libfreetype6_libs
+      - libjpeg-turbo8_libs
+      - liblcms2-2_libs
+      - openjdk-8-jre-headless_core
+    contents:
+      /etc/java-8-openjdk/flavormap.properties:
+      /etc/java-8-openjdk/images/cursors/cursors.properties:
+      /etc/java-8-openjdk/psfont.properties.ja:
+      /etc/java-8-openjdk/psfontj2d.properties:
+      /etc/java-8-openjdk/swing.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libawt.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libawt_headless.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libfontmanager.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjavajpeg.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjavalcms.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libmlib_image.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/charsets.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/CIEXYZ.pf:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/GRAY.pf:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/LINEAR_RGB.pf:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/PYCC.pf:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/cmm/sRGB.pf:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/flavormap.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/images/cursors/cursors.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/psfont.properties.ja:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/psfontj2d.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/swing.properties:
+
+  # Enabled management and monitoring capabilities for Java apps.
+  management:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /etc/java-8-openjdk/management/management.properties:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libmanagement.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/management-agent.jar:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/management/management.properties:
+
+  # Java Flight Recorder - API for collecting diagnostic and profilling data.
+  jfr:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/jfr.jar:
+        arch: [amd64, arm64, armhf, ppc64el]
+
+  # Shared libraries for supporting heap profilling.
+  hprof:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libhprof.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjava_crw_demo.so:
+      /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libnpt.so:
+        arch: amd64
+      /usr/lib/jvm/java-8-openjdk-arm64/jre/lib/aarch64/libnpt.so:
+        arch: arm64
+
+  # Shared libraries for supporting debugging capabilities.
+  debug:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libdt_socket.so:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libjdwp.so:
+      /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libnpt.so:
+        arch: amd64
+      /usr/lib/jvm/java-8-openjdk-arm64/jre/lib/aarch64/libnpt.so:
+        arch: arm64
+
+  tools:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/bin/keytool:
+      /usr/lib/jvm/java-8-openjdk-*/jre/bin/keytool:
+
+  # Java Programming Language Instrumentation Services interface.
+  jplis:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libinstrument.so:
+
+  # Allow querying of DNS records through JNDI.
+  jndidns:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/dnsns.jar:
+
+  zipfs:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/ext/zipfs.jar:
+
+  # No internal usages in JRE8, but part of the com.sun.nio.sctp private API.
+  sctp:
+    essential:
+      - openjdk-8-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-8-openjdk-*/jre/lib/*/libsctp.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/openjdk-8-jre-headless/copyright:

--- a/tests/spread/integration/openjdk-8-jre-headless/smoke.sh
+++ b/tests/spread/integration/openjdk-8-jre-headless/smoke.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+for java in `find /usr/lib/jvm -name java`; do
+# workaround missing /proc filesystem
+    mkdir -p ${rootfs}/proc/self
+    ln -sf ${java} /proc/self/exe
+# check that Java machine can be created
+    ${java} -version
+done

--- a/tests/spread/integration/openjdk-8-jre-headless/task.yaml
+++ b/tests/spread/integration/openjdk-8-jre-headless/task.yaml
@@ -1,0 +1,14 @@
+summary: Integration tests for openjdk-8-jre-headless
+
+environment:
+  SLICE/core: "core"
+
+execute: |
+  # Test different slice installations
+  echo "SLICE=${SLICE}"
+  rootfs="$(install-slices busybox_bins openjdk-8-jre-headless_${SLICE})"
+  (cd ${rootfs}/usr/bin && for applet in $(${rootfs}/usr/bin/busybox --list); do \
+      ln -s busybox $applet ; \
+    done)
+  cp smoke.sh "${rootfs}/"
+  chroot ${rootfs} busybox sh /smoke.sh


### PR DESCRIPTION
# Proposed changes

Copy openjdk slice definitions from 22.04 as they are missing from 24.04.

Add smoke test for openjdk-8-jre-headless slice.

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->