### PR TITLE
ci: use Chisel from main

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -121,7 +121,7 @@ jobs:
           set -ex
 
           # Install chisel
-          go install github.com/canonical/chisel/cmd/chisel@latest
+          go install github.com/canonical/chisel/cmd/chisel@main
 
           # Install dependencies of the install_slices script
           sudo apt-get -y update


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

For installing slices within the CI, we want to use the latest dev version of Chisel (in `main`) instead of the latest release.

## Related issues/PRs
<!-- If any -->

#226 


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
