### PR TITLE
Revert "Rocks-1890/temporarily disable arm tests"

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -11,11 +11,8 @@ jobs:
         runner:
           - name: X64
             runs-on: ubuntu-latest
-          # Execution of arm64 github runners on forked branches was disabled
-          # due to a recently found attack vector.
-          # TODO re-enable this runner once the above mentioned issue is fixed.
-          # - name: ARM64
-          #   runs-on: [noble, ARM64, large]
+          - name: ARM64
+            runs-on: [noble, ARM64, large]
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
     steps:


### PR DESCRIPTION
The ARM runners appear to be available again. Let's re-enable them again in tests