### PR TITLE
fix(openssl): copyright depends on libssl copyright - noble

### DIFF
--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -29,5 +29,7 @@ slices:
       /usr/lib/ssl/cert.pem:
 
   copyright:
+    essential:
+      - libssl3t64_copyright
     contents:
       /usr/share/doc/openssl/copyright:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -17,16 +17,24 @@ slices:
 
   config:
     contents:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /etc/ssl/certs/:
       /etc/ssl/openssl.cnf:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /etc/ssl/private/:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /usr/lib/ssl/private:
 
   data:
     contents:
+      /etc/ssl/certs/:
+      /etc/ssl/private/:
       /usr/lib/ssl/cert.pem:
+      /usr/lib/ssl/certs:
+      /usr/lib/ssl/private:
 
   copyright:
     essential:


### PR DESCRIPTION
### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
See https://github.com/canonical/chisel-releases/pull/522

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->