### PR TITLE
fix(24.04): use correct libmount1 copyright

### DIFF
--- a/slices/libmount1.yaml
+++ b/slices/libmount1.yaml
@@ -1,7 +1,7 @@
 package: libmount1
 
 essential:
-  - libseccomp2_copyright
+  - libmount1_copyright
 
 slices:
   libs:


### PR DESCRIPTION

# Proposed changes
https://github.com/canonical/chisel-releases/pull/274 referenced libssecomp2 copyright instead of libmount1. Use libmount1 copyright.

## Related issues/PRs
[<!-- If any -->](https://github.com/canonical/chisel-releases/pull/274)

### Forward porting
n/a

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->