### PR TITLE
feat(22.04): backport openjdk-21 slices from 24.04

### DIFF
--- a/slices/openjdk-21-jdk-headless.yaml
+++ b/slices/openjdk-21-jdk-headless.yaml
@@ -1,0 +1,160 @@
+package: openjdk-21-jdk-headless
+
+essential:
+  - openjdk-21-jdk-headless_copyright
+
+slices:
+
+  # OpenJDK binaries slice
+  core:
+    essential:
+      - libc6_libs
+      - openjdk-21-jre-headless_core
+      - zlib1g_libs
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/bin/javac:
+      /usr/lib/jvm/java-21-openjdk-*/bin/javadoc:
+      /usr/lib/jvm/java-21-openjdk-*/bin/javap:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jdeprscan:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jdeps:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jimage:
+      /usr/lib/jvm/java-21-openjdk-*/bin/serialver:
+      # used by javac
+      /usr/lib/jvm/java-21-openjdk-*/lib/ct.sym:
+
+  standard:
+    essential:
+      - openjdk-21-jdk-headless_core
+      - openjdk-21-jre-headless_standard
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jar:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jarsigner:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jcmd:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jdb:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jfr:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jhsdb:
+        arch:
+          - amd64
+          - arm64
+      /usr/lib/jvm/java-21-openjdk-*/bin/jinfo:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jmap:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jps:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jrunscript:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jshell:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jstack:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jstat:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jstatd:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jwebserver:
+
+  # OpenJDK modules required to build the runtime image
+  modules:
+    essential:
+      - openjdk-21-jdk-headless_core
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jlink:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.base.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.compiler.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.datatransfer.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.desktop.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.instrument.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.logging.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.management.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.management.rmi.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.naming.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.net.http.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.prefs.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.rmi.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.scripting.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.se.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.security.jgss.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.security.sasl.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.smartcardio.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.sql.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.sql.rowset.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.transaction.xa.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.xml.crypto.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/java.xml.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.accessibility.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.attach.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.charsets.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.compiler.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.crypto.cryptoki.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.crypto.ec.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.dynalink.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.editpad.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.hotspot.agent.jmod:
+        arch:
+          - amd64
+          - arm64
+          - ppc64el
+          - riscv64
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.httpserver.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.ed.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.jvmstat.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.le.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.opt.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.vm.ci.jmod:
+        arch:
+          - amd64
+          - arm64
+          - riscv64
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.vm.compiler.jmod:
+        arch:
+          - amd64
+          - arm64
+          - riscv64
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.internal.vm.compiler.management.jmod:
+        arch:
+          - amd64
+          - arm64
+          - riscv64
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jartool.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.javadoc.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jcmd.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jconsole.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jdeps.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jdi.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jdwp.agent.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jfr.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jlink.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jpackage.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jshell.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jsobject.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.jstatd.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.localedata.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.management.agent.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.management.jfr.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.management.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.naming.dns.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.naming.rmi.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.net.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.nio.mapmode.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.random.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.sctp.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.security.auth.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.security.jgss.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.unsupported.desktop.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.unsupported.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.xml.dom.jmod:
+      /usr/lib/jvm/java-21-openjdk-*/jmods/jdk.zipfs.jmod:
+
+  # OpenJDK headers for JNI
+  headers:
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/include/classfile_constants.h:
+      /usr/lib/jvm/java-21-openjdk-*/include/jni.h:
+      /usr/lib/jvm/java-21-openjdk-*/include/jvmti.h:
+      /usr/lib/jvm/java-21-openjdk-*/include/jvmticmlr.h:
+      /usr/lib/jvm/java-21-openjdk-*/include/linux/jni_md.h:
+
+  # OpenJDK headers for the debug agent development
+  debug-headers:
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/include/jdwpTransport.h:
+
+  copyright:
+    essential:
+      - openjdk-21-jre-headless_copyright
+    contents:
+      /usr/share/doc/openjdk-21-jdk-headless:

