### PR TITLE
feat(24.04): Add SDF for `libavcodec60` and dependencies

### DIFF
--- a/slices/libavcodec60.yaml
+++ b/slices/libavcodec60.yaml
@@ -1,0 +1,52 @@
+package: libavcodec60
+
+essential:
+  - libavcodec60_copyright
+
+slices:
+  libs:
+    essential:
+      - libaom3_libs
+      - libavutil58_libs
+      - libc6_libs
+      - libcairo2_libs
+      - libcodec2-1.2_libs
+      - libdav1d7_libs
+      - libglib2.0-0t64_libs
+      - libgsm1_libs
+      - libjxl0.7_libs
+      - liblzma5_libs
+      - libmp3lame0_libs
+      - libopenjp2-7_libs
+      - libopus0_libs
+      # The librav1e0_libs dependency is currently ommited, it can be added again
+      # once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      - librsvg2-2_libs
+      - libshine3_libs
+      - libsnappy1v5_libs
+      - libspeex1_libs
+      - libsvtav1enc1d1_libs
+      - libswresample4_libs
+      - libtheora0_libs
+      - libtwolame0_libs
+      - libva2_libs
+      - libvorbis0a_libs
+      - libvorbisenc2_libs
+      # The libvpl2_libs dependency is currently ommited, it can be added again
+      # once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      - libvpx9_libs
+      - libwebp7_libs
+      - libwebpmux3_libs
+      - libx264-164_libs
+      - libx265-199_libs
+      - libxvidcore4_libs
+      - libzvbi0t64_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libavcodec.so.60*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libavcodec60/copyright:

--- a/slices/libavcodec60.yaml
+++ b/slices/libavcodec60.yaml
@@ -22,6 +22,7 @@ slices:
       # The librav1e0_libs dependency is currently ommited, it can be added again
       # once chisel supports per-arch package dependencies,
       # see https://github.com/canonical/chisel/issues/93
+      # needed for: not i386
       - librsvg2-2_libs
       - libshine3_libs
       - libsnappy1v5_libs
@@ -36,6 +37,7 @@ slices:
       # The libvpl2_libs dependency is currently ommited, it can be added again
       # once chisel supports per-arch package dependencies,
       # see https://github.com/canonical/chisel/issues/93
+      # needed for: amd64
       - libvpx9_libs
       - libwebp7_libs
       - libwebpmux3_libs

--- a/slices/libavutil58.yaml
+++ b/slices/libavutil58.yaml
@@ -1,0 +1,25 @@
+package: libavutil58
+
+essential:
+  - libavutil58_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libva-drm2_libs
+      - libva-x11-2_libs
+      - libva2_libs
+      - libvdpau1_libs
+      # The libvpl2_libs dependency is currently ommited, it can be added again
+      # once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      - libx11-6_libs
+      - ocl-icd-libopencl1_libs
+    contents:
+      /usr/lib/*-linux-*/libavutil.so.58*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libavutil58/copyright:

--- a/slices/libavutil58.yaml
+++ b/slices/libavutil58.yaml
@@ -15,6 +15,7 @@ slices:
       # The libvpl2_libs dependency is currently ommited, it can be added again
       # once chisel supports per-arch package dependencies,
       # see https://github.com/canonical/chisel/issues/93
+      # needed for: amd64
       - libx11-6_libs
       - ocl-icd-libopencl1_libs
     contents:

--- a/slices/libcairo-gobject2.yaml
+++ b/slices/libcairo-gobject2.yaml
@@ -1,0 +1,16 @@
+package: libcairo-gobject2
+
+essential:
+  - libcairo-gobject2_copyright
+
+slices:
+  libs:
+    essential:
+      - libcairo2_libs
+      - libglib2.0-0t64_libs
+    contents:
+      /usr/lib/*-linux-*/libcairo-gobject.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcairo-gobject2/copyright:

--- a/slices/libhwy1t64.yaml
+++ b/slices/libhwy1t64.yaml
@@ -1,0 +1,19 @@
+package: libhwy1t64
+
+essential:
+  - libhwy1t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libhwy.so.1*:
+      /usr/lib/*-linux-*/libhwy_contrib.so.1*:
+      /usr/lib/*-linux-*/libhwy_test.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libhwy1t64/copyright:

--- a/slices/libjxl0.7.yaml
+++ b/slices/libjxl0.7.yaml
@@ -1,0 +1,21 @@
+package: libjxl0.7
+
+essential:
+  - libjxl0.7_copyright
+
+slices:
+  libs:
+    essential:
+      - libbrotli1_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libhwy1t64_libs
+      - liblcms2-2_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libjxl.so.0.7*:
+      /usr/lib/*-linux-*/libjxl_threads.so.0.7*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libjxl0.7/copyright:

--- a/slices/librsvg2-2.yaml
+++ b/slices/librsvg2-2.yaml
@@ -1,0 +1,23 @@
+package: librsvg2-2
+
+essential:
+  - librsvg2-2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcairo-gobject2_libs
+      - libcairo2_libs
+      - libgcc-s1_libs
+      - libgdk-pixbuf-2.0-0_libs
+      - libglib2.0-0t64_libs
+      - libpango-1.0-0_libs
+      - libpangocairo-1.0-0_libs
+      - libxml2_libs
+    contents:
+      /usr/lib/*-linux-*/librsvg-2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librsvg2-2/copyright:

--- a/slices/libsoxr0.yaml
+++ b/slices/libsoxr0.yaml
@@ -1,0 +1,16 @@
+package: libsoxr0
+
+essential:
+  - libsoxr0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgomp1_libs
+    contents:
+      /usr/lib/*-linux-*/libsoxr.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsoxr0/copyright:

--- a/slices/libswresample4.yaml
+++ b/slices/libswresample4.yaml
@@ -1,0 +1,17 @@
+package: libswresample4
+
+essential:
+  - libswresample4_copyright
+
+slices:
+  libs:
+    essential:
+      - libavutil58_libs
+      - libc6_libs
+      - libsoxr0_libs
+    contents:
+      /usr/lib/*-linux-*/libswresample.so.4*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libswresample4/copyright:

--- a/slices/libva-x11-2.yaml
+++ b/slices/libva-x11-2.yaml
@@ -1,0 +1,23 @@
+package: libva-x11-2
+
+essential:
+  - libva-x11-2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libva2_libs
+      - libx11-6_libs
+      - libx11-xcb1_libs
+      - libxcb-dri3-0_libs
+      - libxcb1_libs
+      - libxext6_libs
+      - libxfixes3_libs
+    contents:
+      /usr/lib/*-linux-*/libva-x11.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libva-x11-2/copyright:

--- a/slices/libvdpau1.yaml
+++ b/slices/libvdpau1.yaml
@@ -7,7 +7,7 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libgcc-s1_libs  # armhf only
+      - libgcc-s1_libs  # needed for armhf only
       - libvdpau1_config
       - libx11-6_libs
       - libxext6_libs

--- a/slices/libvdpau1.yaml
+++ b/slices/libvdpau1.yaml
@@ -1,0 +1,24 @@
+package: libvdpau1
+
+essential:
+  - libvdpau1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs  # armhf only
+      - libvdpau1_config
+      - libx11-6_libs
+      - libxext6_libs
+    contents:
+      /usr/lib/*-linux-*/libvdpau.so.1*:
+      /usr/lib/*-linux-*/vdpau/libvdpau_trace.so.1*:
+
+  config:
+    contents:
+      /etc/vdpau_wrapper.cfg:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvdpau1/copyright:

--- a/slices/libvpl2.yaml
+++ b/slices/libvpl2.yaml
@@ -1,0 +1,21 @@
+package: libvpl2
+
+essential:
+  - libvpl2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm-intel1_libs
+      - libdrm2_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libwayland-client0_libs
+    contents:
+      /usr/lib/*-linux-*/libvpl.so.2*:
+      /usr/lib/*-linux-*/vpl/libvpl_wayland.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvpl2/copyright:

--- a/slices/libxfixes3.yaml
+++ b/slices/libxfixes3.yaml
@@ -1,0 +1,16 @@
+package: libxfixes3
+
+essential:
+  - libxfixes3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libXfixes.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxfixes3/copyright:


### PR DESCRIPTION
# Proposed changes

Add SDF for `libavcodec60` and dependencies.

See https://github.com/canonical/chisel/issues/93#issuecomment-2562008596 for the dependencies diff.

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

24.10 PR: #442

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->