### PR TITLE
fix(openjdk-21): remove jvm.cfg-default (packaging)

### DIFF
--- a/slices/openjdk-21-jre-headless.yaml
+++ b/slices/openjdk-21-jre-headless.yaml
@@ -58,7 +58,6 @@ slices:
       /usr/lib/jvm/java-21-openjdk-*/lib/jexec:
       /usr/lib/jvm/java-21-openjdk-*/lib/jspawnhelper:
       /usr/lib/jvm/java-21-openjdk-*/lib/jvm.cfg:
-      /usr/lib/jvm/java-21-openjdk-*/lib/jvm.cfg-default:
       /usr/lib/jvm/java-21-openjdk-*/lib/libextnet.so:
       /usr/lib/jvm/java-21-openjdk-*/lib/libjava.so:
       # lib/modules support


### PR DESCRIPTION
# Proposed changes

jvm.cfg-default is a packaging artifact:
[d/rules](https://salsa.debian.org/openjdk-team/openjdk/-/blob/master/debian/rules?ref_type=heads#L1335)

It is not needed for the runtime and is provided as a sample of JVM config file.

## Related issues/PRs


### Forward porting


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->