### PR TITLE
feat: compatibility matrix CI for Chisel versions

### DIFF
--- a/.github/scripts/install-slices/version-matrix.py
+++ b/.github/scripts/install-slices/version-matrix.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+
+import os
+import json
+
+arches, releases = json.loads(os.environ["ARCHES"]), json.loads(os.environ["RELEASES"])
+matrix = []
+for arch in arches:
+    for release in releases:
+        for chisel_version in release["chisel-versions"]:
+            matrix.append({
+                "arch": arch,
+                "ref": release["ref"],
+                "chisel-version": chisel_version,
+            })
+
+print(json.dumps(matrix))

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -21,8 +21,15 @@ on:
 
 env:
   # Package architectures and chisel-releases branches to test on.
-  ARCHES: ${{ toJson('["amd64","arm64","armhf","i386","ppc64el","riscv64","s390x"]') }}
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-24.10"]') }}
+  ARCHES: '["amd64","arm64","armhf","i386","ppc64el","riscv64","s390x"]'
+  # TODO this is just an example.
+  RELEASES: |
+    [
+      {"ref": "ubuntu-20.04", "chisel-versions": ["main"]},
+      {"ref": "ubuntu-22.04", "chisel-versions": ["main"]},
+      {"ref": "ubuntu-24.04", "chisel-versions": ["main"]},
+      {"ref": "ubuntu-24.10", "chisel-versions": ["v1.0.0", "v1.1.0", "main"]}
+    ]
 
 jobs:
   prepare-install:
@@ -31,29 +38,49 @@ jobs:
     outputs:
       install-all: ${{ steps.set-output.outputs.install_all }}
       matrix: ${{ steps.set-output.outputs.matrix }}
-      checkout-main-ref: ${{ steps.set-output.outputs.checkout_main_ref }}
+      checkout-main-ref: ${{ steps.set-main-ref.outputs.checkout_main_ref }}
     steps:
-      - name: Set output
-        id: set-output
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Set reference to main branch
+        id: set-main-ref
         run: |
-          set -ex
-
-          if [[
-            "${{ github.base_ref || github.ref_name }}" == "main" ||
-            "${{ github.event_name }}" == "schedule"
-          ]]; then
-            echo "matrix={\"ref\":${{ env.RELEASES }},\"arch\":${{ env.ARCHES }}}" >> $GITHUB_OUTPUT
-            echo "install_all=true" >> $GITHUB_OUTPUT
-          else
-            echo "matrix={\"arch\":${{ env.ARCHES }}}" >> $GITHUB_OUTPUT
-          fi
-
           if [[ "${{ github.base_ref }}" == "main" ]]; then
             # For PRs to main, use the updated files.
             # Leaving checkout_main_ref unset will checkout the PR head_ref.
             echo "checkout_main_ref=" >> $GITHUB_OUTPUT
           else
             echo "checkout_main_ref=main" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.set-main-ref.outputs.checkout_main_ref }}
+
+      - name: Set output
+        id: set-output
+        run: |
+          set -ex
+
+          ln -s ".github/scripts/install-slices/version-matrix.py" version-matrix
+
+          if [[
+            "${{ github.base_ref || github.ref_name }}" == "main" ||
+            "${{ github.event_name }}" == "schedule"
+          ]]; then
+            MATRIX=$(./version-matrix)
+            echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
+
+            echo "install_all=true" >> $GITHUB_OUTPUT
+          else
+            # Filter the releases to only the affected branch.
+            export RELEASES=$(echo "$RELEASES" | jq '[.[] | select(.ref == "${{ github.base_ref }}")]')
+            MATRIX=$(./version-matrix)
+            echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
           fi
 
   # The "install" job tests the slices by installing them.
@@ -121,7 +148,7 @@ jobs:
           set -ex
 
           # Install chisel
-          go install github.com/canonical/chisel/cmd/chisel@main
+          go install "github.com/canonical/chisel/cmd/chisel@${{ matrix.chisel-version }}"
 
           # Install dependencies of the install_slices script
           sudo apt-get -y update

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -71,6 +71,11 @@ jobs:
             "${{ github.base_ref || github.ref_name }}" == "main" ||
             "${{ github.event_name }}" == "schedule"
           ]]; then
+            # When installing all the slices only use the main version of
+            # chisel to avoid expensive CI jobs. We are testing that slices can
+            # be installed together so using a single version of chisel is
+            # enough.
+            export RELEASES=$(echo "$RELEASES" | jq 'map(.["chisel-versions"] |= ["main"])')
             MATRIX=$(./version-matrix)
             echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -22,13 +22,12 @@ on:
 env:
   # Package architectures and chisel-releases branches to test on.
   ARCHES: '["amd64","arm64","armhf","i386","ppc64el","riscv64","s390x"]'
-  # TODO this is just an example.
   RELEASES: |
     [
-      {"ref": "ubuntu-20.04", "chisel-versions": ["main"]},
-      {"ref": "ubuntu-22.04", "chisel-versions": ["main"]},
-      {"ref": "ubuntu-24.04", "chisel-versions": ["main"]},
-      {"ref": "ubuntu-24.10", "chisel-versions": ["v1.0.0", "v1.1.0", "main"]}
+      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.0.0","main"]},
+      {"ref": "ubuntu-22.04", "chisel-versions": ["v1.0.0","main"]},
+      {"ref": "ubuntu-24.04", "chisel-versions": ["v1.0.0","main"]},
+      {"ref": "ubuntu-24.10", "chisel-versions": ["v1.0.0","main"]}
     ]
 
 jobs:


### PR DESCRIPTION
# Proposed changes
This commit adds another dimension of testing for the CI. Now we can specify Chisel versions that should be tested against a branch. This is necessary to make sure we maintain backwards compatibility with complex features such as hard link support.

## Related issues/PRs
Internal Jira ticket.

### Forward porting
N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
Example run:
* Push on main: https://github.com/letFunny/chisel-releases/actions/runs/13590801595/job/37996227785
* On pull request: https://github.com/letFunny/chisel-releases/actions/runs/13627359023/job/38087361799

> [!CAUTION]
> After we change this PR to incorporate the feedback I will run the workflows again to make sure they still works. Github actions are rather flaky, especially in regards to escaping quotes and json values.