### PR TITLE
fix(22.04/libnss3): libs should contain all libraries

### DIFF
--- a/slices/ca-certificates-java.yaml
+++ b/slices/ca-certificates-java.yaml
@@ -7,7 +7,7 @@ slices:
   data:
     essential:
       - ca-certificates_data
-      - libnss3_libs
+      - libnss3_nss
     contents:
       /etc/default/cacerts:
       /etc/ssl/certs/java/:

--- a/slices/ca-certificates-java.yaml
+++ b/slices/ca-certificates-java.yaml
@@ -7,7 +7,6 @@ slices:
   data:
     essential:
       - ca-certificates_data
-      - libnss3_nss
     contents:
       /etc/default/cacerts:
       /etc/ssl/certs/java/:

--- a/slices/ca-certificates-java.yaml
+++ b/slices/ca-certificates-java.yaml
@@ -7,6 +7,7 @@ slices:
   data:
     essential:
       - ca-certificates_data
+      - libnss3_nss
     contents:
       /etc/default/cacerts:
       /etc/ssl/certs/java/:

--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -27,11 +27,6 @@ slices:
     contents:
       /usr/lib/*-linux-*/libnss3.so:
       /usr/lib/*-linux-*/libnssutil3.so:
-      # Checksum files (.chk) are required for the NSS softoken to operate in
-      # FIPS 140 mode.
-      # https://www-archive.mozilla.org/projects/security/pki/nss/tech-notes/tn6
-      /usr/lib/*-linux-*/nss/libsoftokn3.chk:
-      /usr/lib/*-linux-*/nss/libsoftokn3.so:
 
   smime:
     essential:

--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -23,6 +23,7 @@ slices:
     essential:
       - libc6_libs
       - libnspr4_libs
+      - libsqlite3-0_libs
     contents:
       /usr/lib/*-linux-*/libnss3.so:
       /usr/lib/*-linux-*/libnssutil3.so:

--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -1,17 +1,38 @@
+# Network Security Service libraries.
+#
+# This is a set of libraries designed to support cross-platform development of
+# security-enabled client and server applications. It can support SSLv2 and v4,
+# TLS, PKCS #5, #7, #11, #12, S/MIME, X.509 v3 certificates and other security
+# standards.
 package: libnss3
 
 essential:
   - libnss3_copyright
 
 slices:
+  # The libs slice contains all the libraries coming from this package.
   libs:
+    essential:
+      # This package still has many other libraries which are not part of any
+      # slices yet. Upon creation of new slices containing those libraries,
+      # make sure to add those slices in this list.
+      - libnss3_nss
+      - libnss3_smime
+
+  nss:
     essential:
       - libc6_libs
       - libnspr4_libs
-      - libsqlite3-0_libs
     contents:
       /usr/lib/*-linux-*/libnss3.so:
       /usr/lib/*-linux-*/libnssutil3.so:
+
+  smime:
+    essential:
+      - libc6_libs
+      - libnspr4_libs
+    contents:
+      /usr/lib/*-linux-*/libsmime3.so:
 
   copyright:
     contents:

--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -27,6 +27,11 @@ slices:
     contents:
       /usr/lib/*-linux-*/libnss3.so:
       /usr/lib/*-linux-*/libnssutil3.so:
+      # Checksum files (.chk) are required for the NSS softoken to operate in
+      # FIPS 140 mode.
+      # https://www-archive.mozilla.org/projects/security/pki/nss/tech-notes/tn6
+      /usr/lib/*-linux-*/nss/libsoftokn3.chk:
+      /usr/lib/*-linux-*/nss/libsoftokn3.so:
 
   smime:
     essential:

--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -79,6 +79,7 @@ slices:
   security:
     essential:
       - ca-certificates-java_data
+      - libnss3_nss
       - libpcsclite1_libs
       - openjdk-8-jre-headless_core
     contents:

--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -79,7 +79,6 @@ slices:
   security:
     essential:
       - ca-certificates-java_data
-      - libnss3_nss
       - libpcsclite1_libs
       - openjdk-8-jre-headless_core
     contents:


### PR DESCRIPTION
This PR restructures the libnss3 slices. It renames the former `libs` slice to `nss`, to only include nss3-specific libraries. It also adds a new slice `smime` to include S/MIME libraries.

Finally, the `libs` slice is added back, which includes all of the slices that provide libraries. The rationale is that "libs" slices should contain all libraries coming from the package.

Note that the ca-certificates-java slice has also been updated to reflect this change.

Resolves #381 