### PR TITLE
slices: add ubuntu-keyring

### DIFF
--- a/slices/ubuntu-keyring.yaml
+++ b/slices/ubuntu-keyring.yaml
@@ -1,0 +1,19 @@
+package: ubuntu-keyring
+
+essential:
+  - ubuntu-keyring_copyright
+
+slices:
+  keys:
+    contents:
+      /etc/apt/trusted.gpg.d/ubuntu-keyring-2012-cdimage.gpg:
+      /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg:
+      /usr/share/keyrings/ubuntu-archive-keyring.gpg:
+      /usr/share/keyrings/ubuntu-archive-removed-keys.gpg:
+      /usr/share/keyrings/ubuntu-cloudimage-keyring.gpg:
+      /usr/share/keyrings/ubuntu-cloudimage-removed-keys.gpg:
+      /usr/share/keyrings/ubuntu-master-keyring.gpg:
+
+  copyright:
+    contents:
+      /usr/share/doc/ubuntu-keyring/copyright:


### PR DESCRIPTION
# Proposed changes

Add the ubuntu-keyring package that bundles gpg keys neccessary for UC.

### Forward porting

I can propose this for 24.10 as well

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
