### PR TITLE
Rocks-1890/temporarily disable arm tests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -11,8 +11,9 @@ jobs:
         runner:
           - name: X64
             runs-on: ubuntu-latest
-          # Execution of arm64 github runners on forked branches was disabled due to a recently found attack vector.
-          # see https://warthogs.atlassian.net/browse/ROCKS-1890
+          # Execution of arm64 github runners on forked branches was disabled
+          # due to a recently found attack vector.
+          # TODO re-enable this runner once the above mentioned issue is fixed.
           # - name: ARM64
           #   runs-on: [noble, ARM64, large]
     name: Run Spread tests | ${{ matrix.runner.name }}

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -11,8 +11,10 @@ jobs:
         runner:
           - name: X64
             runs-on: ubuntu-latest
-          - name: ARM64
-            runs-on: [noble, ARM64, large]
+          # Execution of arm64 github runners on forked branches was disabled due to a recently found attack vector.
+          # see https://warthogs.atlassian.net/browse/ROCKS-1890
+          # - name: ARM64
+          #   runs-on: [noble, ARM64, large]
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
     steps:


### PR DESCRIPTION
# Proposed changes

Execution of arm64 github runners on forked branches was disabled due to a recently found attack vector.
We have temporarily disabled arm64 spread tests from the CI matrix to keep development going. This change needs to be reverted in ~2wks when the runner restrictions are lifted