--- a/slices/openjdk-21-jre-headless.yaml
+++ b/slices/openjdk-21-jre-headless.yaml
@@ -1,0 +1,182 @@
+package: openjdk-21-jre-headless
+
+essential:
+  - openjdk-21-jre-headless_copyright
+
+slices:
+
+  # A set of slices to run headless openjdk runtime
+  standard:
+    essential:
+      - openjdk-21-jre-headless_class-data-sharing
+      - openjdk-21-jre-headless_console
+      - openjdk-21-jre-headless_core
+      - openjdk-21-jre-headless_debug
+      - openjdk-21-jre-headless_jfr
+      - openjdk-21-jre-headless_management
+      - openjdk-21-jre-headless_prefs
+      - openjdk-21-jre-headless_rmi
+      - openjdk-21-jre-headless_security
+      - openjdk-21-jre-headless_tools
+
+  # List of classes required to create the Class Data Sharing archive
+  class-data-sharing:
+    essential:
+      - openjdk-21-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/lib/classlist:
+
+  # A minimal set of files to run a Java application
+  # excluded dependencies:
+  # - ca-certificates-java_essential - needs chisel support to run
+  #                                    maintainer scripts.
+  # - java-common                    - provides update-alternatives,
+  #                                    not relevant.
+  # - util-linux                     - needed for bash completion
+  #                                    not relevant.
+  # - libjpeg8                       - used in awt, not relevant
+  # - liblcms2-2                     - used in awt, not relevant
+  core:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+    contents:
+      /etc/java-21-openjdk/jaxp.properties:
+      /etc/java-21-openjdk/jvm-*.cfg:
+      /etc/java-21-openjdk/logging.properties:
+      /etc/java-21-openjdk/net.properties:
+      /etc/java-21-openjdk/security/java.policy:
+      /etc/java-21-openjdk/security/java.security:
+      /usr/lib/jvm/java-21-openjdk-*/bin/java:
+      /usr/lib/jvm/java-21-openjdk-*/conf/jaxp.properties:
+      /usr/lib/jvm/java-21-openjdk-*/conf/logging.properties:
+      /usr/lib/jvm/java-21-openjdk-*/conf/net.properties:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/java.policy:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/java.security:
+      /usr/lib/jvm/java-21-openjdk-*/lib/jexec:
+      /usr/lib/jvm/java-21-openjdk-*/lib/jspawnhelper:
+      /usr/lib/jvm/java-21-openjdk-*/lib/jvm.cfg:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libextnet.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libjava.so:
+      # lib/modules support
+      /usr/lib/jvm/java-21-openjdk-*/lib/libjimage.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libjli.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libjsig.so:
+      # required for IO.
+      /usr/lib/jvm/java-21-openjdk-*/lib/libnet.so:
+      # required for IO.
+      /usr/lib/jvm/java-21-openjdk-*/lib/libnio.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libverify.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libzip.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/modules:
+      /usr/lib/jvm/java-21-openjdk-*/lib/server/libjsig.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/server/libjvm.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/tzdb.dat:
+
+  # Native part of jdk.prefs modules
+  prefs:
+    essential:
+      - openjdk-21-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libprefs.so:
+
+  # Native part of java.rmi
+  rmi:
+    essential:
+      - openjdk-21-jre-headless_security
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/bin/rmiregistry:
+      /usr/lib/jvm/java-21-openjdk-*/lib/librmi.so:
+
+  # Native part of the console support
+  console:
+    essential:
+      - openjdk-21-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/lib/lible.so:
+
+  # Debug support
+  debug:
+    essential:
+      - openjdk-21-jre-headless_core
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libattach.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libdt_socket.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libinstrument.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libjdwp.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libsaproc.so:
+        arch:
+          - amd64
+          - arm64
+          - armhf
+          - ppc64el
+          - riscv64
+
+  # Configuration and native part of Java Management Extensions
+  management:
+    essential:
+      - openjdk-21-jre-headless_rmi
+    contents:
+      /etc/java-21-openjdk/management/jmxremote.access:
+      /etc/java-21-openjdk/management/management.properties:
+      /usr/lib/jvm/java-21-openjdk-*/conf/management/jmxremote.access:
+      /usr/lib/jvm/java-21-openjdk-*/conf/management/management.properties:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libmanagement.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libmanagement_agent.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libmanagement_ext.so:
+
+  # Security configuration files and native libraries
+  security:
+    essential:
+      - libnss3_nss
+      - libpcsclite1_libs
+      - openjdk-21-jre-headless_core
+    contents:
+      /etc/java-21-openjdk/security/blocked.certs:
+      /etc/java-21-openjdk/security/default.policy:
+      /etc/java-21-openjdk/security/nss.cfg:
+      /etc/java-21-openjdk/security/policy/limited/default_US_export.policy:
+      /etc/java-21-openjdk/security/policy/limited/default_local.policy:
+      /etc/java-21-openjdk/security/policy/limited/exempt_local.policy:
+      /etc/java-21-openjdk/security/policy/unlimited/default_US_export.policy:
+      /etc/java-21-openjdk/security/policy/unlimited/default_local.policy:
+      /etc/java-21-openjdk/security/public_suffix_list.dat:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/nss.cfg:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/policy/limited/default_US_export.policy:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/policy/limited/default_local.policy:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/policy/limited/exempt_local.policy:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/policy/unlimited/default_US_export.policy:
+      /usr/lib/jvm/java-21-openjdk-*/conf/security/policy/unlimited/default_local.policy:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libj2gss.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libj2pcsc.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libj2pkcs11.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/libjaas.so:
+      /usr/lib/jvm/java-21-openjdk-*/lib/security/blocked.certs:
+      /usr/lib/jvm/java-21-openjdk-*/lib/security/cacerts:
+      /usr/lib/jvm/java-21-openjdk-*/lib/security/default.policy:
+      /usr/lib/jvm/java-21-openjdk-*/lib/security/public_suffix_list.dat:
+
+  # OpenJDK tools
+  tools:
+    essential:
+      - openjdk-21-jre-headless_security
+    contents:
+      /usr/lib/jvm/java-21-openjdk-*/bin/jpackage:
+      /usr/lib/jvm/java-21-openjdk-*/bin/keytool:
+
+  # Java Flight Recorder configuration and jar file
+  jfr:
+    essential:
+      - openjdk-21-jre-headless_core
+    contents:
+      /etc/java-21-openjdk/jfr/default.jfc:
+      /etc/java-21-openjdk/jfr/profile.jfc:
+      /usr/lib/jvm/java-21-openjdk-*/lib/jfr/default.jfc:
+      /usr/lib/jvm/java-21-openjdk-*/lib/jfr/profile.jfc:
+      /usr/lib/jvm/java-21-openjdk-*/lib/jrt-fs.jar:
+
+  copyright:
+    contents:
+      /usr/share/doc/openjdk-21-jre-headless/copyright:

--- a/tests/spread/integration/openjdk-21-jdk-headless/Main.java
+++ b/tests/spread/integration/openjdk-21-jdk-headless/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args){
+        System.out.println("Hello world");
+    }
+}

--- a/tests/spread/integration/openjdk-21-jdk-headless/MonitoringTest.java
+++ b/tests/spread/integration/openjdk-21-jdk-headless/MonitoringTest.java
@@ -1,0 +1,7 @@
+public class MonitoringTest {
+    public static void main(String[] args) throws InterruptedException {
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/tests/spread/integration/openjdk-21-jdk-headless/SerializableObject.java
+++ b/tests/spread/integration/openjdk-21-jdk-headless/SerializableObject.java
@@ -1,0 +1,4 @@
+import java.io.Serializable;
+
+public class SerializableObject  implements Serializable {
+}

--- a/tests/spread/integration/openjdk-21-jdk-headless/task.yaml
+++ b/tests/spread/integration/openjdk-21-jdk-headless/task.yaml
@@ -1,0 +1,128 @@
+summary: Integration tests for openjdk-21-jdk-headless
+
+environment:
+  SLICE/core: "core"
+  SLICE/standard: "standard"
+  SLICE/modules: "modules"
+
+execute: |
+  pids=()
+  cleanup() {
+    for pid in "${pids[@]}"; do
+      kill "$pid" 2>/dev/null
+    done
+    apt remove -y --purge openjdk-21-jdk-headless
+  }
+  for sig in INT QUIT HUP TERM; do trap "cleanup; trap - $sig EXIT; kill -s $sig "'"$$"' "$sig"; done
+  trap cleanup EXIT
+
+  apt-get update && apt-get install -y openjdk-21-jdk-headless curl
+  # Need to ensure we're using the right java version
+  update-java-alternatives --set /usr/lib/jvm/java-1.21.0*
+  nohup java MonitoringTest.java &
+  pid=$!
+  pids+=("$pid")
+
+  # Test different slice installations
+  echo "SLICE=${SLICE}"
+  rootfs="$(install-slices openjdk-21-jdk-headless_${SLICE} dash_bins)"
+  cp *.java ${rootfs}/
+  javac *.java
+  cp *.class ${rootfs}/
+  cd ${rootfs}
+  mkdir -p proc sys tmp
+  mount --bind /proc proc
+  mount --bind /sys sys
+  mount --bind /tmp tmp
+  case ${SLICE} in
+    core)
+      for java in `find usr/lib/jvm -name java`; do
+        home=$(dirname ${java})
+        # /usr/lib/jvm/java-21-openjdk-*/bin/javac:
+        chroot . ${home}/javac /Main.java -d /
+        # /usr/lib/jvm/java-21-openjdk-*/bin/javadoc:
+        chroot . ${home}/javadoc /Main.java
+        # /usr/lib/jvm/java-21-openjdk-*/bin/javap:
+        chroot . ${home}/javap -l /Main.class
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jdeprscan:
+        chroot . ${home}/jdeprscan --class-path . Main
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jdeps:
+        chroot . ${home}/jdeps -m java.base
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jimage:
+        chroot . ${home}/jimage info ${home}/../lib/modules
+        # /usr/lib/jvm/java-21-openjdk-*/bin/serialver:
+        chroot . ${home}/serialver -classpath / SerializableObject
+      done
+      ;;
+    standard)
+      for java in `find usr/lib/jvm -name java`; do
+        home=$(dirname ${java})
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jar:
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jarsigner:
+        chroot . ${home}/jar cvf test.jar *.java
+        DNAME="CN=Sample Cert, OU=R&D, O=Company Ltd., L=Dublin 4, S=Dublin, C=IE"
+        chroot . ${home}/keytool -genkeypair -keystore foo -storepass barbar -keyalg RSA -dname "$DNAME" -alias foo
+        chroot . ${home}/jarsigner -keystore foo -storepass barbar test.jar foo
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jdb:
+        chroot . /bin/sh -c "echo run | ${home}/jdb Main.java"
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jcmd:
+        chroot . ${home}/jcmd jdk.compiler/com.sun.tools.javac.launcher.Main VM.version
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jhsdb:
+        if [ -f ${home}/jhsdb ]; then
+          chroot . ${home}/jhsdb jstack --pid ${pid}
+        fi
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jfr:
+        chroot . ${home}/jcmd ${pid} JFR.start maxsize=1MB
+        chroot . ${home}/jcmd ${pid} JFR.stop
+        chroot . ${home}/jcmd ${pid} JFR.dump filename=/tmp/recording.jfr
+        chroot . ${home}/jfr print /tmp/recording.jfr > /dev/null
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jinfo:
+        chroot . ${home}/jinfo ${pid}
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jshell:
+        chroot . /bin/sh -c "echo 'System.out.println(\"hello world\")' | ${home}/jshell"
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jmap:
+        chroot . ${home}/jmap ${pid}
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jps:
+        chroot . ${home}/jps -l
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jstack:
+        chroot . ${home}/jstack ${pid}
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jstat:
+        chroot . ${home}/jstat -gc ${pid}
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jstatd:
+        nohup chroot . ${home}/jstatd > ./jstatd.log &
+        pids+=($!)
+        for retry in 0 1 2 3 4 5; do
+          if [ ${retry} -eq 5 ]; then
+            exit 1
+          fi
+          grep -q "bound to /JStatRemoteHost" "jstatd.log" && break
+          sleep 10
+        done
+        # /usr/lib/jvm/java-21-openjdk-amd64/bin/jwebserver
+        nohup chroot . ${home}/jwebserver &
+        sleep 10
+        pids+=($!)
+        for retry in 0 1 2 3 4 5; do
+          if [ ${retry} -eq 5 ]; then
+            exit 1
+          fi
+          curl http://127.0.0.1:8000 && break
+          sleep 10
+        done
+        # /usr/lib/jvm/java-21-openjdk-*/bin/jrunscript:
+        ${home}/jrunscript -q
+      done
+      ;;
+    modules)
+      cd ${rootfs}
+      for jlink in `find usr/lib/jvm -name jlink`; do
+        output=$(basename $(mktemp -u))
+        chroot . ${jlink} --add-modules java.base --output ${output}
+        rm -rf ${rootfs}/${output}
+      done
+      for jmod in `find usr/lib/jvm -name jmod`; do
+        home=$(dirname ${jmod})
+        chroot . ${jmod} list ${home}/../jmods/java.rmi.jmod
+      done
+      ;;
+  esac

