### PR TITLE
feat(24.10): Add SDF for `libgl1` and dependencies

### DIFF
--- a/slices/libgbm1.yaml
+++ b/slices/libgbm1.yaml
@@ -1,0 +1,21 @@
+package: libgbm1
+
+essential:
+  - libgbm1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libexpat1_libs
+      - libgcc-s1_libs
+      - libwayland-server0_libs
+      - libxcb-randr0_libs
+      - mesa-libgallium_libs
+    contents:
+      /usr/lib/*-linux-*/libgbm.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgbm1/copyright:

--- a/slices/libgl1-mesa-dri.yaml
+++ b/slices/libgl1-mesa-dri.yaml
@@ -1,0 +1,245 @@
+package: libgl1-mesa-dri
+
+essential:
+  - libgl1-mesa-dri_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgbm1_libs
+      - libgcc-s1_libs
+      - libgl1-mesa-dri_config
+      - libvulkan1_libs
+    contents:
+      /usr/lib/*-linux-*/dri/armada-drm_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/crocus_dri.so:
+        arch:
+          - amd64
+          - i386
+      /usr/lib/*-linux-*/dri/d3d12_dri.so:
+        arch:
+          - amd64
+          - arm64
+      /usr/lib/*-linux-*/dri/etnaviv_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/exynos_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/gm12u320_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/hdlcd_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/hx8357d_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/i915_dri.so:
+        arch:
+          - amd64
+          - i386
+      /usr/lib/*-linux-*/dri/ili9163_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/ili9225_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/ili9341_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/ili9486_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/imx-dcss_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/imx-drm_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/imx-lcdif_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/ingenic-drm_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/iris_dri.so:
+        arch:
+          - amd64
+          - i386
+      /usr/lib/*-linux-*/dri/kgsl_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/kirin_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/kms_swrast_dri.so:
+      /usr/lib/*-linux-*/dri/komeda_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/lima_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/mali-dp_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/mcde_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/mediatek_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/meson_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/mi0283qt_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/msm_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/mxsfb-drm_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/nouveau_dri.so:
+      /usr/lib/*-linux-*/dri/panel-mipi-dbi_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/panfrost_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/pl111_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/r300_dri.so:
+      /usr/lib/*-linux-*/dri/r600_dri.so:
+      /usr/lib/*-linux-*/dri/radeonsi_dri.so:
+      /usr/lib/*-linux-*/dri/rcar-du_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/repaper_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/rockchip_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/st7586_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/st7735r_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/sti_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/stm_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/sun4i-drm_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/swrast_dri.so:
+      /usr/lib/*-linux-*/dri/tegra_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/udl_dri.so:
+        arch:
+          - arm64
+          - armhf
+          - riscv64
+      /usr/lib/*-linux-*/dri/v3d_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/vc4_dri.so:
+        arch:
+          - arm64
+          - armhf
+      /usr/lib/*-linux-*/dri/virtio_gpu_dri.so:
+      /usr/lib/*-linux-*/dri/vmwgfx_dri.so:
+        arch:
+          - amd64
+          - arm64
+          - armhf
+          - i386
+      /usr/lib/*-linux-*/dri/zink_dri.so:
+
+  config:
+    contents:
+      /usr/share/drirc.d/00-mesa-defaults.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgl1-mesa-dri/copyright:

--- a/slices/libgl1.yaml
+++ b/slices/libgl1.yaml
@@ -1,0 +1,17 @@
+package: libgl1
+
+essential:
+  - libgl1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libglvnd0_libs
+      - libglx0_libs
+    contents:
+      /usr/lib/*-linux-*/libGL.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgl1/copyright:

--- a/slices/libglapi-mesa.yaml
+++ b/slices/libglapi-mesa.yaml
@@ -1,0 +1,15 @@
+package: libglapi-mesa
+
+essential:
+  - libglapi-mesa_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libglapi.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglapi-mesa/copyright:

--- a/slices/libglvnd0.yaml
+++ b/slices/libglvnd0.yaml
@@ -1,0 +1,15 @@
+package: libglvnd0
+
+essential:
+  - libglvnd0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libGLdispatch.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglvnd0/copyright:

--- a/slices/libglx-mesa0.yaml
+++ b/slices/libglx-mesa0.yaml
@@ -1,0 +1,36 @@
+package: libglx-mesa0
+
+essential:
+  - libglx-mesa0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libexpat1_libs
+      - libgl1-mesa-dri_libs
+      - libglapi-mesa_libs
+      - libx11-6_libs
+      - libx11-xcb1_libs
+      - libxcb-dri2-0_libs
+      - libxcb-dri3-0_libs
+      - libxcb-glx0_libs
+      - libxcb-present0_libs
+      - libxcb-randr0_libs
+      - libxcb-shm0_libs
+      - libxcb-sync1_libs
+      - libxcb-xfixes0_libs
+      - libxcb1_libs
+      - libxext6_libs
+      - libxfixes3_libs
+      - libxshmfence1_libs
+      - libxxf86vm1_libs
+      - mesa-libgallium_libs
+    contents:
+      /usr/lib/*-linux-*/libGLX_indirect.so.0*:
+      /usr/lib/*-linux-*/libGLX_mesa.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglx-mesa0/copyright:

