### PR TITLE
Fix: Inject correct ref for testing feature branches

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -81,8 +81,9 @@ jobs:
 
             echo "install_all=true" >> $GITHUB_OUTPUT
           else
-            # Filter the releases to only the affected branch.
-            export RELEASES=$(echo "$RELEASES" | jq '[.[] | select(.ref == "${{ github.base_ref }}")]')
+            # Filter the releases to only the affected branch, then swap the ref
+            # such that the correct branch is tested.
+            export RELEASES=$(echo "$RELEASES" | jq '[.[] | select(.ref == "${{ github.base_ref }}") | .ref = "${{ github.head_ref }}"]')
             MATRIX=$(./version-matrix)
             echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
# Included in this PR:
- When testing specific branches, swap the ref in the RELEASE JSON with the current feature branch to be merged in


This should fix the instability tests we are currently seeing.