### PR TITLE
fix(libsubid4): typo in essential

### DIFF
--- a/slices/libsubid4.yaml
+++ b/slices/libsubid4.yaml
@@ -1,6 +1,6 @@
 package: libsubid4
 
-esential:
+essential:
   - libsubid4_copyright
 
 slices:


### PR DESCRIPTION
The typo causing the error: https://github.com/canonical/chisel-releases/actions/runs/12000988007/job/33450865802

(by @letFunny )