### PR TITLE
Fix: Clear ref in installability matrix for pull requests

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -83,7 +83,7 @@ jobs:
           else
             # Filter the releases to only the affected branch, then swap the ref
             # such that the correct branch is tested.
-            export RELEASES=$(echo "$RELEASES" | jq '[.[] | select(.ref == "${{ github.base_ref }}") | .ref = "${{ github.head_ref }}"]')
+            export RELEASES=$(echo "$RELEASES" | jq '[.[] | select(.ref == "${{ github.base_ref }}") | .ref = ""]')
             MATRIX=$(./version-matrix)
             echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION

# Included in this PR:
- This is a correction to the prior PR #526 to enable installability test across chisel-release forks.
  Sample Execution: https://github.com/clay-lake/chisel-releases/pull/5