### PR TITLE
feat(22.04): add pro archives definition

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -4,7 +4,6 @@ archives:
   # archive.ubuntu.com/ubuntu/      (amd64, i386)
   # ports.ubuntu.com/ubuntu-ports/  (other arch)
   ubuntu:
-    default: true
     priority: 10
     version: 22.04
     components: [main, universe]

--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,12 +1,41 @@
 format: v1
 
 archives:
+  # archive.ubuntu.com/ubuntu/
   ubuntu:
     default: true
+    priority: 10
     version: 22.04
     components: [main, universe]
     suites: [jammy, jammy-security, jammy-updates]
     public-keys: [ubuntu-archive-key-2018]
+
+  # esm.ubuntu.com/fips-updates/ubuntu/
+  ubuntu-fips-updates:
+    pro: fips-updates
+    priority: 21
+    version: 22.04
+    components: [main]
+    suites: [jammy-updates]
+    public-keys: [ubuntu-fips-key-v1]
+
+  # esm.ubuntu.com/apps/ubuntu/
+  ubuntu-esm-apps:
+    pro: esm-apps
+    priority: 16
+    version: 22.04
+    components: [main]
+    suites: [jammy-apps-security, jammy-apps-updates]
+    public-keys: [ubuntu-apps-key]
+
+  # esm.ubuntu.com/infra/ubuntu/
+  ubuntu-esm-infra:
+    pro: esm-infra
+    priority: 15
+    version: 22.04
+    components: [main]
+    suites: [jammy-infra-security, jammy-infra-updates]
+    public-keys: [ubuntu-esm-key-v2]
 
 public-keys:
   # Ubuntu Archive Automatic Signing Key (2018) <ftpmaster@ubuntu.com>
@@ -42,4 +71,109 @@ public-keys:
       SpIKi/ekAXLs117bvFHaCvmUYN7JVp1GMmVFxhIdx6CFm3fxG8QjNb5tere/YqK+
       uOgcXny1UlwtCUzlrSaP
       =9AdM
