### PR TITLE
feat(24.10): Add SDF for `librdkafka++1`

### DIFF
--- a/slices/librdkafka++1.yaml
+++ b/slices/librdkafka++1.yaml
@@ -1,0 +1,18 @@
+package: librdkafka++1
+
+essential:
+  - librdkafka++1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - librdkafka1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/librdkafka++.so.1:
+
+  copyright:
+    contents:
+      /usr/share/doc/librdkafka++1/copyright:

--- a/slices/librdkafka1.yaml
+++ b/slices/librdkafka1.yaml
@@ -1,0 +1,21 @@
+package: librdkafka1
+
+essential:
+  - librdkafka1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcurl4t64_libs
+      - liblz4-1_libs
+      - libsasl2-2_libs
+      - libssl3t64_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/librdkafka.so.1:
+
+  copyright:
+    contents:
+      /usr/share/doc/librdkafka1/copyright:


### PR DESCRIPTION
# Proposed changes

Add SDF for the `librdkafka++1` package and dependencies

## Related issues/PRs

* 24.04 PR: #399
  Notable difference: `librdkafka` has a new dependency on `libcurl4t64` in 24.10 that it did not have in 24.04
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->