### PR TITLE
feat(24.04) add erlang slices

### DIFF
--- a/slices/erlang-asn1.yaml
+++ b/slices/erlang-asn1.yaml
@@ -1,0 +1,17 @@
+package: erlang-asn1
+
+essential:
+  - erlang-asn1_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+      - libc6_libs
+    contents:
+      /usr/lib/erlang/lib/asn1-*/ebin/**:
+      /usr/lib/erlang/lib/asn1-*/priv/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-asn1/copyright:

--- a/slices/erlang-base.yaml
+++ b/slices/erlang-base.yaml
@@ -1,0 +1,41 @@
+package: erlang-base
+
+essential:
+  - erlang-base_copyright
+
+slices:
+  bins:
+    essential:
+      - erlang-base_modules
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libsystemd0_libs
+      - libtinfo6_libs
+      - zlib1g_libs
+    contents:
+      /usr/bin/epmd:
+      /usr/bin/erl:
+      /usr/bin/erl_call:
+      /usr/bin/erlc:
+      /usr/bin/escript:
+      /usr/bin/run_erl:
+      /usr/bin/start_embedded:
+      /usr/bin/to_erl:
+      /usr/lib/erlang/bin/**:
+      /usr/lib/erlang/erts-*/bin/**:
+      /usr/lib/erlang/lib/erl_interface-*/bin/erl_call:
+
+  modules:
+    contents:
+      /usr/lib/erlang/lib/compiler-*/ebin/**:
+      /usr/lib/erlang/lib/erts-*/ebin/**:
+      /usr/lib/erlang/lib/kernel-*/ebin/**:
+      /usr/lib/erlang/lib/sasl-*/ebin/**:
+      /usr/lib/erlang/lib/stdlib-*/ebin/**:
+      /usr/lib/erlang/lib/stdlib-*/include/**:
+      /usr/lib/erlang/releases/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-base/copyright:

--- a/slices/erlang-crypto.yaml
+++ b/slices/erlang-crypto.yaml
@@ -1,0 +1,18 @@
+package: erlang-crypto
+
+essential:
+  - erlang-crypto_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+      - libc6_libs
+      - libssl3t64_libs
+    contents:
+      /usr/lib/erlang/lib/crypto-*/ebin/**:
+      /usr/lib/erlang/lib/crypto-*/priv/lib/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-crypto/copyright:

--- a/slices/erlang-eldap.yaml
+++ b/slices/erlang-eldap.yaml
@@ -1,0 +1,17 @@
+package: erlang-eldap
+
+essential:
+  - erlang-eldap_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-asn1_modules
+      - erlang-base_bins
+      - erlang-ssl_modules
+    contents:
+      /usr/lib/erlang/lib/eldap-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-eldap/copyright:

--- a/slices/erlang-ftp.yaml
+++ b/slices/erlang-ftp.yaml
@@ -1,0 +1,17 @@
+package: erlang-ftp
+
+essential:
+  - erlang-ftp_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+      - erlang-runtime-tools_modules
+      - erlang-ssl_modules
+    contents:
+      /usr/lib/erlang/lib/ftp-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-ftp/copyright:

--- a/slices/erlang-inets.yaml
+++ b/slices/erlang-inets.yaml
@@ -1,0 +1,27 @@
+package: erlang-inets
+
+essential:
+  - erlang-inets_copyright
+
+slices:
+  scripts:
+    essential:
+      - erlang-inets_modules
+    contents:
+      /usr/lib/erlang/lib/inets-*/priv/bin/runcgi.sh:
+
+  modules:
+    essential:
+      - erlang-base_bins
+      - erlang-ftp_modules
+      - erlang-mnesia_modules
+      - erlang-runtime-tools_modules
+      - erlang-ssl_modules
+      - erlang-tftp_modules
+    contents:
+      /usr/lib/erlang/lib/inets-*/ebin/**:
+      /usr/lib/erlang/lib/inets-*/include/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-inets/copyright:

--- a/slices/erlang-mnesia.yaml
+++ b/slices/erlang-mnesia.yaml
@@ -1,0 +1,15 @@
+package: erlang-mnesia
+
+essential:
+  - erlang-mnesia_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+    contents:
+      /usr/lib/erlang/lib/mnesia-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-mnesia/copyright:

--- a/slices/erlang-os-mon.yaml
+++ b/slices/erlang-os-mon.yaml
@@ -1,0 +1,24 @@
+package: erlang-os-mon
+
+essential:
+  - erlang-os-mon_copyright
+
+slices:
+  bins:
+    essential:
+      - erlang-os-mon_modules
+    contents:
+      /usr/lib/erlang/lib/os_mon-*/priv/**:
+
+  modules:
+    essential:
+      - erlang-base_bins
+      - erlang-mnesia_modules
+      - erlang-snmp_bins
+      - libc6_libs
+    contents:
+      /usr/lib/erlang/lib/os_mon-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-os-mon/copyright:

--- a/slices/erlang-parsetools.yaml
+++ b/slices/erlang-parsetools.yaml
@@ -1,0 +1,15 @@
+package: erlang-parsetools
+
+essential:
+  - erlang-parsetools_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+    contents:
+      /usr/lib/erlang/lib/parsetools-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-parsetools/copyright:

--- a/slices/erlang-public-key.yaml
+++ b/slices/erlang-public-key.yaml
@@ -1,0 +1,17 @@
+package: erlang-public-key
+
+essential:
+  - erlang-public-key_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-asn1_modules
+      - erlang-base_bins
+      - erlang-crypto_modules
+    contents:
+      /usr/lib/erlang/lib/public_key-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-public-key/copyright:

--- a/slices/erlang-runtime-tools.yaml
+++ b/slices/erlang-runtime-tools.yaml
@@ -1,0 +1,18 @@
+package: erlang-runtime-tools
+
+essential:
+  - erlang-runtime-tools_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+      - erlang-mnesia_modules
+      - libc6_libs
+    contents:
+      /usr/lib/erlang/lib/runtime_tools-*/ebin/**:
+      /usr/lib/erlang/lib/runtime_tools-*/priv/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-runtime-tools/copyright:

--- a/slices/erlang-snmp.yaml
+++ b/slices/erlang-snmp.yaml
@@ -1,0 +1,36 @@
+package: erlang-snmp
+
+essential:
+  - erlang-snmp_copyright
+
+slices:
+  bins:
+    essential:
+      - erlang-base_bins
+      - erlang-crypto_modules
+      - erlang-mnesia_modules
+      - erlang-runtime-tools_modules
+      - erlang-snmp_config
+      - erlang-snmp_data
+      - erlang-snmp_modules
+    contents:
+      /usr/bin/snmpc:
+      /usr/lib/erlang/lib/snmp-*/bin/snmpc:
+
+  config:
+    contents:
+      /usr/lib/erlang/lib/snmp-*/priv/conf/**:
+
+  data:
+    contents:
+      /usr/lib/erlang/lib/snmp-*/mibs/**:
+      /usr/lib/erlang/lib/snmp-*/priv/mibs/**:
+
+  modules:
+    contents:
+      /usr/lib/erlang/lib/snmp-*/ebin/**:
+      /usr/lib/erlang/lib/snmp-*/include/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-snmp/copyright:

--- a/slices/erlang-ssl.yaml
+++ b/slices/erlang-ssl.yaml
@@ -1,0 +1,18 @@
+package: erlang-ssl
+
+essential:
+  - erlang-ssl_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+      - erlang-crypto_modules
+      - erlang-public-key_modules
+      - erlang-runtime-tools_modules
+    contents:
+      /usr/lib/erlang/lib/ssl-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-ssl/copyright:

--- a/slices/erlang-syntax-tools.yaml
+++ b/slices/erlang-syntax-tools.yaml
@@ -1,0 +1,16 @@
+package: erlang-syntax-tools
+
+essential:
+  - erlang-syntax-tools_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+    contents:
+      /usr/lib/erlang/lib/syntax_tools-*/ebin/**:
+      /usr/lib/erlang/lib/syntax_tools-*/include/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-syntax-tools/copyright:

--- a/slices/erlang-tftp.yaml
+++ b/slices/erlang-tftp.yaml
@@ -1,0 +1,15 @@
+package: erlang-tftp
+
+essential:
+  - erlang-tftp_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+    contents:
+      /usr/lib/erlang/lib/tftp-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-tftp/copyright:

--- a/slices/erlang-tools.yaml
+++ b/slices/erlang-tools.yaml
@@ -1,0 +1,18 @@
+package: erlang-tools
+
+essential:
+  - erlang-tools_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+      - erlang-runtime-tools_modules
+    contents:
+      /usr/lib/erlang/lib/tools-*/ebin/**:
+      /usr/lib/erlang/lib/tools-*/emacs/**:
+      /usr/lib/erlang/lib/tools-*/priv/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-tools/copyright:

--- a/slices/erlang-xmerl.yaml
+++ b/slices/erlang-xmerl.yaml
@@ -1,0 +1,15 @@
+package: erlang-xmerl
+
+essential:
+  - erlang-xmerl_copyright
+
+slices:
+  modules:
+    essential:
+      - erlang-base_bins
+    contents:
+      /usr/lib/erlang/lib/xmerl-*/ebin/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/erlang-xmerl/copyright:

--- a/tests/spread/integration/erlang/task.yaml
+++ b/tests/spread/integration/erlang/task.yaml
@@ -1,0 +1,27 @@
+summary: Integration tests for Erlang
+
+execute: |
+  rootfs="$(install-slices erlang-base_bins erlang-inets_scripts erlang-os-mon_bins erlang-crypto_modules erlang-eldap_modules erlang-mnesia_modules erlang-parsetools_modules erlang-public-key_modules erlang-runtime-tools_modules erlang-ssl_modules erlang-syntax-tools_modules erlang-tools_modules erlang-xmerl_modules base-files_base bash_bins coreutils_bins)"
+
+  mkdir -p "$rootfs"/bin "$rootfs"/etc "$rootfs"/dev "$rootfs"/root
+  cp /bin/sh "$rootfs"/bin/
+  cp /etc/resolv.conf "$rootfs"/etc/
+  cp /etc/nsswitch.conf "$rootfs"/etc/
+  touch "$rootfs"/dev/null
+  chmod 777 "$rootfs"/dev/null
+  echo "cookie" > "$rootfs"/root/.erlang.cookie
+  chroot "$rootfs" chmod 400 /root/.erlang.cookie
+  # test epmd daemon
+  chroot "$rootfs" /usr/bin/epmd -daemon
+  # test erl eval
+  chroot "$rootfs" /usr/bin/erl -noshell -eval 'io:format("Erlang OK~n"), halt().' | grep "Erlang OK"
+  # test escript by executing a simple script
+  echo '#!/usr/bin/escript' > test_script
+  echo 'main(_) -> io:format("escript OK~n").' >> test_script
+  chmod +x test_script
+  mv test_script "$rootfs"
+  chroot "$rootfs" /usr/bin/escript test_script
+  # test start_embedded to start the embedded environment
+  chroot "$rootfs" /usr/bin/start_embedded
+  # test runcgi.sh from erlang-inets
+  chroot "$rootfs" /usr/lib/erlang/lib/inets-8.3.1.2/priv/bin/runcgi.sh /bin


### PR DESCRIPTION
# Proposed changes

Add erlang-* slices to 24.04

Note that erlang packages are not available for i386 arch.

## Related issues/PRs

PR #258

## Forward porting

N/A\n\n

## Checklist

* [x] I have read the [contributing guidelines](\nhttps://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](\nhttps://ubuntu.com/legal/contributors/agreement)

## Additional Context

N/A
