### PR TITLE
feat(24.04): add wget slices

### DIFF
--- a/slices/wget.yaml
+++ b/slices/wget.yaml
@@ -1,0 +1,20 @@
+package: wget
+
+essential:
+  - wget_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libidn2-0_libs
+      - libpcre2-8-0_libs
+      - libpsl5t64_libs
+      - libssl3t64_libs
+      - libuuid1_libs
+      - zlib1g_libs
+    contents:
+      /usr/bin/wget:
+  copyright:
+    contents:
+      /usr/share/doc/wget/copyright:

--- a/tests/spread/integration/wget/task.yaml
+++ b/tests/spread/integration/wget/task.yaml
@@ -1,0 +1,11 @@
+summary: Integration tests for wget
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices ca-certificates_data wget_bins)"
+  cp /etc/resolv.conf "${rootfs}/etc/"
+
+  # Download README.md from repo and compare to a known hash.
+  chroot "${rootfs}/" wget https://raw.githubusercontent.com/canonical/chisel-releases/refs/heads/ubuntu-24.04/README.md
+  [[ $(sha256sum "${rootfs}/README.md" | cut -d' ' -f1) == e3323f69dc6bc6bf41a45dc0d550a3882b7ed1dcb49e4f1f125b3cb5f2cfab8f ]]

--- a/tests/spread/integration/wget/task.yaml
+++ b/tests/spread/integration/wget/task.yaml
@@ -6,6 +6,6 @@ execute: |
   rootfs="$(install-slices ca-certificates_data wget_bins)"
   cp /etc/resolv.conf "${rootfs}/etc/"
 
-  # Download README.md from repo and compare to a known hash.
-  chroot "${rootfs}/" wget https://raw.githubusercontent.com/canonical/chisel-releases/refs/heads/ubuntu-24.04/README.md
-  [[ $(sha256sum "${rootfs}/README.md" | cut -d' ' -f1) == e3323f69dc6bc6bf41a45dc0d550a3882b7ed1dcb49e4f1f125b3cb5f2cfab8f ]]
+  # Download Chisel release and compare to a known hash.
+  chroot "${rootfs}/" wget https://github.com/canonical/chisel/releases/download/v1.0.0/chisel_v1.0.0_linux_amd64.tar.gz
+  [[ $(sha256sum "${rootfs}/README.md" | cut -d' ' -f1) == 655ca8f45e6f052ab60a4acfeca5017c7d992035e0e4a01f78881c0fe45f2103ce2f18a352ddc8f5fb88bfdd1ed8cc6b ]]

--- a/tests/spread/integration/wget/task.yaml
+++ b/tests/spread/integration/wget/task.yaml
@@ -8,4 +8,4 @@ execute: |
 
   # Download Chisel release and compare to a known hash.
   chroot "${rootfs}/" wget https://github.com/canonical/chisel/releases/download/v1.0.0/chisel_v1.0.0_linux_amd64.tar.gz
-  [[ $(sha256sum "${rootfs}/README.md" | cut -d' ' -f1) == 655ca8f45e6f052ab60a4acfeca5017c7d992035e0e4a01f78881c0fe45f2103ce2f18a352ddc8f5fb88bfdd1ed8cc6b ]]
+  [[ $(sha384sum "${rootfs}/README.md" | cut -d' ' -f1) == 655ca8f45e6f052ab60a4acfeca5017c7d992035e0e4a01f78881c0fe45f2103ce2f18a352ddc8f5fb88bfdd1ed8cc6b ]]

--- a/tests/spread/integration/wget/task.yaml
+++ b/tests/spread/integration/wget/task.yaml
@@ -8,4 +8,5 @@ execute: |
 
   # Download Chisel release and compare to a known hash.
   chroot "${rootfs}/" wget https://github.com/canonical/chisel/releases/download/v1.0.0/chisel_v1.0.0_linux_amd64.tar.gz
-  [[ $(sha384sum "${rootfs}/README.md" | cut -d' ' -f1) == 655ca8f45e6f052ab60a4acfeca5017c7d992035e0e4a01f78881c0fe45f2103ce2f18a352ddc8f5fb88bfdd1ed8cc6b ]]
+  chroot "${rootfs}/" wget https://github.com/canonical/chisel/releases/download/v1.0.0/chisel_v1.0.0_linux_amd64.tar.gz.sha384
+  cd "${rootfs}" && sha384sum -c chisel_v1.0.0_linux_amd64.tar.gz.sha384


### PR DESCRIPTION
Add slices for gnu wget.

# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->
This change adds the GNU variant of `wget`.

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
Assuming this change is approved I'm happy to also PR for 24.10.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->
I have manually tested the installation and usage of the slice.