### PR TITLE
feat(24.04): add libpam-pwquality and dependencies

### DIFF
--- a/slices/libpam-pwquality.yaml
+++ b/slices/libpam-pwquality.yaml
@@ -1,0 +1,22 @@
+package: libpam-pwquality
+
+essential:
+  - libpam-pwquality_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libpam-runtime_pam-defaults
+      - libpam0g_libs
+      - libpwquality1_libs
+    contents:
+      /usr/lib/*-linux-*/security/pam_pwquality.so:
+
+  pam-config:
+    contents:
+      /usr/share/pam-configs/pwquality:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpam-pwquality/copyright:

--- a/slices/libpwquality-common.yaml
+++ b/slices/libpwquality-common.yaml
@@ -1,0 +1,13 @@
+package: libpwquality-common
+
+essential:
+  - libpwquality-common_copyright
+
+slices:
+  config:
+    contents:
+      /etc/security/pwquality.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpwquality-common/copyright:

--- a/slices/libpwquality1.yaml
+++ b/slices/libpwquality1.yaml
@@ -1,0 +1,17 @@
+package: libpwquality1
+
+essential:
+  - libpwquality1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcrack2_libs
+      - libpwquality-common_config
+    contents:
+      /usr/lib/*-linux-*/libpwquality.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpwquality1/copyright:

--- a/tests/spread/integration/libpam-pwquality/task.yaml
+++ b/tests/spread/integration/libpam-pwquality/task.yaml
@@ -1,0 +1,12 @@
+summary: Integration tests for libpam-pwquality
+
+execute: |
+  rootfs="$(install-slices libpam-pwquality_libs)"
+
+  # simple test that just ensures slices install and
+  # that the primary library is valid file
+
+  apt install --update -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/security/pam_pwquality.so


### PR DESCRIPTION
# Proposed changes

Add the libpam-pwquality library and its dependencies which are relatively basic.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
