### PR TITLE
feat(24.04): add libnss-{extrausers,mdns}

### DIFF
--- a/slices/libnss-extrausers.yaml
+++ b/slices/libnss-extrausers.yaml
@@ -1,0 +1,21 @@
+package: libnss-extrausers
+
+essential:
+  - libnss-extrausers_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnss-extrausers_var
+    contents:
+      /usr/lib/libnss_extrausers.so.2:
+      /usr/lib32/libnss_extrausers.so.2:
+
+  var:
+    contents:
+      /var/lib/extrausers/:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnss-extrausers/copyright:

--- a/slices/libnss-extrausers.yaml
+++ b/slices/libnss-extrausers.yaml
@@ -9,8 +9,8 @@ slices:
       - libc6_libs
       - libnss-extrausers_var
     contents:
-      /usr/lib/libnss_extrausers.so.2:
-      /usr/lib32/libnss_extrausers.so.2: { arch: [amd64, s390x] }
+      /usr/lib/libnss_extrausers.so.*:
+      /usr/lib32/libnss_extrausers.so.*: { arch: [amd64, s390x] }
 
   var:
     contents:

--- a/slices/libnss-extrausers.yaml
+++ b/slices/libnss-extrausers.yaml
@@ -10,7 +10,7 @@ slices:
       - libnss-extrausers_var
     contents:
       /usr/lib/libnss_extrausers.so.2:
-      /usr/lib32/libnss_extrausers.so.2:
+      /usr/lib32/libnss_extrausers.so.2: { arch: [amd64, s390x] }
 
   var:
     contents:

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -10,18 +10,18 @@ slices:
       - libnss-mdns_mdns4
       - libnss-mdns_mdns6
     contents:
-      /lib/*-linux-*/libnss_mdns.so.*:
-      /lib/*-linux-*/libnss_mdns_minimal.so.*:
+      /usr/lib/*-linux-*/libnss_mdns.so.*:
+      /usr/lib/*-linux-*/libnss_mdns_minimal.so.*:
 
   mdns4:
     contents:
-      /lib/*-linux-*/libnss_mdns4.so.*:
-      /lib/*-linux-*/libnss_mdns4_minimal.so.*:
+      /usr/lib/*-linux-*/libnss_mdns4.so.*:
+      /usr/lib/*-linux-*/libnss_mdns4_minimal.so.*:
 
   mdns6:
     contents:
-      /lib/*-linux-*/libnss_mdns6.so.*:
-      /lib/*-linux-*/libnss_mdns6_minimal.so.*:
+      /usr/lib/*-linux-*/libnss_mdns6.so.*:
+      /usr/lib/*-linux-*/libnss_mdns6_minimal.so.*:
 
   copyright:
     contents:

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -1,0 +1,28 @@
+package: libnss-mdns
+
+essential:
+  - libnss-mdns_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnss-mdns_mdns4
+      - libnss-mdns_mdns6
+    contents:
+      /lib/*-linux-*/libnss_mdns.so.*:
+      /lib/*-linux-*/libnss_mdns_minimal.so.*:
+
+  mdns4:
+    contents:
+      /lib/*-linux-*/libnss_mdns4.so.*:
+      /lib/*-linux-*/libnss_mdns4_minimal.so.*:
+
+  mdns6:
+    contents:
+      /lib/*-linux-*/libnss_mdns6.so.*:
+      /lib/*-linux-*/libnss_mdns6_minimal.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnss-mdns/copyright:

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -7,14 +7,14 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libnss-mdns_full
+      - libnss-mdns_standard
       - libnss-mdns_minimal
 
-  full:
+  standard:
     essential:
-      - libnss-mdns_mdns-full
-      - libnss-mdns_mdns4-full
-      - libnss-mdns_mdns6-full
+      - libnss-mdns_mdns-standard
+      - libnss-mdns_mdns4-standard
+      - libnss-mdns_mdns6-standard
 
   minimal:
     essential:
@@ -26,7 +26,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libnss_mdns_minimal.so.*:
 
-  mdns-full:
+  mdns-standard:
     contents:
       /usr/lib/*-linux-*/libnss_mdns.so.*:
 
@@ -34,7 +34,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libnss_mdns4_minimal.so.*:
 
-  mdns4-full:
+  mdns4-standard:
     contents:
       /usr/lib/*-linux-*/libnss_mdns4.so.*:
 
@@ -42,7 +42,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libnss_mdns6_minimal.so.*:
 
-  mdns6-full:
+  mdns6-standard:
     contents:
       /usr/lib/*-linux-*/libnss_mdns6.so.*:
 

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -7,21 +7,44 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libnss-mdns_mdns4
-      - libnss-mdns_mdns6
+      - libnss-mdns_full
+      - libnss-mdns_minimal
+
+  full:
+    essential:
+      - libnss-mdns_mdns-full
+      - libnss-mdns_mdns4-full
+      - libnss-mdns_mdns6-full
+
+  minimal:
+    essential:
+      - libnss-mdns_mdns-minimal
+      - libnss-mdns_mdns4-minimal
+      - libnss-mdns_mdns6-minimal
+
+  mdns-minimal:
     contents:
-      /usr/lib/*-linux-*/libnss_mdns.so.*:
       /usr/lib/*-linux-*/libnss_mdns_minimal.so.*:
 
-  mdns4:
+  mdns-full:
     contents:
-      /usr/lib/*-linux-*/libnss_mdns4.so.*:
+      /usr/lib/*-linux-*/libnss_mdns.so.*:
+
+  mdns4-minimal:
+    contents:
       /usr/lib/*-linux-*/libnss_mdns4_minimal.so.*:
 
-  mdns6:
+  mdns4-full:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns4.so.*:
+
+  mdns6-minimal:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns6_minimal.so.*:
+
+  mdns6-full:
     contents:
       /usr/lib/*-linux-*/libnss_mdns6.so.*:
-      /usr/lib/*-linux-*/libnss_mdns6_minimal.so.*:
 
   copyright:
     contents:

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -7,8 +7,8 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libnss-mdns_standard
       - libnss-mdns_minimal
+      - libnss-mdns_standard
 
   standard:
     essential:


### PR DESCRIPTION
# Proposed changes

Add libnss extra libraries like extrausers and mdns:

* extrausers does not exist on i386

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
