### PR TITLE
fix(openssl): copyright depends on libssl copyright - focal

### DIFF
--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -16,11 +16,15 @@ slices:
 
   config:
     contents:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /etc/ssl/certs/:
       /etc/ssl/openssl.cnf:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /etc/ssl/private/:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
+      # TODO: this is not a config, but data. Remove it for future releases.
       /usr/lib/ssl/private:
 
   # Use this slice with "ca-certificates_data" as OpenSSL looks at
@@ -28,7 +32,11 @@ slices:
   # Ref: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
   data:
     contents:
+      /etc/ssl/certs/:
+      /etc/ssl/private/:
       /usr/lib/ssl/cert.pem: {symlink: /etc/ssl/certs/ca-certificates.crt}
+      /usr/lib/ssl/certs:
+      /usr/lib/ssl/private:
 
   copyright:
     essential:

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -31,5 +31,7 @@ slices:
       /usr/lib/ssl/cert.pem: {symlink: /etc/ssl/certs/ca-certificates.crt}
 
   copyright:
+    essential:
+      - libssl1.1_copyright
     contents:
       /usr/share/doc/openssl/copyright:


### PR DESCRIPTION


### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
See https://github.com/canonical/chisel-releases/pull/524/files

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->