### PR TITLE
feat(24.04): add finalrd and add bins slice to libc-bin

### DIFF
--- a/slices/finalrd.yaml
+++ b/slices/finalrd.yaml
@@ -5,9 +5,9 @@ essential:
 
 slices:
   # finalrd is a shell script that relies on a couple of packages to even
-  # work correctly: libc-bin, systemd, mount, grep and coreutils. If initramfs-tools
-  # is supplied (which is optional), it also needs findutils and debianutils.
-  # so rely on atleast the first set of binaries.
+  # work correctly: libc-bin, systemd, mount, grep and coreutils. 
+  # If initramfs-tools is supplied (which is optional), it also needs 
+  # findutils and debianutils. so rely on atleast the first set of binaries.
   bins:
     essential:
       - coreutils_bins
@@ -18,7 +18,7 @@ slices:
       - systemd_bins
     contents:
       /usr/bin/finalrd:
-  
+
   config:
     contents:
       /usr/lib/finalrd/finalrd-static.conf:

--- a/slices/finalrd.yaml
+++ b/slices/finalrd.yaml
@@ -5,8 +5,8 @@ essential:
 
 slices:
   # finalrd is a shell script that relies on a couple of packages to even
-  # work correctly: libc-bin, systemd, mount, grep and coreutils. 
-  # If initramfs-tools is supplied (which is optional), it also needs 
+  # work correctly: libc-bin, systemd, mount, grep and coreutils.
+  # If initramfs-tools is supplied (which is optional), it also needs
   # findutils and debianutils. so rely on atleast the first set of binaries.
   bins:
     essential:

--- a/slices/finalrd.yaml
+++ b/slices/finalrd.yaml
@@ -1,0 +1,33 @@
+package: finalrd
+
+essential:
+  - finalrd_copyright
+
+slices:
+  # finalrd is a shell script that relies on a couple of packages to even
+  # work correctly: libc-bin, systemd, mount, grep and coreutils. If initramfs-tools
+  # is supplied (which is optional), it also needs findutils and debianutils.
+  # so rely on atleast the first set of binaries.
+  bins:
+    essential:
+      - coreutils_bins
+      - finalrd_config
+      - grep_bins
+      - libc-bin_bins
+      - mount_bins
+      - systemd_bins
+    contents:
+      /usr/bin/finalrd:
+  
+  config:
+    contents:
+      /usr/lib/finalrd/finalrd-static.conf:
+      /usr/share/finalrd/:
+
+  services:
+    contents:
+      /lib/systemd/system/finalrd.service:
+
+  copyright:
+    contents:
+      /usr/share/doc/finalrd/copyright:

--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -6,8 +6,8 @@ essential:
 slices:
   bins:
     essential:
-      - libc6_libs
       - libc-bin_config
+      - libc6_libs
     contents:
       /usr/bin/getconf:
       /usr/bin/getent:

--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -4,6 +4,33 @@ essential:
   - libc-bin_copyright
 
 slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libc-bin_config
+    contents:
+      /usr/bin/getconf:
+      /usr/bin/getent:
+      /usr/bin/iconv:
+      /usr/bin/ld.so:
+      /usr/bin/ldd:
+      /usr/bin/locale:
+      /usr/bin/localedef:
+      /usr/bin/pldd:
+      /usr/bin/tzselect:
+      /usr/bin/zdump:
+      /usr/sbin/iconvconfig:
+      /usr/sbin/ldconfig:
+      /usr/sbin/ldconfig.real:
+      /usr/sbin/zic:
+
+  config:
+    contents:
+      /etc/bindresvport.blacklist:
+      /etc/gai.conf:
+      /etc/ld.so.conf:
+      /etc/ld.so.conf.d/libc.conf:
+
   nsswitch:
     contents:
       /etc/nsswitch.conf: {copy: /usr/share/libc-bin/nsswitch.conf}

--- a/tests/spread/integration/finalrd/task.yaml
+++ b/tests/spread/integration/finalrd/task.yaml
@@ -1,0 +1,13 @@
+summary: Integration tests for finalrd
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices bash_bins base-files_base finalrd_bins)"
+  
+  # the script need /bin/sh
+  chroot "${rootfs}" ln -s /usr/bin/bash /bin/sh
+
+  # try to execute the script, it will fail as it will hit
+  # an apparmor denial in remounting /run as rw,exec
+  chroot "${rootfs}" finalrd 2>&1 | grep "cannot remount"


### PR DESCRIPTION
# Proposed changes

Finalrd is needed by Ubuntu Core - added the package and extended libc-bin by adding the binaries it carries. Those are needed not only by the finalrd script (which invokes ldconfig), but also by our hooks in ubuntu core.

I added a test for finalrd, but as expected it will fail, so we just ensure it fails in the way we expect.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