--- a/tests/spread/integration/openjdk-21-jre-headless/ConsoleTest.java
+++ b/tests/spread/integration/openjdk-21-jre-headless/ConsoleTest.java
@@ -1,0 +1,11 @@
+import java.io.Console;
+
+public class ConsoleTest {
+    public static void main(String[] args) {
+        Console c = System.console();
+        if (c == null) {
+            throw new RuntimeException("Console is not available");
+        }
+        c.printf("console output %s\n", "success");
+    }
+}

--- a/tests/spread/integration/openjdk-21-jre-headless/Main.java
+++ b/tests/spread/integration/openjdk-21-jre-headless/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}

--- a/tests/spread/integration/openjdk-21-jre-headless/PrefsTest.java
+++ b/tests/spread/integration/openjdk-21-jre-headless/PrefsTest.java
@@ -1,0 +1,13 @@
+import java.util.prefs.*;
+
+public class PrefsTest {
+    public static void main(String[] args) {
+        if ("put".equals(args[0])) {
+            Preferences.userRoot().put("a", "b");
+        } else if ("get".equals(args[0])) {
+            if (!"b".equals(Preferences.userRoot().get("a", null))) {
+                throw new RuntimeException("Unable to read the preference");
+            }
+        }
+    }
+}

--- a/tests/spread/integration/openjdk-21-jre-headless/ReadCertificate.java
+++ b/tests/spread/integration/openjdk-21-jre-headless/ReadCertificate.java
@@ -1,0 +1,35 @@
+import java.security.cert.*;
+import java.io.*;
+
+public class ReadCertificate {
+
+    static final String PEM = """
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIULvuqN3MiptnZSYS9y1qJAZYKFA4wDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDA4MTUwMjQzNDhaFw0yNTA4
+MTUwMjQzNDhaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDm3990peBuPYaz0UEEc75Q7i79P4RzrD84MxhDpoPs
+MSdnmO3rTkIG84Wp72+8T7TGjGjBhX++8UmZLrXy2AfcejZi3JcddMWH4V5XEnAj
+hTBe1HLkiotayZst/cxuTP6KmuahjsROAqriCv/A4BBA8KjYx1e4E9k9+81FreZy
+PJ8p3m7R8qZ/DtjuW1aMQ3oDRKA/iqQhLHVpJy/iYiyjwTdJm6/lA3ywGCr6ZMWm
+9tWUT+4TvhyRM67Y0gcCtH51cwxPqUFGEKAkLWIu2fS6DaoXtHylxgGeKKPes3JX
+uSn9QezEEqvrgLFQRqIUS8tNZFEhoJQ7dmxMP/XKAD51AgMBAAGjUzBRMB0GA1Ud
+DgQWBBSb70j+xaI3eTxp4H7MDm1MLVRGNTAfBgNVHSMEGDAWgBSb70j+xaI3eTxp
+4H7MDm1MLVRGNTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAp
+0GIjKtwvD7BkQy+cf3dsdwYodxoIYl4E8UvHfBSPQQfFNh+chHPmrNYRuFM3Q6sT
+ogNhHKLecQMK4tNUDa/vVRGnqmZVWjxqLnyH/qFKtakqPB6h6x4h50huzA+twhNm
+SDjg3QqqpOuUzrs77JqYkxSjqd0QgmwmgxOdbcF0SY+ebQhAd0UXY7wIs6ByDEHO
+kElgJmnGKhOpf1SFpQh2qpKGq/MvcdHWN4oKri440wCf+czkrOTyGVc275oTbRnM
+Z76Ro4JDuomyWeR9iQ5pP5ug4ciflLa7hlYcH0xJbF3b2M3BlnUYKMqih/TjqKdr
+NBs121h64SPY0gh7kIvF
+-----END CERTIFICATE-----
+            """;
+    
+    public static void main(String[] args) throws Throwable {
+        java.security.cert.Certificate cert = CertificateFactory.getInstance("X509").generateCertificate(new ByteArrayInputStream(PEM.getBytes()));
+        if (cert == null)
+            throw new RuntimeException("It should be possible to decode a certificate");
+    }
+}

