### PR TITLE
ci: add workflow for auto-requesting reviews

### DIFF
--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -2,7 +2,7 @@ name: Triage PRs
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   add-reviewers:

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -19,5 +19,5 @@ jobs:
             /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
             -f "team_reviewers[]=${{ env.REVIEWERS }}"
 
-          # Canno use `gh pr edit`:
+          # Cannot use `gh pr edit`:
           # https://github.com/cli/cli/issues/4844

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -1,0 +1,23 @@
+name: Triage PRs
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GITHUB_TOKEN: ${{ secrets.ROCKSBOT_PR_TOKEN }}
+          REVIEWERS: "slice-reviewers-guild"
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -f "team_reviewers[]=${{ env.REVIEWERS }}"
+
+          # Canno use `gh pr edit`:
+          # https://github.com/cli/cli/issues/4844

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   add-reviewers:
+    if: github.repository_owner == 'canonical'
     runs-on: ubuntu-latest
     steps:
       - env:

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -1,7 +1,7 @@
 name: Triage PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

On every PR, this new workflow will auto-request the canonical/slice-reviewers-guild team to review it.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Test: https://github.com/cjdcordeiro-new-test/ci-playground/pull/11