### PR TITLE
feat(24.04): add libcrack-runtime and its dependencies

### DIFF
--- a/slices/cracklib-runtime.yaml
+++ b/slices/cracklib-runtime.yaml
@@ -1,0 +1,46 @@
+package: cracklib-runtime
+
+essential:
+  - cracklib-runtime_copyright
+
+# Cracklib runs /usr/sbin/update-cracklib on install, and this
+# in turns generate the cracklib caches. This is mostly possible to do
+# as a mutation script, and is provided here:
+# https://paste.ubuntu.com/p/Jc5vvgk3tN/
+# however the files it writes are malformed as we cannot write raw bytes,
+# but instead we write files as text which results in larger files than
+# expected (i.e the generated cracklib_dict.hwm is 1618 bytes instead of 1024).
+# If we could use the above mutation script, then the contents of the 'bins'
+# slice would probably not be needed, together with most of the 'config'
+# slice.
+slices:
+  # the scripts use both 'file', 'find' and 'grep'
+  # so we ensure those dependencies are added.
+  # furthermore, libssl3t64 is required as well
+  bins:
+    essential:
+      - cracklib-runtime_config
+      - file_bins
+      - findutils_bins
+      - grep_bins
+      - libc6_libs
+      - libcrack2_libs
+      - libssl3t64_libs
+    contents:
+      /usr/sbin/cracklib-check:
+      /usr/sbin/cracklib-format:
+      /usr/sbin/cracklib-packer:
+      /usr/sbin/cracklib-unpacker:
+      /usr/sbin/create-cracklib-dict:
+      /usr/sbin/update-cracklib:
+
+  config:
+    contents:
+      /etc/cracklib/cracklib.conf:
+      /etc/logcheck/ignore.d.paranoid/cracklib-runtime:
+      /usr/share/dict/cracklib-small:
+      /var/cache/cracklib/: { make: true, mode: 0755 }
+
+  copyright:
+    contents:
+      /usr/share/doc/cracklib-runtime/copyright:

--- a/slices/libcrack2.yaml
+++ b/slices/libcrack2.yaml
@@ -1,0 +1,15 @@
+package: libcrack2
+
+essential:
+  - libcrack2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libcrack.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcrack2/copyright:

--- a/tests/spread/integration/cracklib-runtime/task.yaml
+++ b/tests/spread/integration/cracklib-runtime/task.yaml
@@ -1,0 +1,33 @@
+summary: Integration tests for cracklib-runtime
+
+execute: |
+  rootfs="$(install-slices bash_bins base-files_base coreutils_bins cracklib-runtime_bins)"
+
+  chroot "$rootfs" ln -s /usr/bin/bash /bin/sh
+  chroot "$rootfs" /usr/sbin/update-cracklib
+
+  if ! [ -e "$rootfs"/var/cache/cracklib/cracklib_dict.hwm ]; then
+    echo "expected /var/cache/cracklib/cracklib_dict.hwm to exist"
+    exit -1
+  fi
+
+  if ! [ -e "$rootfs"/var/cache/cracklib/cracklib_dict.pwd ]; then
+    echo "expected /var/cache/cracklib/cracklib_dict.pwd to exist"
+    exit -1
+  fi
+
+  if ! [ -e "$rootfs"/var/cache/cracklib/cracklib_dict.pwi ]; then
+    echo "expected /var/cache/cracklib/cracklib_dict.pwi to exist"
+    exit -1
+  fi
+
+  if ! [ -e "$rootfs"/var/cache/cracklib/src-dicts ]; then
+    echo "expected /var/cache/cracklib/src-dicts to exist"
+    exit -1
+  fi
+
+  # smoke-test rest of binaries
+  chroot "$rootfs" /usr/sbin/update-check --help
+  chroot "$rootfs" /usr/sbin/update-format --help
+  chroot "$rootfs" /usr/sbin/update-packer --help
+  chroot "$rootfs" /usr/sbin/update-unpacker --help


### PR DESCRIPTION
# Proposed changes

Proposing libcrack-runtime and the dependencies it has. Unfortunately I was not able to write a mutation script that does what `update-cracklib` does due to limitations in how we write files. We need the capability to write raw file bytes instead of formatted as text, as it otherwise results in malaligned files.

### Forward porting

I can propose this for 24.10 when this is approved


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

My attempt at the mutation script: https://paste.ubuntu.com/p/Jc5vvgk3tN/