### PR TITLE
fix(spread): check chisel binary integrity

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -84,16 +84,16 @@ backends:
 prepare: |
   # Deb arch to GOARCH
   arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/g' -e 's/ppc64el/ppc64le/g')"
-  chisel_tar="chisel.tar.gz"
 
   apt install -y curl wget
   curl -s https://api.github.com/repos/canonical/chisel/releases/latest \
     | awk "/browser_download_url/ && /chisel_v/ && /$arch/" \
     | cut -d : -f 2,3 \
     | tr -d \" \
-    | xargs wget -O $chisel_tar
+    | xargs wget
 
-  tar -xf $chisel_tar -C /usr/local/bin
+  sha384sum -c chisel_v*sha384
+  tar -xf chisel_v*tar.gz -C /usr/local/bin
 
 prepare-each: chisel version
 


### PR DESCRIPTION
# Proposed changes

Chisel's v1.0.0 has 2 release assets per architecture now. This PR fixes the installation of Chisel in the spread system and add integrity verification of the downloaded binary.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Quick test via: `spread lxd:tests/spread/integration/base-passwd`