### PR TITLE
feat(22.04): add slices file for package libtbb2 and missing depend…

### DIFF
--- a/slices/libatomic1.yaml
+++ b/slices/libatomic1.yaml
@@ -8,4 +8,3 @@ slices:
       # libs slice and is thus omitted.
     contents:
       /usr/lib/*-linux-*/libatomic.so.1*:
-

--- a/slices/libatomic1.yaml
+++ b/slices/libatomic1.yaml
@@ -1,0 +1,10 @@
+package: libatomic1
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      # Although gcc-12-base is a package dependency, it is not needed for this
+      # libs slice and is thus omitted.
+    contents:
+      /usr/lib/*-linux-*/libatomic.so.1*:

--- a/slices/libatomic1.yaml
+++ b/slices/libatomic1.yaml
@@ -8,3 +8,4 @@ slices:
       # libs slice and is thus omitted.
     contents:
       /usr/lib/*-linux-*/libatomic.so.1*:
+

--- a/slices/libatomic1.yaml
+++ b/slices/libatomic1.yaml
@@ -1,10 +1,17 @@
 package: libatomic1
 
+essential:
+  - libatomic1_copyright
+
 slices:
   libs:
     essential:
       - libc6_libs
-      # Although gcc-12-base is a package dependency, it is not needed for this
-      # libs slice and is thus omitted.
     contents:
       /usr/lib/*-linux-*/libatomic.so.1*:
+
+  copyright:
+    essential:
+      - gcc-12-base_copyright
+    contents:
+      /usr/share/doc/libatomic1:

--- a/slices/libtbb2.yaml
+++ b/slices/libtbb2.yaml
@@ -1,5 +1,8 @@
 package: libtbb2
 
+essential:
+  - libtbb2_copyright
+
 slices:
   libs:
     essential:
@@ -10,3 +13,7 @@ slices:
       - libtbbmalloc2_libs
     contents:
       /usr/lib/*-linux-*/libtbb.so.2:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtbb2/copyright:

--- a/slices/libtbb2.yaml
+++ b/slices/libtbb2.yaml
@@ -1,0 +1,12 @@
+package: libtbb2
+
+slices:
+  libs:
+    essential:
+      - libatomic1_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libtbbmalloc2_libs
+    contents:
+      /usr/lib/*-linux-*/libtbb.so.2:

--- a/slices/libtbb2.yaml
+++ b/slices/libtbb2.yaml
@@ -6,7 +6,8 @@ essential:
 slices:
   libs:
     essential:
-      - libatomic1_libs
+      # libatomic1 is only required for the riscv64 architecture.
+      # - libatomic1_libs
       - libc6_libs
       - libgcc-s1_libs
       - libstdc++6_libs

--- a/slices/libtbbmalloc2.yaml
+++ b/slices/libtbbmalloc2.yaml
@@ -1,0 +1,11 @@
+package: libtbbmalloc2
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libtbbmalloc.so.2*:
+      /usr/lib/*-linux-*/libtbbmalloc_proxy.so.2*:

--- a/slices/libtbbmalloc2.yaml
+++ b/slices/libtbbmalloc2.yaml
@@ -1,5 +1,8 @@
 package: libtbbmalloc2
 
+essential:
+  - libtbbmalloc2_copyright
+
 slices:
   libs:
     essential:
@@ -9,3 +12,7 @@ slices:
     contents:
       /usr/lib/*-linux-*/libtbbmalloc.so.2*:
       /usr/lib/*-linux-*/libtbbmalloc_proxy.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtbbmalloc2/copyright:


### PR DESCRIPTION
# Proposed changes
Adds a "libs" slice for package `libtbb2` and additional slices files for dependencies that don't exist yet.

## Related issues/PRs
https://github.com/canonical/chisel-releases/issues/410

### Forward porting
20.04, 22.04, 24.04, 24.10

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
see https://github.com/canonical/chisel-releases/issues/410