### PR TITLE
feat: dynamic runner selection

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         runner:
           - name: X64
-            runs-on: ubuntu-latest
+            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "X64", "large"]') || 'ubuntu-24.04' }}
           - name: ARM64
-            runs-on: [noble, ARM64, large]
+            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
     steps:


### PR DESCRIPTION
# Proposed changes
- Allow dynamic selection of Github runners based on repository owner. This allows forks of chisel-releases to run both AMD64 and ARM64 spread tests.

# Testing:
- Forked repo scenario: https://github.com/clay-lake/chisel-releases/actions/runs/14617501925?pr=4
- Upstream repo scenario: https://github.com/clay-lake/chisel-releases/actions/runs/14617501925/job/41071341853?pr=4
  - Note: This is "simulated" canonical environment and will fail since we cannot satisfy the canonical hosted runner labels on my fork
