### PR TITLE
feat(24.04): add dbus-user-session and libpam-systemd

### DIFF
--- a/slices/dbus-user-session.yaml
+++ b/slices/dbus-user-session.yaml
@@ -1,0 +1,21 @@
+package: dbus-user-session
+
+essential:
+  - dbus-user-session_copyright
+
+slices:
+  services:
+    essential:
+      - dbus-daemon_base
+      - dbus-session-bus-common_config
+      - libpam-systemd_libs
+      - systemd_bins
+    contents:
+      /etc/X11/Xsession.d/20dbus_xdg-runtime:
+      /usr/lib/systemd/user/dbus.service:
+      /usr/lib/systemd/user/dbus.socket:
+      /usr/lib/systemd/user/sockets.target.wants/dbus.socket:
+
+  copyright:
+    contents:
+      /usr/share/doc/dbus-user-session/copyright:

--- a/slices/libpam-systemd.yaml
+++ b/slices/libpam-systemd.yaml
@@ -1,0 +1,28 @@
+package: libpam-systemd
+
+essential:
+  - libpam-systemd_copyright
+
+slices:
+  libs:
+    essential:
+      - dbus_bins
+      - libc6_libs
+      - libcap2_libs
+      - libpam-runtime_libs
+      - libpam0g_libs
+      - systemd_bins
+      - systemd-dev_dbus-interfaces
+      - libpam-systemd_pam-config
+    contents:
+      /usr/lib/*-linux-*/security/pam_systemd.so:
+      /usr/lib/*-linux-*/security/pam_systemd_loadkey.so:
+
+  # Used by libpam-runtime to generate proper pam.d files.
+  pam-config:
+    contents:
+      /usr/share/pam-configs/systemd:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpam-systemd/copyright:

--- a/tests/spread/integration/libpam-systemd/task.yaml
+++ b/tests/spread/integration/libpam-systemd/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for libpam-systemd
+
+execute: |
+  rootfs="$(install-slices libpam-systemd_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/pam_systemd.so
+  test -f ${rootfs}/usr/lib/${arch}/pam_systemd_loadkey.so


### PR DESCRIPTION
# Proposed changes

Add dbus-user-session which is package that simply carries systemd units. It also depends on libpam-systemd which is a pure library, so added very basic test for the libpam-systemd as I'm a bit unsure how to best test this. What the user units does are executing dbus-daemon in user context instead of system context as we already test for dbus.

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
