### PR TITLE
fix(24.04/libnss3): libs should contain all libraries

### DIFF
--- a/slices/libnss3.yaml
+++ b/slices/libnss3.yaml
@@ -1,10 +1,25 @@
+# Network Security Service libraries.
+#
+# This is a set of libraries designed to support cross-platform development of
+# security-enabled client and server applications. It can support SSLv2 and v4,
+# TLS, PKCS #5, #7, #11, #12, S/MIME, X.509 v3 certificates and other security
+# standards.
 package: libnss3
 
 essential:
   - libnss3_copyright
 
 slices:
+  # The libs slice contains all the libraries coming from this package.
   libs:
+    essential:
+      # This package still has many other libraries which are not part of any
+      # slices yet. Upon creation of new slices containing those libraries,
+      # make sure to add those slices in this list.
+      - libnss3_nss
+      - libnss3_smime
+
+  nss:
     essential:
       - libc6_libs
       - libnspr4_libs
@@ -12,6 +27,13 @@ slices:
     contents:
       /usr/lib/*-linux-*/libnss3.so:
       /usr/lib/*-linux-*/libnssutil3.so:
+
+  smime:
+    essential:
+      - libc6_libs
+      - libnspr4_libs
+    contents:
+      /usr/lib/*-linux-*/libsmime3.so:
 
   copyright:
     contents:

--- a/slices/openjdk-11-jre-headless.yaml
+++ b/slices/openjdk-11-jre-headless.yaml
@@ -131,7 +131,7 @@ slices:
   # Security configuration files and native libraries
   security:
     essential:
-      - libnss3_libs
+      - libnss3_nss
       - libpcsclite1_libs
       - openjdk-11-jre-headless_core
     contents:

--- a/slices/openjdk-17-jre-headless.yaml
+++ b/slices/openjdk-17-jre-headless.yaml
@@ -118,7 +118,7 @@ slices:
   # Security configuration files and native libraries
   security:
     essential:
-      - libnss3_libs
+      - libnss3_nss
       - libpcsclite1_libs
       - openjdk-17-jre-headless_core
     contents:

--- a/slices/openjdk-21-jre-headless.yaml
+++ b/slices/openjdk-21-jre-headless.yaml
@@ -130,7 +130,7 @@ slices:
   # Security configuration files and native libraries
   security:
     essential:
-      - libnss3_libs
+      - libnss3_nss
       - libpcsclite1_libs
       - openjdk-21-jre-headless_core
     contents:

--- a/slices/openjdk-8-jre-headless.yaml
+++ b/slices/openjdk-8-jre-headless.yaml
@@ -80,7 +80,7 @@ slices:
   # of the runtime.
   security:
     essential:
-      - libnss3_libs
+      - libnss3_nss
       - libpcsclite1_libs
       - openjdk-8-jre-headless_core
     contents:


### PR DESCRIPTION
This PR restructures the libnss3 slices. It renames the former "libs" slice to "nss", to only include nss3-specific libraries. It also adds a new slice "smime" to include S/MIME libraries.

Finally, the "libs" slice is added back, which includes all of the slices that provide libraries. The rationale is that "libs" slices should contain all libraries coming from the package.

Note that the openjdk-*-jre-headless slices have also been updated to reflect this change.

Resolves #381

## Forward-porting
- #382.