### PR TITLE
Fix(22.04): Include apt-get update in LXC allocation

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -29,6 +29,7 @@ backends:
       do
         sleep 5
       done
+      lxc exec $SPREAD_SYSTEM -- apt-get update
       lxc exec $SPREAD_SYSTEM -- systemctl enable --now ssh
       lxc exec $SPREAD_SYSTEM -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
       lxc exec $SPREAD_SYSTEM -- bash -c "sed -i 's/^\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/# COMMENTED OUT BY SPREAD: \0/' /etc/ssh/sshd_config.d/* || true"


### PR DESCRIPTION
## Included in this PR:
- Execute `apt-get update` on allocation of lxc instances for spread tests. This fixes errors found in integration tests while configuring the test environment.
  See: #521 and https://github.com/canonical/chisel-releases/actions/runs/14645651222/job/41113484419#step:10:193