### PR TITLE
Update changed-files action to v45

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -26,9 +26,9 @@ jobs:
             slices:
               - added|modified: 'slices/**/*.yaml'
           list-files: shell
-      
+
       - name: Check changed test directories
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v45
         id: changed-tests
         with:
           separator: " "


### PR DESCRIPTION
# Proposed changes

Update the [changed-files](https://github.com/tj-actions/changed-files) github action to version 45. Versions before 41 are subject to a command injection vulnerability, see https://github.com/advisories/GHSA-mcph-m25j-8j63

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->