### PR TITLE
ci: bump canonical/has-signed-canonical-cla to v2

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
Following the conversations on Mattermost, let's bump the [Has Signed Canonical CLA](https://github.com/marketplace/actions/has-signed-canonical-cla) action to v2.