### PR TITLE
fix(24.04): add missing symlink for `libblas3`

### DIFF
--- a/slices/libblas3.yaml
+++ b/slices/libblas3.yaml
@@ -11,6 +11,29 @@ slices:
     contents:
       /usr/lib/*-linux-*/blas/libblas.so.3*:
 
+      # The following symlinks replace the following command that normally
+      # runs as a post-install script:
+      #   update-alternatives --install /usr/lib/x86_64-linux-gnu/libblas.so.3 \
+      #     libblas.so.3-x86_64-linux-gnu /usr/lib/x86_64-linux-gnu/blas/libblas.so.3 10
+      /usr/lib/aarch64-linux-gnu/libblas.so.3:
+        arch: [arm64]
+        symlink: /usr/lib/aarch64-linux-gnu/blas/libblas.so.3
+      /usr/lib/arm-linux-gnu/libblas.so.3:
+        arch: [armhf]
+        symlink: /usr/lib/arm-linux-gnu/blas/libblas.so.3
+      /usr/lib/powerpc64le-linux-gnu/libblas.so.3:
+        arch: [ppc64el]
+        symlink: /usr/lib/powerpc64le-linux-gnu/blas/libblas.so.3
+      /usr/lib/riscv64-linux-gnu/libblas.so.3:
+        arch: [riscv64]
+        symlink: /usr/lib/riscv64-linux-gnu/blas/libblas.so.3
+      /usr/lib/s390x-linux-gnu/libblas.so.3:
+        arch: [s390x]
+        symlink: /usr/lib/s390x-linux-gnu/blas/libblas.so.3
+      /usr/lib/x86_64-linux-gnu/libblas.so.3:
+        arch: [amd64]
+        symlink: /usr/lib/x86_64-linux-gnu/blas/libblas.so.3
+
   copyright:
     contents:
       /usr/share/doc/libblas3/copyright:


### PR DESCRIPTION
# Proposed changes

The `libblas3` package post install scripts create a symbolic link that is currently missing from the corresponding package slice, leading to errors finding the lib when trying to run a program that links against it:
```sh
ffmpeg: error while loading shared libraries: libblas.so.3: cannot open shared object file: No such file or directory
```

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->