### PR TITLE
Feat(25.04): Revert to `canonical` CI

### DIFF
--- a/.github/workflows/ci-pr-target.yaml
+++ b/.github/workflows/ci-pr-target.yaml
@@ -11,4 +11,4 @@ on:
 jobs:
   pkg-deps:
     name: Package dependencies
-    uses: clay-lake/chisel-releases/.github/workflows/pkg-deps.yaml@main
+    uses: canonical/chisel-releases/.github/workflows/pkg-deps.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,16 +10,16 @@ jobs:
   cla-check:
     if: github.event_name == 'pull_request'
     name: CLA check
-    uses: clay-lake/chisel-releases/.github/workflows/cla-check.yaml@main
+    uses: canonical/chisel-releases/.github/workflows/cla-check.yaml@main
 
   installability-tests:
     name: Installability tests
-    uses: clay-lake/chisel-releases/.github/workflows/install-slices.yaml@main
+    uses: canonical/chisel-releases/.github/workflows/install-slices.yaml@main
 
   lint:
     name: Lint
-    uses: clay-lake/chisel-releases/.github/workflows/lint.yaml@main
+    uses: canonical/chisel-releases/.github/workflows/lint.yaml@main
 
   integration-tests:
     name: Integration tests
-    uses: clay-lake/chisel-releases/.github/workflows/spread.yaml@main
+    uses: canonical/chisel-releases/.github/workflows/spread.yaml@main


### PR DESCRIPTION
# Included in this PR:
- Revert modifications made for testing `ubuntu-25.04` on my fork back to their original state.