### PR TITLE
feat(24.04): add dpkg and dependencies

### DIFF
--- a/slices/diffutils.yaml
+++ b/slices/diffutils.yaml
@@ -1,0 +1,18 @@
+package: diffutils
+
+essential:
+  - diffutils_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/cmp:
+      /usr/bin/diff:
+      /usr/bin/diff3:
+      /usr/bin/sdiff:
+
+  copyright:
+    contents:
+      /usr/share/doc/diffutils/copyright:

--- a/slices/dpkg.yaml
+++ b/slices/dpkg.yaml
@@ -51,7 +51,7 @@ slices:
       /usr/share/dpkg/*table:
 
   var:
-    # Directories that are included in the tarball because they need to exist in /var for dpkg to run.
+    # Directories that are included in the tarball because they need to exist in /var
     contents:
       /var/lib/dpkg/alternatives/: {make: true}
       /var/lib/dpkg/info/: {make: true}

--- a/slices/dpkg.yaml
+++ b/slices/dpkg.yaml
@@ -1,9 +1,13 @@
 package: dpkg
 
+essential:
+  - dpkg_copyright
+
 slices:
   bins:
     essential:
       - dpkg_config
+      - dpkg_var
       - libbz2-1.0_libs
       - libc-bin_ldconfig
       - libc6_libs
@@ -14,19 +18,42 @@ slices:
       - tar_tar
       - zlib1g_libs
     contents:
-      /usr/bin/dpkg*:
+      /usr/bin/dpkg:
+      /usr/bin/dpkg-deb:
+      /usr/bin/dpkg-divert:
+      /usr/bin/dpkg-maintscript-helper:
+      /usr/bin/dpkg-query:
+      /usr/bin/dpkg-realpath:
+      /usr/bin/dpkg-split:
+      /usr/bin/dpkg-statoverride:
+      /usr/bin/dpkg-trigger:
       /usr/bin/update-alternatives:
       /usr/libexec/dpkg/*:
       /usr/sbin/start-stop-daemon:
-      /var/lib/dpkg/tmp.ci/: {make: true}
-      /var/log/dpkg.log: {text: ""}
+
+  copyright:
+    contents:
+      /usr/share/doc/dpkg/copyright:
 
   config:
     contents:
       /etc/dpkg/dpkg.cfg:
+      /etc/dpkg/dpkg.cfg.d/: {make: true}
 
   locales:
     essential:
       - dpkg_bins
     contents:
       /usr/share/locale/**/dpkg.mo:
+
+  tables:
+    contents:
+      /usr/share/dpkg/*table:
+
+  var:
+    # Directories that are included in the tarball because they need to exist in /var for dpkg to run.
+    contents:
+      /var/lib/dpkg/alternatives/: {make: true}
+      /var/lib/dpkg/info/: {make: true}
+      /var/lib/dpkg/parts/: {make: true}
+      /var/lib/dpkg/updates/: {make: true}

--- a/slices/dpkg.yaml
+++ b/slices/dpkg.yaml
@@ -53,7 +53,7 @@ slices:
   var:
     # Directories that are included in the tarball because they need to exist in /var
     contents:
-      /var/lib/dpkg/alternatives/: {make: true}
-      /var/lib/dpkg/info/: {make: true}
-      /var/lib/dpkg/parts/: {make: true}
-      /var/lib/dpkg/updates/: {make: true}
+      /var/lib/dpkg/alternatives/:
+      /var/lib/dpkg/info/:
+      /var/lib/dpkg/parts/:
+      /var/lib/dpkg/updates/:

--- a/slices/dpkg.yaml
+++ b/slices/dpkg.yaml
@@ -38,7 +38,7 @@ slices:
   config:
     contents:
       /etc/dpkg/dpkg.cfg:
-      /etc/dpkg/dpkg.cfg.d/: {make: true}
+      /etc/dpkg/dpkg.cfg.d/:
 
   locales:
     essential:

--- a/slices/dpkg.yaml
+++ b/slices/dpkg.yaml
@@ -1,0 +1,32 @@
+package: dpkg
+
+slices:
+  bins:
+    essential:
+      - dpkg_config
+      - libbz2-1.0_libs
+      - libc-bin_ldconfig
+      - libc6_libs
+      - liblzma5_libs
+      - libmd0_libs
+      - libselinux1_libs
+      - libzstd1_libs
+      - tar_tar
+      - zlib1g_libs
+    contents:
+      /usr/bin/dpkg*:
+      /usr/bin/update-alternatives:
+      /usr/libexec/dpkg/*:
+      /usr/sbin/start-stop-daemon:
+      /var/lib/dpkg/tmp.ci/: {make: true}
+      /var/log/dpkg.log: {text: ""}
+
+  config:
+    contents:
+      /etc/dpkg/dpkg.cfg:
+
+  locales:
+    essential:
+      - dpkg_bins
+    contents:
+      /usr/share/locale/**/dpkg.mo:

