### PR TITLE
feat(24.10): port libnss-extra-mdns to 24.10

### DIFF
--- a/slices/libnss-extrausers.yaml
+++ b/slices/libnss-extrausers.yaml
@@ -1,0 +1,21 @@
+package: libnss-extrausers
+
+essential:
+  - libnss-extrausers_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnss-extrausers_var
+    contents:
+      /usr/lib/libnss_extrausers.so.*:
+      /usr/lib32/libnss_extrausers.so.*: { arch: [amd64, s390x] }
+
+  var:
+    contents:
+      /var/lib/extrausers/:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnss-extrausers/copyright:

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -7,8 +7,8 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libnss-mdns_standard
       - libnss-mdns_minimal
+      - libnss-mdns_standard
 
   standard:
     essential:

--- a/slices/libnss-mdns.yaml
+++ b/slices/libnss-mdns.yaml
@@ -1,0 +1,51 @@
+package: libnss-mdns
+
+essential:
+  - libnss-mdns_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnss-mdns_standard
+      - libnss-mdns_minimal
+
+  standard:
+    essential:
+      - libnss-mdns_mdns-standard
+      - libnss-mdns_mdns4-standard
+      - libnss-mdns_mdns6-standard
+
+  minimal:
+    essential:
+      - libnss-mdns_mdns-minimal
+      - libnss-mdns_mdns4-minimal
+      - libnss-mdns_mdns6-minimal
+
+  mdns-minimal:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns_minimal.so.*:
+
+  mdns-standard:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns.so.*:
+
+  mdns4-minimal:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns4_minimal.so.*:
+
+  mdns4-standard:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns4.so.*:
+
+  mdns6-minimal:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns6_minimal.so.*:
+
+  mdns6-standard:
+    contents:
+      /usr/lib/*-linux-*/libnss_mdns6.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnss-mdns/copyright:


### PR DESCRIPTION
Forward port from https://github.com/canonical/chisel-releases/pull/345
