### PR TITLE
feat(24.04): libharfbuzz0b slice

### DIFF
--- a/slices/libharfbuzz0b.yaml
+++ b/slices/libharfbuzz0b.yaml
@@ -1,0 +1,18 @@
+package: libharfbuzz0b
+
+essential:
+  - libharfbuzz0b_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libfreetype6_libs
+      - libglib2.0-0t64_libs
+      - libgraphite2-3_libs
+    contents:
+      /usr/lib/*-linux-*/libharfbuzz.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libharfbuzz0b/copyright:

--- a/tests/spread/integration/libharfbuzz0b/task.yaml
+++ b/tests/spread/integration/libharfbuzz0b/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for libharfbuzz0b
+
+execute: |
+  rootfs="$(install-slices libharfbuzz0b_libs fonts-dejavu-mono_fonts)"
+  apt install --update -y libharfbuzz-dev gcc
+  gcc test.c -lharfbuzz -o test-harfbuzz
+  cp test-harfbuzz ${rootfs}/
+  chroot ${rootfs} /test-harfbuzz

--- a/tests/spread/integration/libharfbuzz0b/test.c
+++ b/tests/spread/integration/libharfbuzz0b/test.c
@@ -1,0 +1,37 @@
+#include <harfbuzz/hb.h>
+#include <stdlib.h>
+
+int main()
+{
+    const char* text = "Sample text";
+    hb_buffer_t *buf;
+    buf = hb_buffer_create();
+    hb_buffer_add_utf8(buf, text, -1, 0, -1);
+    hb_buffer_set_direction(buf, HB_DIRECTION_LTR);
+    hb_buffer_set_script(buf, HB_SCRIPT_LATIN);
+    hb_buffer_set_language(buf, hb_language_from_string("en", -1));
+    hb_blob_t *blob = hb_blob_create_from_file("/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf");
+    if (blob == NULL)
+        exit(-1);
+    hb_face_t *face = hb_face_create(blob, 0);
+    if (face == NULL)
+        exit(-2);
+
+    hb_font_t *font = hb_font_create(face);
+    if (font == NULL)
+        exit(-3);
+
+    hb_shape(font, buf, NULL, 0);
+    unsigned int glyph_count;
+    hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(buf, &glyph_count);
+    if (glyph_count == 0)
+        exit(-4);
+    if (glyph_info == NULL)
+        exit(-5);
+
+    hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(buf, &glyph_count);
+    if (glyph_count == 0)
+        exit(-6);
+    if (glyph_pos == NULL)
+        exit(-7);
+}


### PR DESCRIPTION
# Proposed changes

The slice is required as a generic openjdk awt dependency. It is used by OpenJDK libfontmanager.


## Related issues/PRs

[openjdk-21](https://github.com/canonical/chisel-releases/pull/313)

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->