### PR TITLE
feat(20.04): add slice to generate DB

### DIFF
--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -63,6 +63,13 @@ slices:
       /etc/os-release:
       /usr/lib/os-release:
 
+  # Dedicated slice for generating the Chisel manifest.
+  chisel:
+    essential:
+      - base-files_var
+    contents:
+      /var/lib/chisel/**: {generate: manifest}
+
   copyright:
     contents:
       /usr/share/doc/base-files/copyright:


### PR DESCRIPTION
This commit adds a new slice ``base-files_chisel`` which does not extract anything from the package, rather comes with an artificial path where the Chisel DB should be generated.

This commit is the first one to introduce the "generate" keyword to paths. The "generate" keyword is designed to _generate_ various bookkeeping stuff for a chiselled file system. Right now, it only supports one value: "manifest". Mark a path with "generate: manifest" to generate a Chisel DB at that location. Please note that, the marking path must be in the following format:

    /absolute/path/to/dir/**

The path must be an absolute directory path with no wildcard in it's name followed by trailing ** which makes sure nothing else is generated in that directory.

### Related PRs

- #226 
- #357 