### PR TITLE
fix(24.10): Fix notices file path in `aspnetcore-runtime-9.0_notice` slice

### DIFF
--- a/slices/aspnetcore-runtime-9.0.yaml
+++ b/slices/aspnetcore-runtime-9.0.yaml
@@ -14,7 +14,7 @@ slices:
 
   notice:
     contents:
-      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/9.0.0/THIRD-PARTY-NOTICES.txt:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/9.0*/THIRD-PARTY-NOTICES.txt:
       /usr/share/doc/aspnetcore-runtime-9.0/NOTICE.txt.gz:
 
   copyright:


### PR DESCRIPTION
# Proposed changes

Fix third party notices filepath in `aspnetcore-runtime-9.0_notice` slice.

Currently running `chisel cut --release ubuntu-24.10 --root rootfs aspnetcore-runtime-9.0_notice` yields the following error:
```
error: cannot extract from package "aspnetcore-runtime-9.0": no content at /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/9.0.0/THIRD-PARTY-NOTICES.txt
```
This is because that file is at `/usr/lib/dotnet/shared/Microsoft.AspNetCore.App/9.0.1/THIRD-PARTY-NOTICES.txt` on amd64 and other `rc` version paths for other archs, for example `/usr/lib/dotnet/shared/Microsoft.AspNetCore.App/9.0.0-rc.1.24452.1/THIRD-PARTY-NOTICES.txt` for arm64, see https://packages.ubuntu.com/oracular/aspnetcore-runtime-9.0.

This currently causes all 24.10 "Install slices" CI workflow runs to fail: https://github.com/canonical/chisel-releases/actions/runs/12839001216
## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->