--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -8,6 +8,13 @@ slices:
     contents:
       /etc/nsswitch.conf: {copy: /usr/share/libc-bin/nsswitch.conf}
 
+  ldconfig:
+    essential:
+      - dash_bins
+    contents:
+      /usr/sbin/ldconfig:
+      /usr/sbin/ldconfig.real:
+
   locale:
     contents:
       /usr/lib/locale/C.utf8/LC_ADDRESS:

--- a/slices/tar.yaml
+++ b/slices/tar.yaml
@@ -1,5 +1,8 @@
 package: tar
 
+essential:
+  - tar_copyright
+
 slices:
   bins:
     essential:
@@ -7,6 +10,10 @@ slices:
       - tar_tar
     contents:
       /usr/sbin/tarcat:
+
+  copyright:
+    contents:
+      /usr/share/doc/tar/copyright:
 
   rmt:
     essential:

--- a/slices/tar.yaml
+++ b/slices/tar.yaml
@@ -1,0 +1,24 @@
+package: tar
+
+slices:
+  bins:
+    essential:
+      - tar_rmt
+      - tar_tar
+    contents:
+      /usr/sbin/tarcat:
+
+  rmt:
+    essential:
+      - libc6_libs
+    contents:
+      /etc/rmt: {symlink: /usr/sbin/rmt-tar}
+      /usr/sbin/rmt-tar:
+
+  tar:
+    essential:
+      - libacl1_libs
+      - libc6_libs
+      - libselinux1_libs
+    contents:
+      /usr/bin/tar:

--- a/tests/spread/integration/diffutils/task.yaml
+++ b/tests/spread/integration/diffutils/task.yaml
@@ -1,0 +1,25 @@
+summary: Integration tests for diffutils
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices diffutils_bins)"
+
+  mkdir "${rootfs}/test"
+  echo "This is a test file" > "${rootfs}/test1.txt"
+  echo "This is another test file" > "${rootfs}/test2.txt"
+
+  # Compare two different files with cmp
+  actual="$(! chroot "${rootfs}/" cmp -b /test1.txt /test2.txt)"
+  expected='/test1.txt /test2.txt differ: byte 10, line 1 is  40   156 n'
+  [[ "$actual" == "$expected" ]]
+
+  # Compare with diff
+  cp "${rootfs}/test1.txt" "${rootfs}/test3.txt"
+  [[ "$(chroot "${rootfs}/" diff /test1.txt /test3.txt)" == "" ]]
+
+  # Compare with diff3
+  chroot "${rootfs}/" diff3 -a /test1.txt /test2.txt /test3.txt
+
+  # ...and sdiff
+  chroot "${rootfs}/" sdiff /test1.txt /test3.txt

--- a/tests/spread/integration/diffutils/task.yaml
+++ b/tests/spread/integration/diffutils/task.yaml
@@ -10,16 +10,14 @@ execute: |
   echo "This is another test file" > "${rootfs}/test2.txt"
 
   # Compare two different files with cmp
-  actual="$(! chroot "${rootfs}/" cmp -b /test1.txt /test2.txt)"
-  expected='/test1.txt /test2.txt differ: byte 10, line 1 is  40   156 n'
-  [[ "$actual" == "$expected" ]]
+  chroot "${rootfs}/" cmp -b /test1.txt /test2.txt | grep -q '/test1.txt /test2.txt differ: byte 10, line 1'
 
   # Compare with diff
   cp "${rootfs}/test1.txt" "${rootfs}/test3.txt"
   [[ "$(chroot "${rootfs}/" diff /test1.txt /test3.txt)" == "" ]]
 
   # Compare with diff3