--- a/tests/spread/integration/openjdk-21-jre-headless/TestJMX.java
+++ b/tests/spread/integration/openjdk-21-jre-headless/TestJMX.java
@@ -1,0 +1,42 @@
+import java.lang.management.ManagementFactory;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.remote.*;
+
+import com.sun.tools.attach.*;
+
+
+public class TestJMX implements TestJMXMBean {
+
+    static final String CONNECTOR_ADDRESS =
+        "com.sun.management.jmxremote.localConnectorAddress";
+
+    @Override
+    public void test() {
+
+    }
+
+    public static void main(String[] args) throws Throwable {
+        ObjectName objectName = new ObjectName("test:type=basic,name=mbeantest");
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        server.registerMBean(new TestJMX(), objectName);
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:5000/jmxrmi");
+        int count = JMXConnectorFactory.connect(url)
+            .getMBeanServerConnection()
+            .getMBeanCount();
+        System.out.println(count);
+    }
+}

--- a/tests/spread/integration/openjdk-21-jre-headless/TestJMXMBean.java
+++ b/tests/spread/integration/openjdk-21-jre-headless/TestJMXMBean.java
@@ -1,0 +1,3 @@
+public interface TestJMXMBean {
+    void test();
+}

--- a/tests/spread/integration/openjdk-21-jre-headless/task.yaml
+++ b/tests/spread/integration/openjdk-21-jre-headless/task.yaml
@@ -1,0 +1,64 @@
+summary: Integration tests for openjdk-21-jre-headless
+
+environment:
+  SLICE/classdatasharing: "class-data-sharing"
+  SLICE/core: "core"
+  SLICE/prefs: "prefs"
+#  SLICE/rmi: "rmi" # Tested in management slice
+#  SLICE/console: "console" # This test requires /dev/pty. Skip it.
+  SLICE/debug: "debug"
+  SLICE/management: "management"
+  SLICE/jfr: "jfr"
+  SLICE/security: "security"
+  SLICE/tools: "tools"
+
+execute: |
+  # Test different slice installations
+  echo "SLICE=${SLICE}"
+  rootfs="$(install-slices openjdk-21-jre-headless_${SLICE})"
+  apt-get update && apt-get install -y openjdk-21-jdk-headless
+  # Need to ensure we're using the right java version
+  update-java-alternatives --set /usr/lib/jvm/java-1.21.0*
+  javac *.java
+  cp *.java ${rootfs}/
+  cp *.class ${rootfs}/
+  cd ${rootfs}
+  mkdir -p proc/self
+  for java in `find usr/lib/jvm -name java`; do
+    ln -sf /${java} proc/self/exe
+    chroot . ${java} --version
+    case ${SLICE} in
+      class-data-sharing)
+        chroot . ${java} -XX:ArchiveClassesAtExit=archive.cds /Main.java
+      ;;
+      core)
+        chroot . ${java} /Main.java
+      ;;
+      prefs)
+        chroot . ${java} /PrefsTest.java put
+        chroot . ${java} /PrefsTest.java get
+      ;;
+      debug)
+        chroot . ${java} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 /Main.java
+      ;;
+      management)
+        chroot . ${java} -Dcom.sun.management.jmxremote.port=5000 \
+          -Dcom.sun.management.jmxremote.authenticate=false \
+          -Dcom.sun.management.jmxremote=true \
+          -Dcom.sun.management.jmxremote.ssl=false  -cp . TestJMX
+      ;;
+      jfr)
+        chroot . ${java} -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=dump.jfr /Main.java
+      ;;
+      security)
+        chroot . ${java} /ReadCertificate.java
+      ;;
+      tools)
+        DNAME="CN=Sample Cert, OU=R&D, O=Company Ltd., L=Dublin 4, S=Dublin, C=IE"
+        chroot . $(dirname ${java})/keytool -genkeypair -keystore foo -storepass barbar -keyalg RSA -dname "$DNAME"
+      ;;
+    esac
+  done
+
+restore: |
+  apt remove -y --purge openjdk-21-jdk-headless


### PR DESCRIPTION

# Proposed changes
Backport  openjdk-21 chisel slices


## Related issues/PRs
https://github.com/canonical/chisel-releases/pull/313
https://github.com/canonical/chisel-releases/pull/363 

### Forward porting
n/a (present in 24.04)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->