### PR TITLE
fix(24.04): add default archive in chisel.yaml

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -2,6 +2,7 @@ format: v1
 
 archives:
   ubuntu:
+    default: true
     version: 24.04
     components: [main, universe]
     suites: [noble, noble-security, noble-updates]


### PR DESCRIPTION
This PR adds `default: true` to the `ubuntu` archive in chisel.yaml. This is being added due to chisel supporting multiple archives now: https://github.com/canonical/chisel/commit/7eb8428f432557aeaa502fec8ee7c28aa0c8d271.

Related:

- [ ] #373
- [ ] #374 
- [ ] #375 
- [ ] #376 