### PR TITLE
feat(24.10): Add SDF for `libtheora0` and `libx11-xcb1`

### DIFF
--- a/slices/libtheora0.yaml
+++ b/slices/libtheora0.yaml
@@ -1,0 +1,19 @@
+package: libtheora0
+
+essential:
+  - libtheora0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcairo2_libs
+      - libogg0_libs
+    contents:
+      /usr/lib/*-linux-*/libtheora.so.0*:
+      /usr/lib/*-linux-*/libtheoradec.so.1*:
+      /usr/lib/*-linux-*/libtheoraenc.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtheora0/copyright:

--- a/slices/libx11-xcb1.yaml
+++ b/slices/libx11-xcb1.yaml
@@ -1,0 +1,15 @@
+package: libx11-xcb1
+
+essential:
+  - libx11-xcb1_copyright
+
+slices:
+  libs:
+    essential:
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libX11-xcb.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libx11-xcb1/copyright:


### PR DESCRIPTION
# Proposed changes

Add SDF for `libtheora0` and `libx11-xcb1`

## Related issues/PRs

* 24.04: #433
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->