-  chroot "${rootfs}/" diff3 -a /test1.txt /test2.txt /test3.txt
+  chroot "${rootfs}/" diff3 -a /test1.txt /test2.txt /test3.txt | grep -q -e '====2' -e '[1-3]:1c'
 
   # ...and sdiff
-  chroot "${rootfs}/" sdiff /test1.txt /test3.txt
+  chroot "${rootfs}/" sdiff /test1.txt /test2.txt | grep -q -E 'This is a test file\s+| This is another test file'

--- a/tests/spread/integration/dpkg/task.yaml
+++ b/tests/spread/integration/dpkg/task.yaml
@@ -1,0 +1,12 @@
+summary: Integration tests for dpkg
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices coreutils_bins diffutils_bins dpkg_bins)"
+
+  # Get a sample deb file to install. Contains no dependencies or install scripts.
+  wget -P "${rootfs}/" http://archive.ubuntu.com/ubuntu/pool/main/l/lsb-release-minimal/lsb-release_12.1-1_all.deb
+
+  # Run a smoke test for dpkg to ensure that it does not throw an error
+  chroot "${rootfs}/" dpkg --install ./lsb-release_12.1-1_all.deb

--- a/tests/spread/integration/tar/task.yaml
+++ b/tests/spread/integration/tar/task.yaml
@@ -25,3 +25,9 @@ execute: |
 
   # Expect an error gzipping a tarball since gzip is not installed in the chroot.
   ! chroot "${rootfs}/" tar -czf test.tar.gz /test/ 2| grep -q "tar (child): gzip: Cannot exec: No such file or directory"
+
+  # New environment for rmt slice.
+  rootfs="$(install-slices tar_rmt)"
+
+  # We can't really do much with rmt, so just check that the executable works.
+  chroot "${rootfs}/" rmt-tar --version

--- a/tests/spread/integration/tar/task.yaml
+++ b/tests/spread/integration/tar/task.yaml
@@ -1,0 +1,27 @@
+summary: Integration tests for tar
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices tar_tar)"
+
+  mkdir "${rootfs}/test"
+
+  echo "This is a test file" > "${rootfs}/test/test.txt"
+  touch --date=2020-01-01T00:00:00Z "${rootfs}/test/test.txt"
+  touch --date=2020-01-01T00:00:00Z "${rootfs}/test/"
+
+  # Create an uncompressed tarball and compare to a known hash.
+  chroot "${rootfs}/" tar -cf test.tar /test/
+  [[ $(sha256sum "${rootfs}/test.tar" | cut -d' ' -f1) == f5893661db55f15954c90dee860ee6c93042ea482c303f5f162c8078cdc79928 ]]
+
+  # Decompress back to a new directory and ensure the file is correct.
+  mkdir "${rootfs}/test-result"
+  chroot "${rootfs}/" tar -xf test.tar -C /test-result
+  [[ "$(cat ${rootfs}/test/test.txt)" == "$(cat ${rootfs}/test-result/test/test.txt)" ]]
+  # Check modification times
+  [[ $(stat -c %Y ${rootfs}/test-result/test) == 1577836800 ]]
+  [[ $(stat -c %Y ${rootfs}/test-result/test) == 1577836800 ]]
+
+  # Expect an error gzipping a tarball since gzip is not installed in the chroot.
+  ! chroot "${rootfs}/" tar -czf test.tar.gz /test/ 2| grep -q "tar (child): gzip: Cannot exec: No such file or directory"


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

- Adds an `ldconfig` slice for `libc-bin`
- Adds slices for `diffutils`, `dpkg` and `tar`
- Adds an integration test for a basic `dpkg` package.

## Related issues/PRs
<!-- If any -->
This is a newer subset of https://github.com/canonical/chisel-releases/pull/136/files

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->

Eventually this should allow `snapcraft`, `charmcraft`, etc. to use chiseled versions of apt.