### PR TITLE
feat(24.10): add publicsuffix and libproxy1v5 slices

### DIFF
--- a/slices/libduktape207.yaml
+++ b/slices/libduktape207.yaml
@@ -1,0 +1,15 @@
+package: libduktape207
+
+essential:
+  - libduktape207_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libduktape.so.207:
+
+  copyright:
+    contents:
+      /usr/share/doc/libduktape207/copyright:

--- a/slices/libproxy1v5.yaml
+++ b/slices/libproxy1v5.yaml
@@ -1,0 +1,17 @@
+package: libproxy1v5
+
+essential:
+  - libproxy1v5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libproxy.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libproxy1v5/copyright:

--- a/slices/libproxy1v5.yaml
+++ b/slices/libproxy1v5.yaml
@@ -7,10 +7,13 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libgcc-s1_libs
-      - libstdc++6_libs
+      - libcurl3t64-gnutls_libs
+      - libduktape207_libs
+      - libglib2.0-0t64_libs
+
     contents:
-      /usr/lib/*-linux-*/libproxy.so.1*:
+      /usr/lib/*-linux-*/libproxy.so.*:
+      /usr/lib/*-linux-*/libproxy/libpxbackend-1.*.so:
 
   copyright:
     contents:

--- a/slices/publicsuffix.yaml
+++ b/slices/publicsuffix.yaml
@@ -1,0 +1,15 @@
+package: publicsuffix
+
+essential:
+  - publicsuffix_copyright
+
+slices:
+  data:
+    contents:
+      /usr/share/publicsuffix/effective_tld_names.dat:
+      /usr/share/publicsuffix/public_suffix_list.dafsa:
+      /usr/share/publicsuffix/public_suffix_list.dat:
+
+  copyright:
+    contents:
+      /usr/share/doc/publicsuffix/copyright:


### PR DESCRIPTION
## Forward porting
Port forward of #389  

## Description 
Rework of #49, as it has not been updated in a while.

This PD adds the following changes:
- The data slice in `publicsuffix` is more explicit following earlier comments in #49 
- `glib-networking` and dependent `gsettings-desktop-schemas` were removed. Since these packages related to the gnome desktop environment, I am hesitant to add them unless they can be tested in a minimal rootfs. 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
