### PR TITLE
Feat: Add plucky to CI

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -27,7 +27,8 @@ env:
       {"ref": "ubuntu-20.04", "chisel-versions": ["v1.0.0","main"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.0.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.0.0","main"]},
-      {"ref": "ubuntu-24.10", "chisel-versions": ["v1.0.0","main"]}
+      {"ref": "ubuntu-24.10", "chisel-versions": ["v1.0.0","main"]},
+      {"ref": "ubuntu-25.04", "chisel-versions": ["v1.0.0","main"]}
     ]
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   # chisel-releases branches to lint on.
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-24.10"]') }}
+  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-24.10","ubuntu-25.04"]') }}
 
 jobs:
   prepare-lint:


### PR DESCRIPTION
# Included in this PR:
- Added entries to enable CI for Plucky Puffin (ubuntu-25.04)

Note: The README.md will also have to be adjusted, but should not be done until `ubuntu-25.04` is pushed from staging.