### PR TITLE
feat(24.04): Add SDF for `librocksdb8.9` and dependencies

### DIFF
--- a/slices/libgflags2.2.yaml
+++ b/slices/libgflags2.2.yaml
@@ -1,0 +1,18 @@
+package: libgflags2.2
+
+essential:
+  - libgflags2.2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libgflags.so.2.2*:
+      /usr/lib/*-linux-*/libgflags_nothreads.so.2.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgflags2.2/copyright:

--- a/slices/librocksdb8.9.yaml
+++ b/slices/librocksdb8.9.yaml
@@ -1,0 +1,23 @@
+package: librocksdb8.9
+
+essential:
+  - librocksdb8.9_copyright
+
+slices:
+  libs:
+    essential:
+      - libbz2-1.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libgflags2.2_libs
+      - liblz4-1_libs
+      - libsnappy1v5_libs
+      - libstdc++6_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/librocksdb.so.8.9*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librocksdb8.9/copyright:

--- a/slices/libsnappy1v5.yaml
+++ b/slices/libsnappy1v5.yaml
@@ -1,0 +1,18 @@
+package: libsnappy1v5
+
+essential:
+  - libsnappy1v5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      # libsnappy1v5 depends on libgcc-s1 on riscv64 and armhf
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libsnappy.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsnappy1v5/copyright:


### PR DESCRIPTION
# Proposed changes

Add SDF for the `librocksdb8.9` package and dependencies

## Related issues/PRs

## Forward porting

* 24.10 PR: #400
  Notable difference: package is `librocksdb8.9` on 24.04 and `librocksdb9.3` on 24.10, SDF are otherwise similar


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->