--- a/slices/libglx0.yaml
+++ b/slices/libglx0.yaml
@@ -1,0 +1,18 @@
+package: libglx0
+
+essential:
+  - libglx0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libglvnd0_libs
+      - libglx-mesa0_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libGLX.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglx0/copyright:

--- a/slices/libllvm19.yaml
+++ b/slices/libllvm19.yaml
@@ -1,0 +1,24 @@
+package: libllvm19
+
+essential:
+  - libllvm19_copyright
+
+slices:
+  libs:
+    essential:
+      - libatomic1_libs
+      - libc6_libs
+      - libedit2_libs
+      - libffi8_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libxml2_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libLLVM-19.so:
+      /usr/lib/*-linux-*/libLLVM.so.19.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libllvm19/copyright:

--- a/slices/libsensors-config.yaml
+++ b/slices/libsensors-config.yaml
@@ -6,6 +6,7 @@ essential:
 slices:
   config:
     contents:
+      /etc/sensors.d/: {make: true}
       /etc/sensors3.conf:
 
   copyright:

--- a/slices/libsensors-config.yaml
+++ b/slices/libsensors-config.yaml
@@ -6,7 +6,7 @@ essential:
 slices:
   config:
     contents:
-      /etc/sensors.d/: {make: true}
+      /etc/sensors.d/:
       /etc/sensors3.conf:
 
   copyright:

--- a/slices/libsensors-config.yaml
+++ b/slices/libsensors-config.yaml
@@ -1,0 +1,13 @@
+package: libsensors-config
+
+essential:
+  - libsensors-config_copyright
+
+slices:
+  config:
+    contents:
+      /etc/sensors3.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsensors-config/copyright:

--- a/slices/libsensors5.yaml
+++ b/slices/libsensors5.yaml
@@ -1,0 +1,16 @@
+package: libsensors5
+
+essential:
+  - libsensors5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libsensors-config_config
+    contents:
+      /usr/lib/*-linux-*/libsensors.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsensors5/copyright:

--- a/slices/libvulkan1.yaml
+++ b/slices/libvulkan1.yaml
@@ -1,0 +1,15 @@
+package: libvulkan1
+
+essential:
+  - libvulkan1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libvulkan.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libvulkan1/copyright:

--- a/slices/libwayland-server0.yaml
+++ b/slices/libwayland-server0.yaml
@@ -1,0 +1,16 @@
+package: libwayland-server0
+
+essential:
+  - libwayland-server0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libffi8_libs
+    contents:
+      /usr/lib/*-linux-*/libwayland-server.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libwayland-server0/copyright:

--- a/slices/libxxf86vm1.yaml
+++ b/slices/libxxf86vm1.yaml
@@ -1,0 +1,17 @@
+package: libxxf86vm1
+
+essential:
+  - libxxf86vm1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+      - libxext6_libs
+    contents:
+      /usr/lib/*-linux-*/libXxf86vm.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxxf86vm1/copyright:

--- a/slices/mesa-libgallium.yaml
+++ b/slices/mesa-libgallium.yaml
@@ -1,0 +1,39 @@
+package: mesa-libgallium
+
+essential:
+  - mesa-libgallium_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm-amdgpu1_libs
+      # The libdrm-intel1_libs dependency is currently ommited, it can be
+      # added again once chisel supports per-arch package dependencies,
+      # see https://github.com/canonical/chisel/issues/93
+      # needed for: amd64 and i386
+      - libdrm-radeon1_libs
+      - libdrm2_libs
+      - libelf1t64_libs
+      - libexpat1_libs
+      - libgcc-s1_libs
+      - libglapi-mesa_libs
+      - libllvm19_libs
+      - libsensors5_libs
+      - libstdc++6_libs
+      - libx11-xcb1_libs
+      - libxcb-dri2-0_libs
+      - libxcb-dri3-0_libs
+      - libxcb-present0_libs
+      - libxcb-sync1_libs
+      - libxcb-xfixes0_libs
+      - libxcb1_libs
+      - libxshmfence1_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libgallium-*.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/mesa-libgallium/copyright:


### PR DESCRIPTION
# Proposed changes

Add SDF for `libgl1` and dependencies.

See https://github.com/canonical/chisel/issues/93 for the dependency diff.

## Related issues/PRs

24.04 PR: #474 (dropped)
24.04 PR: #508 (current, back-ported)

### Forward porting
N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->