### PR TITLE
feat(24.10): create jre 23 slice

### DIFF
--- a/slices/openjdk-23-jre-headless.yaml
+++ b/slices/openjdk-23-jre-headless.yaml
@@ -1,0 +1,183 @@
+package: openjdk-23-jre-headless
+
+essential:
+  - openjdk-23-jre-headless_copyright
+
+slices:
+  # List of classes required to create the Class Data Sharing archive
+  class-data-sharing:
+    essential:
+      - openjdk-23-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-23-openjdk-*/lib/classlist:
+
+  # Native part of the console support
+  console:
+    essential:
+      - openjdk-23-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libsyslookup.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/openjdk-23-jre-headless/copyright:
+
+  # A minimal set of files to run a Java application
+  # excluded dependencies:
+  # - ca-certificates-java_essential - needs chisel support to run
+  #                                    maintainer scripts.
+  # - java-common                    - provides update-alternatives,
+  #                                    not relevant.
+  # - util-linux                     - needed for bash completion
+  #                                    not relevant.
+  # - libjpeg8                       - used in awt, not relevant
+  # - liblcms2-2                     - used in awt, not relevant
+  core:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+    contents:
+      /etc/java-23-openjdk/accessibility.properties:
+      /etc/java-23-openjdk/jaxp-strict.properties:
+      /etc/java-23-openjdk/jaxp.properties:
+      /etc/java-23-openjdk/jvm-*.cfg:
+      /etc/java-23-openjdk/logging.properties:
+      /etc/java-23-openjdk/net.properties:
+      /etc/java-23-openjdk/security/java.policy:
+      /etc/java-23-openjdk/security/java.security:
+      /usr/lib/jvm/java-23-openjdk-*/bin/java:
+      /usr/lib/jvm/java-23-openjdk-*/conf/accessibility.properties:
+      /usr/lib/jvm/java-23-openjdk-*/conf/jaxp-strict.properties:
+      /usr/lib/jvm/java-23-openjdk-*/conf/jaxp.properties:
+      /usr/lib/jvm/java-23-openjdk-*/conf/logging.properties:
+      /usr/lib/jvm/java-23-openjdk-*/conf/net.properties:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/java.policy:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/java.security:
+      /usr/lib/jvm/java-23-openjdk-*/lib/*/libjsig.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/*/libjvm.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jar.binfmt:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jexec:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jspawnhelper:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jvm.cfg:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libextnet.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libjava.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libjimage.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libjli.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libjsig.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libnet.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libnio.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libverify.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libzip.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/modules:
+      /usr/lib/jvm/java-23-openjdk-*/lib/tzdb.dat:
+      /usr/lib/jvm/java-23-openjdk-*/release:
+
+  # Debug support
+  debug:
+    essential:
+      - openjdk-23-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libattach.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libdt_socket.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libinstrument.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libjdwp.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libsaproc.so:
+        arch:
+          - amd64
+          - arm64
+          - ppc64el
+          - riscv64
+
+  # Java Flight Recorder configuration and jar file
+  jfr:
+    essential:
+      - openjdk-23-jre-headless_core
+    contents:
+      /etc/java-23-openjdk/jfr/default.jfc:
+      /etc/java-23-openjdk/jfr/profile.jfc:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jfr/default.jfc:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jfr/profile.jfc:
+      /usr/lib/jvm/java-23-openjdk-*/lib/jrt-fs.jar:
+
+  # Configuration and native part of Java Management Extensions
+  management:
+    essential:
+      - openjdk-23-jre-headless_rmi
+    contents:
+      /etc/java-23-openjdk/management/jmxremote.access:
+      /etc/java-23-openjdk/management/management.properties:
+      /usr/lib/jvm/java-23-openjdk-*/conf/management/jmxremote.access:
+      /usr/lib/jvm/java-23-openjdk-*/conf/management/management.properties:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libmanagement.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libmanagement_agent.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libmanagement_ext.so:
+
+  # Native part of jdk.prefs modules
+  prefs:
+    essential:
+      - openjdk-23-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libprefs.so:
+
+  # Native part of java.rmi
+  rmi:
+    essential:
+      - openjdk-23-jre-headless_security
+    contents:
+      /usr/lib/jvm/java-23-openjdk-*/bin/rmiregistry:
+      /usr/lib/jvm/java-23-openjdk-*/lib/librmi.so:
+
+  # Security configuration files and native libraries
+  security:
+    essential:
+      - libnss3_nss
+      - libpcsclite1_libs
+      - openjdk-23-jre-headless_core
+    contents:
+      /etc/java-23-openjdk/security/blocked.certs:
+      /etc/java-23-openjdk/security/default.policy:
+      /etc/java-23-openjdk/security/nss.cfg:
+      /etc/java-23-openjdk/security/policy/limited/default_US_export.policy:
+      /etc/java-23-openjdk/security/policy/limited/default_local.policy:
+      /etc/java-23-openjdk/security/policy/limited/exempt_local.policy:
+      /etc/java-23-openjdk/security/policy/unlimited/default_US_export.policy:
+      /etc/java-23-openjdk/security/policy/unlimited/default_local.policy:
+      /etc/java-23-openjdk/security/public_suffix_list.dat:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/nss.cfg:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/policy/limited/default_US_export.policy:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/policy/limited/default_local.policy:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/policy/limited/exempt_local.policy:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/policy/unlimited/default_US_export.policy:
+      /usr/lib/jvm/java-23-openjdk-*/conf/security/policy/unlimited/default_local.policy:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libj2gss.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libj2pcsc.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libj2pkcs11.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/libjaas.so:
+      /usr/lib/jvm/java-23-openjdk-*/lib/security/blocked.certs:
+      /usr/lib/jvm/java-23-openjdk-*/lib/security/cacerts:
+      /usr/lib/jvm/java-23-openjdk-*/lib/security/default.policy:
+      /usr/lib/jvm/java-23-openjdk-*/lib/security/public_suffix_list.dat:
+
+  # A set of slices to run headless openjdk runtime
+  standard:
+    essential:
+      - openjdk-23-jre-headless_class-data-sharing
+      - openjdk-23-jre-headless_console
+      - openjdk-23-jre-headless_core
+      - openjdk-23-jre-headless_debug
+      - openjdk-23-jre-headless_jfr
+      - openjdk-23-jre-headless_management
+      - openjdk-23-jre-headless_prefs
+      - openjdk-23-jre-headless_rmi
+      - openjdk-23-jre-headless_security
+      - openjdk-23-jre-headless_tools
+
+  # OpenJDK tools
+  tools:
+    essential:
+      - openjdk-23-jre-headless_security
+    contents:
+      /usr/lib/jvm/java-23-openjdk-*/bin/jpackage:
+      /usr/lib/jvm/java-23-openjdk-*/bin/keytool:

--- a/tests/spread/integration/openjdk-23-jre-headless/ConsoleTest.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/ConsoleTest.java
@@ -1,0 +1,11 @@
+import java.io.Console;
+
+public class ConsoleTest {
+    public static void main(String[] args) {
+        Console c = System.console();
+        if (c == null) {
+            throw new RuntimeException("Console is not available");
+        }
+        c.printf("console output %s\n", "success");
+    }
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/Main.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/PrefsTest.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/PrefsTest.java
@@ -1,0 +1,13 @@
+import java.util.prefs.*;
+
+public class PrefsTest {
+    public static void main(String[] args) {
+        if ("put".equals(args[0])) {
+            Preferences.userRoot().put("a", "b");
+        } else if ("get".equals(args[0])) {
+            if (!"b".equals(Preferences.userRoot().get("a", null))) {
+                throw new RuntimeException("Unable to read the preference");
+            }
+        }
+    }
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/ReadCertificate.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/ReadCertificate.java
@@ -1,0 +1,35 @@
+import java.security.cert.*;
+import java.io.*;
+
+public class ReadCertificate {
+
+    static final String PEM = """
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIULvuqN3MiptnZSYS9y1qJAZYKFA4wDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDA4MTUwMjQzNDhaFw0yNTA4
+MTUwMjQzNDhaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDm3990peBuPYaz0UEEc75Q7i79P4RzrD84MxhDpoPs
+MSdnmO3rTkIG84Wp72+8T7TGjGjBhX++8UmZLrXy2AfcejZi3JcddMWH4V5XEnAj
+hTBe1HLkiotayZst/cxuTP6KmuahjsROAqriCv/A4BBA8KjYx1e4E9k9+81FreZy
+PJ8p3m7R8qZ/DtjuW1aMQ3oDRKA/iqQhLHVpJy/iYiyjwTdJm6/lA3ywGCr6ZMWm
+9tWUT+4TvhyRM67Y0gcCtH51cwxPqUFGEKAkLWIu2fS6DaoXtHylxgGeKKPes3JX
+uSn9QezEEqvrgLFQRqIUS8tNZFEhoJQ7dmxMP/XKAD51AgMBAAGjUzBRMB0GA1Ud
+DgQWBBSb70j+xaI3eTxp4H7MDm1MLVRGNTAfBgNVHSMEGDAWgBSb70j+xaI3eTxp
+4H7MDm1MLVRGNTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAp
+0GIjKtwvD7BkQy+cf3dsdwYodxoIYl4E8UvHfBSPQQfFNh+chHPmrNYRuFM3Q6sT
+ogNhHKLecQMK4tNUDa/vVRGnqmZVWjxqLnyH/qFKtakqPB6h6x4h50huzA+twhNm
+SDjg3QqqpOuUzrs77JqYkxSjqd0QgmwmgxOdbcF0SY+ebQhAd0UXY7wIs6ByDEHO
+kElgJmnGKhOpf1SFpQh2qpKGq/MvcdHWN4oKri440wCf+czkrOTyGVc275oTbRnM
+Z76Ro4JDuomyWeR9iQ5pP5ug4ciflLa7hlYcH0xJbF3b2M3BlnUYKMqih/TjqKdr
+NBs121h64SPY0gh7kIvF
+-----END CERTIFICATE-----
+            """;
+    
+    public static void main(String[] args) throws Throwable {
+        java.security.cert.Certificate cert = CertificateFactory.getInstance("X509").generateCertificate(new ByteArrayInputStream(PEM.getBytes()));
+        if (cert == null)
+            throw new RuntimeException("It should be possible to decode a certificate");
+    }
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/TestJMX.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/TestJMX.java
@@ -1,0 +1,42 @@
+import java.lang.management.ManagementFactory;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.remote.*;
+
+import com.sun.tools.attach.*;
+
+
+public class TestJMX implements TestJMXMBean {
+
+    static final String CONNECTOR_ADDRESS =
+        "com.sun.management.jmxremote.localConnectorAddress";
+
+    @Override
+    public void test() {
+
+    }
+
+    public static void main(String[] args) throws Throwable {
+        ObjectName objectName = new ObjectName("test:type=basic,name=mbeantest");
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        server.registerMBean(new TestJMX(), objectName);
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:5000/jmxrmi");
+        int count = JMXConnectorFactory.connect(url)
+            .getMBeanServerConnection()
+            .getMBeanCount();
+        System.out.println(count);
+    }
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/TestJMXMBean.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/TestJMXMBean.java
@@ -1,0 +1,3 @@
+public interface TestJMXMBean {
+    void test();
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/VirtualThreadsTest.java
+++ b/tests/spread/integration/openjdk-23-jre-headless/VirtualThreadsTest.java
@@ -1,0 +1,26 @@
+public class VirtualThreadsTest {
+    public static void main(String[] args) throws Exception {
+        // Create and start 1,000 virtual threads
+        final int threadCount = 1_000;
+        final long[] results = new long[threadCount];
+        Thread[] threads = new Thread[threadCount];
+        long startTime = System.currentTimeMillis();
+        // Create virtual threads, each doing a simple calculation
+        for (int i = 0; i < threadCount; i++) {
+            final int id = i;
+            // Using the virtual thread factory API
+            threads[i] = Thread.ofVirtual().name("virtual-thread-" + i).start(() -> {
+                results[id] = fibonacci(15 + (id % 10));
+            });
+        }
+        // Wait for all threads to complete
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        long endTime = System.currentTimeMillis();
+    }
+    private static long fibonacci(int n) {
+        if (n <= 1) return n;
+        return fibonacci(n-1) + fibonacci(n-2);
+    }
+}

--- a/tests/spread/integration/openjdk-23-jre-headless/task.yaml
+++ b/tests/spread/integration/openjdk-23-jre-headless/task.yaml
@@ -1,0 +1,68 @@
+summary: Integration tests for openjdk-23-jre-headless
+
+environment:
+  SLICE/classdatasharing: "class-data-sharing"
+  SLICE/core: "core"
+  SLICE/prefs: "prefs"
+#  SLICE/rmi: "rmi" # Tested in management slice
+#  SLICE/console: "console" # This test requires /dev/pty. Skip it.
+  SLICE/debug: "debug"
+  SLICE/management: "management"
+  SLICE/jfr: "jfr"
+  SLICE/security: "security"
+  SLICE/tools: "tools"
+  SLICE/virtualthreads: "core" # Testing virtual threads using the core slice
+
+execute: |
+  # Test different slice installations
+  echo "SLICE=${SLICE}"
+  rootfs="$(install-slices openjdk-23-jre-headless_${SLICE})"
+  apt install --update -y openjdk-23-jdk-headless
+  # Need to ensure we're using the right java version
+  update-java-alternatives --set /usr/lib/jvm/java-1.23.0*
+  javac *.java
+  cp *.java ${rootfs}/
+  cp *.class ${rootfs}/
+  cd ${rootfs}
+  mkdir -p proc/self
+  for java in `find usr/lib/jvm -name java`; do
+    ln -sf /${java} proc/self/exe
+    chroot . ${java} --version
+    case ${SLICE} in
+      class-data-sharing)
+        chroot . ${java} -XX:ArchiveClassesAtExit=archive.cds /Main.java
+      ;;
+      core)
+        chroot . ${java} /Main.java
+      ;;
+      prefs)
+        chroot . ${java} /PrefsTest.java put
+        chroot . ${java} /PrefsTest.java get
+      ;;
+      debug)
+        chroot . ${java} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 /Main.java
+      ;;
+      management)
+        chroot . ${java} -Dcom.sun.management.jmxremote.port=5000 \
+          -Dcom.sun.management.jmxremote.authenticate=false \
+          -Dcom.sun.management.jmxremote=true \
+          -Dcom.sun.management.jmxremote.ssl=false  -cp . TestJMX
+      ;;
+      jfr)
+        chroot . ${java} -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=dump.jfr /Main.java
+      ;;
+      security)
+        chroot . ${java} /ReadCertificate.java
+      ;;
+      tools)
+        DNAME="CN=Sample Cert, OU=R&D, O=Company Ltd., L=Dublin 4, S=Dublin, C=IE"
+        chroot . $(dirname ${java})/keytool -genkeypair -keystore foo -storepass barbar -keyalg RSA -dname "$DNAME"
+      ;;
+      virtualthreads)
+        chroot . ${java} /VirtualThreadsTest.java
+      ;;
+    esac
+  done
+
+restore: |
+  apt remove -y --purge openjdk-23-jdk-headless


### PR DESCRIPTION
# Proposed changes
This PR creates an `openjdk-23-jre-headless` slice. Based heavily on the JRE 21 slice developed by @vpa1977

## Related issues/PRs

### Forward porting


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->