+      -----END PGP PUBLIC KEY BLOCK-----
+
+  # Ubuntu Federal Information Processing Standards Automatic Signing Key V1 <esm@canonical.com>.
+  # rsa4096/e23341b2a1467edbf07057d6c1997c40ede22758 2019-05-13T19:24:16Z
+  ubuntu-fips-key-v1:
+    id: "C1997C40EDE22758"
+    armor: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+      mQINBFzZxGABEADSWmX0+K//0cosKPyr5m1ewmwWKjRo/KBPTyR8icHhbBWfFd8T
+      DtYggvQHPU0YnKRcWits0et8JqSgZttNa28s7SaSUTBzfgzFJZgULAi/4i8u8TUj
+      +KH2zSoUX55NKC9aozba1cR66jM6O/BHXK5YoZzTpmiY1AHlIWAJ9s6cCClhnYMR
+      zwxSZVbefcYFbVPX/dQw/FMvJVeZ2aQ18NDgMQciu786aYklMFowxWNs/eLLTqum
+      cDHaw9UpKyhgfL/mkaIXuhYy6YRByYq1oOnJ5XffAOtovvCti1MvsPc0NDhPiGLf
+      9Fd/GtnqHxzVDqZmtUXX50mGu4LnJoHgWRjml3mapDPStzFr7Xgbb0NnyflmxnfN
+      kQcu2lFyXFfndWwg/RAOFdBPxBQhRK52uZiCfydKD7zCXz9YGm9xEK541EG0FrwA
+      6Vk1xaFol/jI8MQdP1o3JySX0Pqva3IHF7FHWHmxrIPaJLIHi0IrFG6Fgmk4sQ2w
+      XSc8kbxR+wYYKqIhBUZP0eb1jkFfvRVS6YvAy18xtw5pFD+VURdA0Uu5cotESfyz
+      oHsQ5R7wzg76oV/mYukHGC0x8peqxiPwbyhGFAhG8eUR66iYZgGbzmNI+OJz2EUi
+      UZJJXt4rnI1RVJLbhK9RjeobkOjf58Cm8RExlqJU16gy9saCMSiAqHx8swARAQAB
+      tFxVYnVudHUgRmVkZXJhbCBJbmZvcm1hdGlvbiBQcm9jZXNzaW5nIFN0YW5kYXJk
+      cyBBdXRvbWF0aWMgU2lnbmluZyBLZXkgVjEgPGVzbUBjYW5vbmljYWwuY29tPokC
+      OAQTAQIAIgUCXNnEYAIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQwZl8
+      QO3iJ1j4Vw//SawfmZi1GW+EUnuPqSz+zcmIKdx6AWZTe9/vSj6jgq4SYt//LAiD
+      NQz3dn2m0m5AaCucza2BCixUBrNhMh66m+lXfTqymUtTIpWpu4L1WLUbPjQ+s3Ad
+      xuF7S5wJtQrYmPvmZduZgg1wcb8eaqVltRJREpOP6sxcuqtvcfv4v4QYZ+iYd7eJ
+      8fxPOiyJEOTQPTdPZahYTaUOIloN5pT6uVg03u59Kh4aHCYxlRorvuRBabdctCfA
+      EBgomk4Us20Tv31dqlvMAiGKJqf1wdjhzlUmk4g/fOiRSNETKSC/VeUGH0fSbizl
+      Gs7Mg60jChPKpwzB6Rb5Nv2/Aw/FlSkfFhMdCdfKjl8IWOMPmElTVJFyVx1mmURi
+      3LgsloDFmJfebXefSFA7S8KLyBGlZJ/APaym64Ls12PUOjfh1Glie3E8KO66AGLo
+      ID1dQnzRizuHxW80ET03dSjzTXHLSi+iFycmNAxo6gB3GyOQ8tlIHjo1FfDfNYDf
+      qKic3Q0B9TvF6hqVRIcyePK4lN5YtRpVRdVj/jv8AqbzaIaVCP4k4nNrbaVx5zQf
+      BWq2E9IH+vLZfPyiP+hwxswfrlU3mrXBpPStIxq41yXFwQiDnqgkhEVAcrYPjBnS
+      T6s3+b+4HbAW6mbp4jEHUd/F1+iXz90T2WArrNIkMbmpChMuSyRN8Hc=
+      =DWhM
+      -----END PGP PUBLIC KEY BLOCK-----
+
+  # Ubuntu Apps Automatic Signing Key <esm@canonical.com>.
+  # rsa4096/e8a443ce358113d187bee0e6ab01a101db53907b 2019-11-21T09:08:30Z
+  ubuntu-apps-key:
+    id: "AB01A101DB53907B"
+    armor: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+      mQINBF3WVA4BEAC7MDr8HClfKptSd4VeB12Vy+Ao/4NpY2ITdkRed4vfh/4eBWWn
+      3+in6So2ekweifACSxScB/M9zVObsI1cab7QPMkIiATNUfIyOEP7iNWLX4+AytM1
+      LP3bZo8OpghnLZNstCGbiRUO4CDNmCI04DOPCu9EVEO4WWNuWIMRwCLShDSf7Cid
+      J2fn2TT/7vsmA4eI3YnAne+u8g4X2zMHQFkHANhylB0lPyThXo5jaxHImzm4wf/2
+      LF8f1Y1nRQObS2jcvYc3fm9B7iOGpyNAw3h6hrPKH5T9tY/ZoMtFHqn66J1CBSHb
+      hDkEvA46X50su4yAHeSiEG/hMYG7SoHzmAsjEXnvkTIE41WhmxlidQnRs2uWy34U
+      7VmOpaidWn3R99fNHYOtSOB6bpIvls8snWSQ63jcFXnt05nVZsp/Ixzl0Oqitynx
+      DFwoxEwt3ZuCHwxbx2vZ+FiZXVFN7I0IyBDOEL6XS27FNaMCZ7Q/6z/ckdWto55E
+      264OWf9lnw31bXFXHWSusRXWzD6FK8dqWgjtrWwRxlvF4jm688lqpjac6fFES3UK
+      BhjyHXFGL/+HHZ9CNxlLYF5QnXq1mGR0Ykw975u8KoOFSLBqsx+1a21m6dfzujY7
+      2Gq6Sju+9Yo1aOF+CNvTMYdRBoDL4sFj6VAmUsszMA5aAb+82pOCaDvGJQARAQAB
+      tDVVYnVudHUgQXBwcyBBdXRvbWF0aWMgU2lnbmluZyBLZXkgPGVzbUBjYW5vbmlj
+      YWwuY29tPokCOAQTAQIAIgUCXdZUDgIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgEC
+      F4AACgkQqwGhAdtTkHuTOw/8Czv42TSpwHz+eNtl3ZFyxta9rR/qWC3h+vMu0R/l
+      5KU3aQQOygWOoUcr1QTPSSg3v/H+v/8vqVq2UuUxSIfpMxBj2kIX2vqskv6Roez7
+      xR8lVDa0a47z/NYMfKpxrEJxOLh/c7I6aAsa597bTqDHtucHL/22BvfUJJqw6jq1
+      7SswP5lqKPBFz7x+E2hgfJE7Vn7h0ICm29FkWnOeTKfj8VwTAeKXKUI9Hw6+aqr9
+      29Y2NdLsYZ57mpivRLNM9sBZoF3avP1pUC2k0IwP3dwh4AxUMXjRRPh173iXBfR2
+      yAf1lWET/5+8dSBrfFIZSo+FF/EEBmqIVtJpHkq8+YxUbCLbkoikRi2kwrgyXLEn
+      FqxSU2Ab0xurFHiHcJoCGVD38xjznO5cQl7H4K9+B/rFpTTowOHbOcFpKAzpYqB5
+      8rnR1yRSsB33zac8xesUIfzYWRtLc5/VIb5mOkWlb62d8emILx2XuRFVjKq6mKki
+      oGckhDUOuEFrjW1cQq+PWBBxyJoXcy6wGSoPJ/ELeaf9zg8SF0jwuN6BPHVBeJ/E
+      W53zR5iV0N9fRT+M2JN5tc5HenO92xLgPAh+GPWLYmPdTmHu+kFozqsHx/NUw2iP
+      PBL6Q1VZytt2Uf6qLPUx7GpYMKf42Vldb0feFo/YA/lzOgPlY29pDLKXbse6o+Sr
+      kmk=
+      =AEEr
+      -----END PGP PUBLIC KEY BLOCK-----
+
+  # Ubuntu Extended Security Maintenance Automatic Signing Key v2 <esm@canonical.com>.
+  # rsa4096/56f7650a24c9e9ecf87c4d8d4067e40313cb4b13 2019-04-17T02:33:33Z
+  ubuntu-esm-key-v2:
+    id: "4067E40313CB4B13"
+    armor: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+      mQINBFy2kH0BEADl/2e2pULZaSRovd3E1i1cVk3zebzndHZm/hK8/Srx69ivw3pY
+      680gFE/N3s3R/C5Jh9ThdD1zpGmxVdqcABSPmW1FczdFZY2E37HMH7Uijs4CsnFs
+      8nrNGQaqX/T1g2fQqjia3zkabMeehUEZC5GPYjpeeFW6Wy1O1A1Tzu7/Wjc+uF/t
+      YYe/ZPXea74QZphu/N+8dy/ts/IzL2VtXuxiegGLfBFqzgZuBmlxXHVhftKvcis9
+      t2ko65uVyDcLtItMhSJokKBsIYJliqOXjUbQf5dz8vLXkku94arBMgsxDWT4K/xI
+      OTsaI/GMlSIKQ6Ucd/GKrBEsy5O8RDtD9A2klV7YeEwPEgqL+RhpdxAs/xUeTOZG
+      JKwuvlBjzIhJF9bIfbyzx7DdcGFqRE+a8eBIUMQjVkt9Yk7jj0eV3oVTE7XNhb53
+      rHuPL+zJVkiharxiTgYvkow3Nlbg3oURx9Ln67ni9pUtI1HbortGZsAkyOcpep58
+      K9cYvUePJWzjkY+bjcGKR19CWPl7KaUalIf2Tao5OwtqjrblTsXdtV7eG45ys0MT
+      Kl/DeqTJ0w6+i4eq4ZUfOCL/DIwS5zUB9j1KMUgEfocjYIdHWI8TSrA8jLYNPbVE
+      6+WjekHMB9liNrEQoESWBddS+bglPxuVwy2paGTUYJW1GnRZOTD+CG4ETQARAQAB
+      tFFVYnVudHUgRXh0ZW5kZWQgU2VjdXJpdHkgTWFpbnRlbmFuY2UgQXV0b21hdGlj
+      IFNpZ25pbmcgS2V5IHYyIDxlc21AY2Fub25pY2FsLmNvbT6JAjgEEwECACIFAly2
+      kH0CGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEEBn5AMTy0sTo/8QAJ1C
+      NhAkZ+Xq/BZ8UzAFCQn6GlIYg/ueY216xcQdDX1uN8hNOlPTNmftroIvohFAfFtB
+      m5galzY3DBPU8eZr8Y8XgiGD97wkR4zfhfh1EK/6diMG/HG00kdcWquFXMRB7E7S
+      nDTpyuPfkAzm9n6l69UB3UA53CaEUuVJ7qFfZsWgiQeUJpvqD0MIVsWr+T/paSx7
+      1JE9BVatFefq0egErv1sa2uYgcH9TRZMLw6gYxWtXeGA08Cpp0+OEvIzmJOHo5/F
+      EpJ3hGk87Of77BC7FbqSDpeYkcjnlI2i0QAxxFygKhPOMLuA4XVn3TDuqCgTFIFC
+      puupzIX/Up51FJmo64V9GZ/uF0jZy4tDxsCRJnEV+4Kv2sU5uMlmNchZMBjXYGiG
+      tpH9CqJkSZjFvB6bk+Ot98KI6+CuNWn1N0sXFKpEUGdJLuOKfJ9+xI5plo8Bct5C
+      DM9s4l0IuAPCsyayXrSmlyOAHzxDUeRMCEUnXWfycCUyqdyYIcCMPLV44Ccg9NyS
+      89dEauSCPuyCSxm5UYEHQdsSI/+rxRdS9IzoKs4za2L7fhY8PfdPlmghmXc/chz1
+      RtgjPfAsUHUPRr0h//TzxRm5dbYdUyqMPzZcDO8wYBT/4xrwnFkSHZhnVxpw7PDi
+      JYK4SVVc4ZO20PE1+RZc5oSbt4hRbFTCSb31Pydc
+      =KWLs
       -----END PGP PUBLIC KEY BLOCK-----

--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,7 +1,8 @@
 format: v1
 
 archives:
-  # archive.ubuntu.com/ubuntu/
+  # archive.ubuntu.com/ubuntu/      (amd64, i386)
+  # ports.ubuntu.com/ubuntu-ports/  (other arch)
   ubuntu:
     default: true
     priority: 10
@@ -10,6 +11,7 @@ archives:
     suites: [jammy, jammy-security, jammy-updates]
     public-keys: [ubuntu-archive-key-2018]
 
+v2-archives:
   # esm.ubuntu.com/fips-updates/ubuntu/
   ubuntu-fips-updates:
     pro: fips-updates


### PR DESCRIPTION
This PR adds the Ubuntu Pro archive definitions for Jammy (22.04).

The `pro` and `priority` values are defined in the [RK018 spec](https://docs.google.com/document/d/1nN5UuhwpGD9b07AaYA2RxMEwN1LT8MYQyC1Lg5zlrxg/edit?tab=t.0).

### Forward porting

- [ ] #407
- [x] #409
