### PR TITLE
feat(24.04): add ffmpeg dependencies slices

### DIFF
--- a/slices/libcdio-cdda2t64.yaml
+++ b/slices/libcdio-cdda2t64.yaml
@@ -1,0 +1,16 @@
+package: libcdio-cdda2t64
+
+essential:
+  - libcdio-cdda2t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcdio19t64_libs
+    contents:
+      /usr/lib/*-linux-*/libcdio_cdda.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcdio-cdda2t64/copyright:

--- a/slices/libcdio-paranoia2t64.yaml
+++ b/slices/libcdio-paranoia2t64.yaml
@@ -1,0 +1,17 @@
+package: libcdio-paranoia2t64
+
+essential:
+  - libcdio-paranoia2t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcdio-cdda2t64_libs
+      - libcdio19t64_libs
+    contents:
+      /usr/lib/*-linux-*/libcdio_paranoia.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcdio-paranoia2t64/copyright:

--- a/slices/libcdio19t64.yaml
+++ b/slices/libcdio19t64.yaml
@@ -1,0 +1,15 @@
+package: libcdio19t64
+
+essential:
+  - libcdio19t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libcdio.so.19*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcdio19t64/copyright:

--- a/slices/libnorm1t64.yaml
+++ b/slices/libnorm1t64.yaml
@@ -1,0 +1,17 @@
+package: libnorm1t64
+
+essential:
+  - libnorm1t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libnorm.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnorm1t64/copyright:

--- a/slices/libpgm-5.3-0t64.yaml
+++ b/slices/libpgm-5.3-0t64.yaml
@@ -1,0 +1,15 @@
+package: libpgm-5.3-0t64
+
+essential:
+  - libpgm-5.3-0t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpgm-5.3.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpgm-5.3-0t64/copyright:

--- a/slices/libxcb-dri2-0.yaml
+++ b/slices/libxcb-dri2-0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-dri2-0
+
+essential:
+  - libxcb-dri2-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-dri2.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-dri2-0/copyright:

--- a/slices/libxcb-dri3-0.yaml
+++ b/slices/libxcb-dri3-0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-dri3-0
+
+essential:
+  - libxcb-dri3-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-dri3.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-dri3-0/copyright:

--- a/slices/libxcb-glx0.yaml
+++ b/slices/libxcb-glx0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-glx0
+
+essential:
+  - libxcb-glx0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-glx.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-glx0/copyright:

--- a/slices/libxcb-present0.yaml
+++ b/slices/libxcb-present0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-present0
+
+essential:
+  - libxcb-present0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-present.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-present0/copyright:

--- a/slices/libxcb-randr0.yaml
+++ b/slices/libxcb-randr0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-randr0
+
+essential:
+  - libxcb-randr0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-randr.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-randr0/copyright:

--- a/slices/libxcb-render0.yaml
+++ b/slices/libxcb-render0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-render0
+
+essential:
+  - libxcb-render0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-render.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-render0/copyright:

--- a/slices/libxcb-shape0.yaml
+++ b/slices/libxcb-shape0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-shape0
+
+essential:
+  - libxcb-shape0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-shape.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-shape0/copyright:

--- a/slices/libxcb-shm0.yaml
+++ b/slices/libxcb-shm0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-shm0
+
+essential:
+  - libxcb-shm0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-shm.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-shm0/copyright:

--- a/slices/libxcb-sync1.yaml
+++ b/slices/libxcb-sync1.yaml
@@ -1,0 +1,16 @@
+package: libxcb-sync1
+
+essential:
+  - libxcb-sync1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-sync.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-sync1/copyright:

--- a/slices/libxcb-xfixes0.yaml
+++ b/slices/libxcb-xfixes0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-xfixes0
+
+essential:
+  - libxcb-xfixes0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-xfixes.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-xfixes0/copyright:

--- a/slices/libxcb1.yaml
+++ b/slices/libxcb1.yaml
@@ -1,0 +1,17 @@
+package: libxcb1
+
+essential:
+  - libxcb1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxau6_libs
+      - libxdmcp6_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb1/copyright:

--- a/slices/libxdmcp6.yaml
+++ b/slices/libxdmcp6.yaml
@@ -1,0 +1,16 @@
+package: libxdmcp6
+
+essential:
+  - libxdmcp6_copyright
+
+slices:
+  libs:
+    essential:
+      - libbsd0_libs
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libXdmcp.so.6*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxdmcp6/copyright:

--- a/slices/libzimg2.yaml
+++ b/slices/libzimg2.yaml
@@ -1,0 +1,17 @@
+package: libzimg2
+
+essential:
+  - libzimg2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libzimg.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libzimg2/copyright:

--- a/slices/libzmq5.yaml
+++ b/slices/libzmq5.yaml
@@ -1,0 +1,22 @@
+package: libzmq5
+
+essential:
+  - libzmq5_copyright
+
+slices:
+  libs:
+    essential:
+      - libbsd0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libgssapi-krb5-2_libs
+      - libnorm1t64_libs
+      - libpgm-5.3-0t64_libs
+      - libsodium23_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libzmq.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libzmq5/copyright:


### PR DESCRIPTION
# Proposed changes

The overall goal is to create a SDF for the `ffmpeg` package. Since ffmpeg has a pretty deep dependency tree, this is broken up in a series of smaller PRs (see #326, #297 and #252). This PR adds SDF for the following packages that are all transitive dependencies of ffmpeg:
* libcdio-cdda2t64
* libcdio-paranoia2t64
* libnorm1t64
* libxcb-dri2-0
* libxcb-dri3-0
* libxcb-glx0
* libxcb-present0
* libxcb-randr0
* libxcb-render0
* libxcb-shape0
* libxcb-shm0
* libxcb-sync1
* libxcb-xfixes0
* libxcb1
* libxdmcp6
* libzimg2
* libzmq5


## Related issues/PRs

Followup of #326, #297 and #252

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
  * Note: I did not add new spread tests since those are all `libs` slices 
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->