### PR TITLE
fix(ci): address CVE-2025-30066

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -28,7 +28,7 @@ jobs:
           list-files: shell
 
       - name: Check changed test directories
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         id: changed-tests
         with:
           separator: " "


### PR DESCRIPTION
Address https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/ by pinning the action to a known safe sha.
