### PR TITLE
ci(lint): do not produce warnings

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -92,13 +92,8 @@ jobs:
             echo "error:   " "$@" >&2
             EXIT_CODE=1
           }
-          warn() {
-            echo "warning: " "$@" >&2
-          }
 
           for filename in $(find slices/ | grep "\.yaml$" | sort); do
-            yq '.slices | keys | .[]' "$filename" | sort -C || \
-              warn "$filename: slice names are not sorted"
             for slice in $(yq '.slices | keys | .[]' "$filename"); do
               key="$slice" yq \
                 '.slices | with_entries(select(.key == env(key))) | .[].essential[]' \


### PR DESCRIPTION
The lint workflow currently produces a ton of warnings for slices names not being sorted. In practice, we do not abide by that rule much and it's tough to find the actual errors within the sea of warnings. This PR disables emitting those warnings.