### PR TITLE
feat(24.10): Add SDF for `libavcodec61` and dependencies

### DIFF
--- a/slices/libavcodec61.yaml
+++ b/slices/libavcodec61.yaml
@@ -22,6 +22,7 @@ slices:
       # The librav1e0.7_libs dependency is currently ommited, it can be added again
       # once chisel supports per-arch package dependencies,
       # see https://github.com/canonical/chisel/issues/93
+      # needed for: not i386
       - librsvg2-2_libs
       - libshine3_libs
       - libsnappy1v5_libs
@@ -36,6 +37,7 @@ slices:
       # The libvpl2_libs dependency is currently ommited, it can be added again
       # once chisel supports per-arch package dependencies,
       # see https://github.com/canonical/chisel/issues/93
+      # needed for: amd64
       - libvpx9_libs
       - libwebp7_libs
       - libwebpmux3_libs

--- a/slices/libavcodec61.yaml
+++ b/slices/libavcodec61.yaml
@@ -1,0 +1,52 @@
+package: libavcodec61
+
+essential:
+  - libavcodec61_copyright
+
+slices:
+  libs:
+    essential:
+      - libaom3_libs
+      - libavutil59_libs
+      - libc6_libs
+      - libcairo2_libs
+      - libcodec2-1.2_libs
+      - libdav1d7_libs
+      - libglib2.0-0t64_libs
+      - libgsm1_libs
+      - libjxl0.10_libs
+      - liblzma5_libs
+      - libmp3lame0_libs
+      - libopenjp2-7_libs
+      - libopus0_libs
+      # The librav1e0.7_libs dependency is currently ommited, it can be added again
+      # once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      - librsvg2-2_libs
+      - libshine3_libs
+      - libsnappy1v5_libs
+      - libspeex1_libs
+      - libsvtav1enc2_libs
+      - libswresample5_libs
+      - libtheora0_libs
+      - libtwolame0_libs
+      - libva2_libs
+      - libvorbis0a_libs
+      - libvorbisenc2_libs
+      # The libvpl2_libs dependency is currently ommited, it can be added again
+      # once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      - libvpx9_libs
+      - libwebp7_libs
+      - libwebpmux3_libs
+      - libx264-164_libs
+      - libx265-209_libs
+      - libxvidcore4_libs
+      - libzvbi0t64_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libavcodec.so.61*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libavcodec61/copyright:

--- a/slices/libavutil59.yaml
+++ b/slices/libavutil59.yaml
@@ -1,0 +1,25 @@
+package: libavutil59
+
+essential:
+  - libavutil59_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libva-drm2_libs
+      - libva-x11-2_libs
+      - libva2_libs
+      - libvdpau1_libs
+      # The libvpl2_libs dependency is currently ommited, it can be added again
+      # once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      - libx11-6_libs
+      - ocl-icd-libopencl1_libs
+    contents:
+      /usr/lib/*-linux-*/libavutil.so.59*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libavutil59/copyright:

--- a/slices/libavutil59.yaml
+++ b/slices/libavutil59.yaml
@@ -15,6 +15,7 @@ slices:
       # The libvpl2_libs dependency is currently ommited, it can be added again
       # once chisel supports per-arch package dependencies,
       # see https://github.com/canonical/chisel/issues/93
+      # needed for: amd64
       - libx11-6_libs
       - ocl-icd-libopencl1_libs
     contents:

--- a/slices/libcairo-gobject2.yaml
+++ b/slices/libcairo-gobject2.yaml
@@ -1,0 +1,16 @@
+package: libcairo-gobject2
+
+essential:
+  - libcairo-gobject2_copyright
+
+slices:
+  libs:
+    essential:
+      - libcairo2_libs
+      - libglib2.0-0t64_libs
+    contents:
+      /usr/lib/*-linux-*/libcairo-gobject.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcairo-gobject2/copyright:

--- a/slices/libgdk-pixbuf-2.0-0.yaml
+++ b/slices/libgdk-pixbuf-2.0-0.yaml
@@ -1,0 +1,29 @@
+package: libgdk-pixbuf-2.0-0
+
+essential:
+  - libgdk-pixbuf-2.0-0_copyright
+
+slices:
+  bins:
+    essential:
+      - libgdk-pixbuf-2.0-0_libs
+    contents:
+      /usr/lib/*-linux-*/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders:
+
+  libs:
+    essential:
+      - libc6_libs
+      - libglib2.0-0t64_libs
+      - libjpeg8_libs
+      - libpng16-16t64_libs
+      - libtiff6_libs
+      - shared-mime-info_data
+    contents:
+      /usr/lib/*-linux-*/gdk-pixbuf-2.0/*/loaders/*:
+      /usr/lib/*-linux-*/libgdk_pixbuf-2.0.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgdk-pixbuf-2.0-0/copyright:
+    essential:
+      - libgdk-pixbuf2.0-common_copyright

--- a/slices/libgdk-pixbuf2.0-common.yaml
+++ b/slices/libgdk-pixbuf2.0-common.yaml
@@ -1,0 +1,10 @@
+package: libgdk-pixbuf2.0-common
+
+essential:
+  - libgdk-pixbuf2.0-common_copyright
+
+slices:
+  copyright:
+    # This package has no dependencies and only contains a changelog and copyright file.
+    contents:
+      /usr/share/doc/libgdk-pixbuf2.0-common/copyright:

--- a/slices/libhwy1t64.yaml
+++ b/slices/libhwy1t64.yaml
@@ -1,0 +1,19 @@
+package: libhwy1t64
+
+essential:
+  - libhwy1t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libhwy.so.1*:
+      /usr/lib/*-linux-*/libhwy_contrib.so.1*:
+      /usr/lib/*-linux-*/libhwy_test.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libhwy1t64/copyright:

--- a/slices/libjxl0.10.yaml
+++ b/slices/libjxl0.10.yaml
@@ -1,0 +1,26 @@
+package: libjxl0.10
+
+essential:
+  - libjxl0.10_copyright
+
+slices:
+  libs:
+    essential:
+      - libbrotli1_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libgif7_libs
+      - libhwy1t64_libs
+      - libjpeg8_libs
+      - liblcms2-2_libs
+      - libpng16-16t64_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libjxl.so.0.10*:
+      /usr/lib/*-linux-*/libjxl_cms.so.0.10*:
+      /usr/lib/*-linux-*/libjxl_extras_codec.so.0.10*:
+      /usr/lib/*-linux-*/libjxl_threads.so.0.10*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libjxl0.10/copyright:

--- a/slices/librsvg2-2.yaml
+++ b/slices/librsvg2-2.yaml
@@ -1,0 +1,23 @@
+package: librsvg2-2
+
+essential:
+  - librsvg2-2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libcairo-gobject2_libs
+      - libcairo2_libs
+      - libgcc-s1_libs
+      - libgdk-pixbuf-2.0-0_libs
+      - libglib2.0-0t64_libs
+      - libpango-1.0-0_libs
+      - libpangocairo-1.0-0_libs
+      - libxml2_libs
+    contents:
+      /usr/lib/*-linux-*/librsvg-2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librsvg2-2/copyright:

--- a/slices/libsoxr0.yaml
+++ b/slices/libsoxr0.yaml
@@ -1,0 +1,16 @@
+package: libsoxr0
+
+essential:
+  - libsoxr0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgomp1_libs
+    contents:
+      /usr/lib/*-linux-*/libsoxr.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsoxr0/copyright:

--- a/slices/libswresample5.yaml
+++ b/slices/libswresample5.yaml
@@ -1,0 +1,17 @@
+package: libswresample5
+
+essential:
+  - libswresample5_copyright
+
+slices:
+  libs:
+    essential:
+      - libavutil59_libs
+      - libc6_libs
+      - libsoxr0_libs
+    contents:
+      /usr/lib/*-linux-*/libswresample.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libswresample5/copyright:

--- a/slices/libva-x11-2.yaml
+++ b/slices/libva-x11-2.yaml
@@ -1,0 +1,23 @@
+package: libva-x11-2
+
+essential:
+  - libva-x11-2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libva2_libs
+      - libx11-6_libs
+      - libx11-xcb1_libs
+      - libxcb-dri3-0_libs
+      - libxcb1_libs
+      - libxext6_libs
+      - libxfixes3_libs
+    contents:
+      /usr/lib/*-linux-*/libva-x11.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libva-x11-2/copyright:

--- a/slices/libvdpau1.yaml
+++ b/slices/libvdpau1.yaml
@@ -7,7 +7,7 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libgcc-s1_libs  # armhf only
+      - libgcc-s1_libs  # needed for armhf only
       - libvdpau1_config
       - libx11-6_libs
       - libxext6_libs

--- a/slices/libvdpau1.yaml
+++ b/slices/libvdpau1.yaml
@@ -1,0 +1,24 @@
+package: libvdpau1
+
+essential:
+  - libvdpau1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs  # armhf only
+      - libvdpau1_config
+      - libx11-6_libs
+      - libxext6_libs
+    contents:
+      /usr/lib/*-linux-*/libvdpau.so.1*:
+      /usr/lib/*-linux-*/vdpau/libvdpau_trace.so.1*:
+
+  config:
+    contents:
+      /etc/vdpau_wrapper.cfg:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvdpau1/copyright:

--- a/slices/libvpl2.yaml
+++ b/slices/libvpl2.yaml
@@ -1,0 +1,17 @@
+package: libvpl2
+
+essential:
+  - libvpl2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libvpl.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvpl2/copyright:

--- a/slices/libxfixes3.yaml
+++ b/slices/libxfixes3.yaml
@@ -1,0 +1,16 @@
+package: libxfixes3
+
+essential:
+  - libxfixes3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libXfixes.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxfixes3/copyright:

--- a/slices/shared-mime-info.yaml
+++ b/slices/shared-mime-info.yaml
@@ -1,0 +1,25 @@
+package: shared-mime-info
+
+essential:
+  - shared-mime-info_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libglib2.0-0t64_core
+      - libstdc++6_libs
+      - libxml2_libs
+    contents:
+      /usr/bin/update-mime-database:
+
+  data:
+    contents:
+      /usr/share/gettext/its/shared-mime-info.*:
+      /usr/share/mime/packages/freedesktop.org.xml:
+      /usr/share/pkgconfig/shared-mime-info.pc:
+
+  copyright:
+    contents:
+      /usr/share/doc/shared-mime-info/copyright:

--- a/tests/spread/integration/libgdk-pixbuf-2.0-0/task.yaml
+++ b/tests/spread/integration/libgdk-pixbuf-2.0-0/task.yaml
@@ -1,0 +1,23 @@
+summary: Integration tests for libgdk-pixbuf-2.0-0
+
+execute: |
+  if [[ $(uname -m) == "s390x" ]]; then
+    rootfs="$(install-slices dash_bins libgdk-pixbuf-2.0-0_bins)"
+  else
+    rootfs="$(install-slices dash_bins liblerc4_libs libgdk-pixbuf-2.0-0_bins)"
+  fi
+
+  chroot "${rootfs}" sh -c '/usr/lib/*-linux-*/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders' > loaders
+
+  grep -q "libpixbufloader-ani.so" loaders
+  grep -q "libpixbufloader-bmp.so" loaders
+  grep -q "libpixbufloader-gif.so" loaders
+  grep -q "libpixbufloader-icns.so" loaders
+  grep -q "libpixbufloader-ico.so" loaders
+  grep -q "libpixbufloader-pnm.so" loaders
+  grep -q "libpixbufloader-qtif.so" loaders
+  ! grep -q "libpixbufloader-svg.so" loaders  # svg should not be installed
+  grep -q "libpixbufloader-tga.so" loaders
+  grep -q "libpixbufloader-tiff.so" loaders
+  grep -q "libpixbufloader-xbm.so" loaders
+  grep -q "libpixbufloader-xpm.so" loaders

--- a/tests/spread/integration/shared-mime-info/task.yaml
+++ b/tests/spread/integration/shared-mime-info/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for shared-mime-info
+
+execute: |
+  rootfs="$(install-slices shared-mime-info_bins shared-mime-info_data)"
+
+  chroot "${rootfs}" update-mime-database -v |& grep -q 'update-mime-database (shared-mime-info) 2.4'
+  chroot "${rootfs}" update-mime-database /usr/share/mime


### PR DESCRIPTION
# Proposed changes

Add SDF for `libavcodec61` and dependencies.

See https://github.com/canonical/chisel/issues/93#issuecomment-2562008596 for the dependencies diff.

## Related issues/PRs

24.04 PR: #441

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->