### PR TITLE
Test: include apt update as part of lxc allocation

### DIFF
--- a/slices/liblua5.4-0.yaml
+++ b/slices/liblua5.4-0.yaml
@@ -1,0 +1,17 @@
+package: liblua5.4-0
+
+essential:
+  - liblua5.4-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/liblua5.4.so.*:
+      /usr/lib/*-linux-*/liblua5.4-c++.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/liblua5.4-0/copyright:

--- a/slices/lua5.4.yaml
+++ b/slices/lua5.4.yaml
@@ -1,0 +1,21 @@
+package: lua5.4
+
+essential:
+  - lua5.4_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libreadline8t64_libs
+    contents:
+      /usr/bin/lua:
+        symlink: /usr/bin/lua5.4
+      /usr/bin/lua5.4:
+      /usr/bin/luac:
+        symlink: /usr/bin/luac5.4
+      /usr/bin/luac5.4:
+
+  copyright:
+    contents:
+      /usr/share/doc/lua5.4/copyright:

--- a/spread.yaml
+++ b/spread.yaml
@@ -29,12 +29,21 @@ backends:
       do
         sleep 5
       done
-      lxc exec $SPREAD_SYSTEM -- systemctl enable --now ssh
-      lxc exec $SPREAD_SYSTEM -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
-      lxc exec $SPREAD_SYSTEM -- bash -c "sed -i 's/^\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/# COMMENTED OUT BY SPREAD: \0/' /etc/ssh/sshd_config.d/* || true"
-      lxc exec $SPREAD_SYSTEM -- bash -c "test -d /etc/ssh/sshd_config.d && echo -e 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread.conf"
-      lxc exec $SPREAD_SYSTEM -- bash -c "echo root:${SPREAD_SYSTEM_PASSWORD} | chpasswd"
-      lxc exec $SPREAD_SYSTEM -- killall -HUP sshd
+
+      # sudo apt update
+      lxc exec $SPREAD_SYSTEM -- bash << EOF
+
+        apt-get update
+
+        systemctl enable --now ssh
+        sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+        sed -i 's/^\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/# COMMENTED OUT BY SPREAD: \0/' /etc/ssh/sshd_config.d/* || true
+        test -d /etc/ssh/sshd_config.d && echo -e 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread.conf
+        killall -HUP sshd
+        echo root:${SPREAD_SYSTEM_PASSWORD} | chpasswd
+
+      EOF
+
       ADDRESS `lxc list --format=json $SPREAD_SYSTEM | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address'`
     discard: lxc stop $SPREAD_SYSTEM || true
     systems:

--- a/tests/spread/integration/liblua5.4-0/task.yaml
+++ b/tests/spread/integration/liblua5.4-0/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for liblua5.4-0
+
+execute: |
+  rootfs="$(install-slices liblua5.4-0_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/liblua5.4.so.0

--- a/tests/spread/integration/lua5.4/task.yaml
+++ b/tests/spread/integration/lua5.4/task.yaml
@@ -1,0 +1,6 @@
+summary: Integration tests for lua5.4
+
+execute: |
+  rootfs="$(install-slices lua5.4_bins)"
+
+  lua -e 'print("Hello, Lua!")'

--- a/tests/spread/integration/lua5.4/task.yaml
+++ b/tests/spread/integration/lua5.4/task.yaml
@@ -3,4 +3,4 @@ summary: Integration tests for lua5.4
 execute: |
   rootfs="$(install-slices lua5.4_bins)"
 
-  lua -e 'print("Hello, Lua!")'
+  chroot "${rootfs}/" lua -e 'print("Hello, Lua!")'


### PR DESCRIPTION
This is a draft PR to add an apt-update to the allocation of lxc instances with spread. This should solve the recent HTTP 404 while installing packages.