### PR TITLE
fix(openssl): copyright depends on libssl copyright - oracular

### DIFF
--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -17,15 +17,23 @@ slices:
 
   config:
     contents:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /etc/ssl/certs/:
       /etc/ssl/openssl.cnf:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /etc/ssl/private/:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /usr/lib/ssl/private:
 
   data:
     contents:
+      /etc/ssl/private/:
+      /usr/lib/ssl/private:
+      /etc/ssl/certs/:
+      /usr/lib/ssl/certs:
       /usr/lib/ssl/cert.pem:
 
   copyright:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -32,8 +32,8 @@ slices:
     contents:
       /etc/ssl/certs/:
       /etc/ssl/private/:
-      /usr/lib/ssl/certs:
       /usr/lib/ssl/cert.pem:
+      /usr/lib/ssl/certs:
       /usr/lib/ssl/private:
 
   copyright:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -29,5 +29,7 @@ slices:
       /usr/lib/ssl/cert.pem:
 
   copyright:
+    essential:
+      - libssl3t64_copyright
     contents:
       /usr/share/doc/openssl/copyright:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -30,11 +30,11 @@ slices:
 
   data:
     contents:
-      /etc/ssl/private/:
-      /usr/lib/ssl/private:
       /etc/ssl/certs/:
+      /etc/ssl/private/:
       /usr/lib/ssl/certs:
       /usr/lib/ssl/cert.pem:
+      /usr/lib/ssl/private:
 
   copyright:
     essential:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

The OpenSSL copyright is a symlink to libssl's, so this PR adds that dependency.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->