### PR TITLE
feat(24.10): Add SDF for `librocksdb9.3` and dependencies

### DIFF
--- a/slices/libgflags2.2.yaml
+++ b/slices/libgflags2.2.yaml
@@ -1,0 +1,18 @@
+package: libgflags2.2
+
+essential:
+  - libgflags2.2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libgflags.so.2.2*:
+      /usr/lib/*-linux-*/libgflags_nothreads.so.2.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgflags2.2/copyright:

--- a/slices/librocksdb9.3.yaml
+++ b/slices/librocksdb9.3.yaml
@@ -1,0 +1,23 @@
+package: librocksdb9.3
+
+essential:
+  - librocksdb9.3_copyright
+
+slices:
+  libs:
+    essential:
+      - libbz2-1.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libgflags2.2_libs
+      - liblz4-1_libs
+      - libsnappy1v5_libs
+      - libstdc++6_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/librocksdb.so.9.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librocksdb9.3/copyright:

--- a/slices/libsnappy1v5.yaml
+++ b/slices/libsnappy1v5.yaml
@@ -1,0 +1,18 @@
+package: libsnappy1v5
+
+essential:
+  - libsnappy1v5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      # libsnappy1v5 depends on libgcc-s1 on i386, riscv64 and armhf
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libsnappy.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsnappy1v5/copyright:


### PR DESCRIPTION
# Proposed changes

Add SDF for the `librocksdb9.3` package and dependencies

## Related issues/PRs

* 24.04 PR: #401
  Notable difference: package is `librocksdb8.9` on 24.04 and `librocksdb9.3` on 24.10, SDF are otherwise similar

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->