### PR TITLE
feat(24.04): add rfkill

### DIFF
--- a/slices/rfkill.yaml
+++ b/slices/rfkill.yaml
@@ -1,0 +1,16 @@
+package: rfkill
+
+essential:
+  - rfkill_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libsmartcols1_libs
+    contents:
+      /usr/sbin/rfkill:
+
+  copyright:
+    contents:
+      /usr/share/doc/rfkill/copyright:

--- a/tests/spread/integration/rfkill/task.yaml
+++ b/tests/spread/integration/rfkill/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for rfkill
+
+execute: |
+  rootfs="$(install-slices rfkill_bins)"
+  
+  # smoketest the rfkill binary, the rfkill device is
+  # not available in the test system
+  chroot "${rootfs}" rfkill --help


### PR DESCRIPTION
# Proposed changes

Add the rfkill binary, this is not easily tested as the lxd container does not have /dev/rfkill, so smoke test it instead that it loads.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
