### PR TITLE
chore(24.10): forward-port ca-certificates-java slice from ubuntu 24.04

### DIFF
--- a/slices/ca-certificates-java.yaml
+++ b/slices/ca-certificates-java.yaml
@@ -1,0 +1,39 @@
+package: ca-certificates-java
+
+essential:
+  - ca-certificates-java_copyright
+
+slices:
+  bins:
+    essential:
+      - ca-certificates-java_data-with-certs
+      - ca-certificates_bins
+      # chisel tool does not allow per-architecture packages
+      # openjdk-8 is not published for RISCV in the archive
+      # - openjdk-8-jre-headless_security
+    contents:
+      # In order to generate Java keystore in a chiselled chroot
+      # execute following commands, assuming that 'rootfs' is the
+      # output directory and openjdk-8-jre-headless_security is
+      # also installed.
+      # cd rootfs
+      # sudo chroot . /bin/bash /usr/sbin/update-ca-certificates
+      # sudo chroot . find /etc/ssl/certs/ -name *.pem -exec echo +{} \; > certs
+      # `mkdir proc && mount -t proc /proc proc/` or
+      # `chroot . ln -s /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java proc/self/exe`
+      # sudo chroot . /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
+      #    -jar /usr/share/ca-certificates-java/ca-certificates-java.jar < certs
+      # rm certs
+      # See tests/spread/integration/ca-certificates-java/task.yaml
+      /etc/ssl/certs/java/:
+      /usr/share/ca-certificates-java/ca-certificates-java.jar:
+
+  data-with-certs:
+    essential:
+      - ca-certificates_data-with-certs
+    contents:
+      /etc/ssl/certs/java/:
+
+  copyright:
+    contents:
+      /usr/share/doc/ca-certificates-java/copyright:

--- a/tests/spread/integration/ca-certificates-java/task.yaml
+++ b/tests/spread/integration/ca-certificates-java/task.yaml
@@ -1,0 +1,18 @@
+summary: Integration tests for ca-certificates-java
+
+environment:
+  SLICE/bins: "bins"
+
+execute: |
+  # Test bins slice installation
+  echo "SLICE=${SLICE}"
+  rootfs="$(install-slices ca-certificates-java_${SLICE} openjdk-8-jre-headless_security)"
+
+  cd ${rootfs}
+  chroot . /bin/bash /usr/sbin/update-ca-certificates
+  chroot . find /etc/ssl/certs/ -name *.pem -exec echo +{} \; > ${rootfs}/certs
+  mkdir -p proc/self
+  for java in $(find /usr/lib/jvm -name java -type f); do
+    ln -s /${java} proc/self/exe
+    chroot . /${java} -jar /usr/share/ca-certificates-java/ca-certificates-java.jar < certs
+  done


### PR DESCRIPTION
# Proposed changes

Forward port ca-certificates-java slice that was missed in forward porting openjdk-8 slices.

## Related issues/PRs
[Ubuntu 24.04](https://github.com/canonical/chisel-releases/pull/308)

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->