### PR TITLE
Feat(25.04): Update README on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ the moment, the officially supported Chisel releases are:
 \- Noble
 - [ubuntu-24.10](https://github.com/canonical/chisel-releases/tree/ubuntu-24.10)
 \- Oracular
+- [ubuntu-25.04](https://github.com/canonical/chisel-releases/tree/ubuntu-25.04)
+\- Plucky
 
 In each release branch, you'll find a `chisel.yaml` file that defines the Chisel
 release, plus a `slices` folder with all the Slice Definitions Files (SDFs) for


### PR DESCRIPTION
# Included in this PR:
- Update the README.md in `main` to reflect new ubuntu-25.04 release. 