### PR TITLE
feat(24.04): add ffmpeg dependencies slices

### DIFF
--- a/slices/libblas3.yaml
+++ b/slices/libblas3.yaml
@@ -1,0 +1,16 @@
+package: libblas3
+
+essential:
+  - libblas3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+    contents:
+      /usr/lib/*-linux-*/blas/libblas.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libblas3/copyright:

--- a/slices/libbs2b0.yaml
+++ b/slices/libbs2b0.yaml
@@ -1,0 +1,16 @@
+package: libbs2b0
+
+essential:
+  - libbs2b0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libbs2b.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libbs2b0/copyright:

--- a/slices/libchromaprint1.yaml
+++ b/slices/libchromaprint1.yaml
@@ -1,0 +1,17 @@
+package: libchromaprint1
+
+essential:
+  - libchromaprint1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libchromaprint.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libchromaprint1/copyright:

--- a/slices/libelf1t64.yaml
+++ b/slices/libelf1t64.yaml
@@ -1,0 +1,18 @@
+package: libelf1t64
+
+essential:
+  - libelf1t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libelf-0.190.so*:
+      /usr/lib/*-linux-*/libelf.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libelf1t64/copyright:

--- a/slices/libflac12t64.yaml
+++ b/slices/libflac12t64.yaml
@@ -1,0 +1,16 @@
+package: libflac12t64
+
+essential:
+  - libflac12t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libogg0_libs
+    contents:
+      /usr/lib/*-linux-*/libFLAC.so.12*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libflac12t64/copyright:

--- a/slices/libllvm17t64.yaml
+++ b/slices/libllvm17t64.yaml
@@ -1,0 +1,23 @@
+package: libllvm17t64
+
+essential:
+  - libllvm17t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libedit2_libs
+      - libffi8_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libtinfo6_libs
+      - libxml2_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libLLVM-17.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libllvm17t64/copyright:

--- a/slices/libopenmpt0t64.yaml
+++ b/slices/libopenmpt0t64.yaml
@@ -1,0 +1,21 @@
+package: libopenmpt0t64
+
+essential:
+  - libopenmpt0t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libmpg123-0t64_libs
+      - libstdc++6_libs
+      - libvorbis0a_libs
+      - libvorbisfile3_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libopenmpt.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libopenmpt0t64/copyright:

--- a/slices/libpciaccess0.yaml
+++ b/slices/libpciaccess0.yaml
@@ -1,0 +1,16 @@
+package: libpciaccess0
+
+essential:
+  - libpciaccess0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libpciaccess.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpciaccess0/copyright:

--- a/slices/librav1e0.yaml
+++ b/slices/librav1e0.yaml
@@ -1,0 +1,16 @@
+package: librav1e0
+
+essential:
+  - librav1e0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+    contents:
+      /usr/lib/*-linux-*/librav1e.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librav1e0/copyright:

--- a/slices/librubberband2.yaml
+++ b/slices/librubberband2.yaml
@@ -1,0 +1,19 @@
+package: librubberband2
+
+essential:
+  - librubberband2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libfftw3-double3_libs
+      - libgcc-s1_libs
+      - libsamplerate0_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/librubberband.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librubberband2/copyright:

--- a/slices/libvidstab1.1.yaml
+++ b/slices/libvidstab1.1.yaml
@@ -1,0 +1,16 @@
+package: libvidstab1.1
+
+essential:
+  - libvidstab1.1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgomp1_libs
+    contents:
+      /usr/lib/*-linux-*/libvidstab.so.1.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvidstab1.1/copyright:

--- a/slices/libvorbis0a.yaml
+++ b/slices/libvorbis0a.yaml
@@ -1,0 +1,16 @@
+package: libvorbis0a
+
+essential:
+  - libvorbis0a_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libogg0_libs
+    contents:
+      /usr/lib/*-linux-*/libvorbis.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvorbis0a/copyright:

--- a/slices/libvorbisenc2.yaml
+++ b/slices/libvorbisenc2.yaml
@@ -1,0 +1,16 @@
+package: libvorbisenc2
+
+essential:
+  - libvorbisenc2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libvorbis0a_libs
+    contents:
+      /usr/lib/*-linux-*/libvorbisenc.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvorbisenc2/copyright:

--- a/slices/libvorbisfile3.yaml
+++ b/slices/libvorbisfile3.yaml
@@ -1,0 +1,17 @@
+package: libvorbisfile3
+
+essential:
+  - libvorbisfile3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libogg0_libs
+      - libvorbis0a_libs
+    contents:
+      /usr/lib/*-linux-*/libvorbisfile.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvorbisfile3/copyright:

--- a/slices/libwebpmux3.yaml
+++ b/slices/libwebpmux3.yaml
@@ -1,0 +1,16 @@
+package: libwebpmux3
+
+essential:
+  - libwebpmux3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libwebp7_libs
+    contents:
+      /usr/lib/*-linux-*/libwebpmux.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libwebpmux3/copyright:

--- a/slices/libx265-199.yaml
+++ b/slices/libx265-199.yaml
@@ -1,0 +1,17 @@
+package: libx265-199
+
+essential:
+  - libx265-199_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnuma1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libx265.so.199*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libx265-199/copyright:

--- a/slices/libxml2.yaml
+++ b/slices/libxml2.yaml
@@ -1,0 +1,18 @@
+package: libxml2
+
+essential:
+  - libxml2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libicu74_libs
+      - liblzma5_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libxml2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxml2/copyright:


### PR DESCRIPTION
# Proposed changes

The overall goal is to create a SDF for the `ffmpeg` package. Since ffmpeg has a pretty deep dependency tree, this is broken up in a series of smaller PRs (see #297 and #252). This PR adds SDF for the following packages that are all transitive dependencies of ffmpeg:
* libblas3
* libbs2b0
* libchromaprint1
* libelf1t64
* libflac12t64
* libllvm17t64
* libopenmpt0t64
* libpciaccess0
* librav1e0
* librubberband2
* libvidstab1.1
* libvorbis0a
* libvorbisenc2
* libvorbisfile3
* libwebpmux3
* libx265-199
* libxml2


## Related issues/PRs

Followup of #297 and #252

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
  * Note: I did not add new spread tests since those are all `libs` slices 
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->