### PR TITLE
fix(spread-24.10): make spread work on armhf

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -87,7 +87,7 @@ prepare: |
 
   apt install -y curl wget
   curl -s https://api.github.com/repos/canonical/chisel/releases/latest \
-    | awk "/browser_download_url/ && /chisel_v/ && /$arch/" \
+    | awk "/browser_download_url/ && /chisel_v/ && /_$arch\./" \
     | cut -d : -f 2,3 \
     | tr -d \" \
     | xargs wget

--- a/tests/spread/integration/dash/task.yaml
+++ b/tests/spread/integration/dash/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for dash
+
+execute: |
+  rootfs="$(install-slices dash_bins)"
+
+  chroot "${rootfs}" dash -c "echo Success > /test"
+
+  test $(cat "${rootfs}/test") == "Success"


### PR DESCRIPTION
# Proposed changes
This fixes an error where spread tests on docker for armhf was failing the preparation step due to getting both the arm and arm64 downloads.

## Related issues/PRs
- [Jammy](https://github.com/canonical/chisel-releases/pull/369)
- [Noble](https://github.com/canonical/chisel-releases/pull/370)

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->