### PR TITLE
Add .NET 8 & 9 SDK chisel slice definitions for Ubuntu 24.10

### DIFF
--- a/slices/aspnetcore-targeting-pack-8.0.yaml
+++ b/slices/aspnetcore-targeting-pack-8.0.yaml
@@ -1,0 +1,13 @@
+package: aspnetcore-targeting-pack-8.0
+
+essential:
+  - aspnetcore-targeting-pack-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Ref/8.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/aspnetcore-targeting-pack-8.0/copyright:

--- a/slices/aspnetcore-targeting-pack-9.0.yaml
+++ b/slices/aspnetcore-targeting-pack-9.0.yaml
@@ -1,0 +1,13 @@
+package: aspnetcore-targeting-pack-9.0
+
+essential:
+  - aspnetcore-targeting-pack-9.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Ref/9.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/aspnetcore-targeting-pack-9.0/copyright:

--- a/slices/dotnet-apphost-pack-8.0.yaml
+++ b/slices/dotnet-apphost-pack-8.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-apphost-pack-8.0
+
+essential:
+  - dotnet-apphost-pack-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Host.*/8.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-apphost-pack-8.0/copyright:

--- a/slices/dotnet-apphost-pack-9.0.yaml
+++ b/slices/dotnet-apphost-pack-9.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-apphost-pack-9.0
+
+essential:
+  - dotnet-apphost-pack-9.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Host.*/9.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-apphost-pack-9.0/copyright:

--- a/slices/dotnet-sdk-8.0.yaml
+++ b/slices/dotnet-sdk-8.0.yaml
@@ -1,0 +1,26 @@
+package: dotnet-sdk-8.0
+
+essential:
+  - dotnet-sdk-8.0_copyright
+
+slices:
+  libs:
+    essential:
+      - aspnetcore-runtime-8.0_libs
+      - aspnetcore-targeting-pack-8.0_libs
+      - dotnet-apphost-pack-8.0_libs
+      - dotnet-runtime-8.0_libs
+      - dotnet-targeting-pack-8.0_libs
+      - dotnet-templates-8.0_libs
+      - netstandard-targeting-pack-2.1-9.0_libs
+    contents:
+      /usr/lib/dotnet/sdk/8.0*/**:
+      /usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Runtime.*/8.0*/**:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Runtime.*/8.0*/**:
+      /usr/lib/dotnet/sdk-manifests/8.0.100/microsoft.net.sdk.aspire/8.0.0-preview.*/**:
+      /usr/lib/dotnet/sdk-manifests/8.0.100/microsoft.net.workload.*/**:
+      /usr/lib/dotnet/metadata/workloads/8.0.100/userlocal:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-sdk-8.0/copyright:

--- a/slices/dotnet-sdk-9.0.yaml
+++ b/slices/dotnet-sdk-9.0.yaml
@@ -1,0 +1,29 @@
+package: dotnet-sdk-9.0
+
+essential:
+  - dotnet-sdk-9.0_copyright
+
+slices:
+  libs:
+    essential:
+      - aspnetcore-runtime-9.0_libs
+      - aspnetcore-targeting-pack-9.0_libs
+      - dotnet-apphost-pack-9.0_libs
+      - dotnet-runtime-9.0_libs
+      - dotnet-targeting-pack-9.0_libs
+      - dotnet-templates-9.0_libs
+      - netstandard-targeting-pack-2.1-9.0_libs
+      - dotnet-sdk-aot-9.0_libs
+    contents:
+      /usr/lib/dotnet/sdk/9.0*/**:
+      /usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Runtime.*/9.0*/**:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Runtime.*/9.0*/**:
+      /usr/lib/dotnet/library-packs/Microsoft.DotNet.ILCompiler.9.0.4.nupkg:
+      /usr/lib/dotnet/library-packs/Microsoft.NET.ILLink.Tasks.9.0.4.nupkg:
+      /usr/lib/dotnet/metadata/workloads/9.0.100/userlocal:
+      /usr/lib/dotnet/sdk-manifests/8.0.100/microsoft.net.sdk.aspire/8.2.2/**:
+      /usr/lib/dotnet/sdk-manifests/9.0.100/microsoft.net.workload.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-sdk-9.0/copyright:

--- a/slices/dotnet-sdk-aot-9.0.yaml
+++ b/slices/dotnet-sdk-aot-9.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-sdk-aot-9.0
+
+essential:
+  - dotnet-templates-9.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/runtime.*.Microsoft.DotNet.ILCompiler/9.0.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-sdk-aot-9.0/copyright:

--- a/slices/dotnet-targeting-pack-8.0.yaml
+++ b/slices/dotnet-targeting-pack-8.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-targeting-pack-8.0
+
+essential:
+  - dotnet-targeting-pack-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/8.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-targeting-pack-8.0/copyright:

--- a/slices/dotnet-targeting-pack-9.0.yaml
+++ b/slices/dotnet-targeting-pack-9.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-targeting-pack-9.0
+
+essential:
+  - dotnet-targeting-pack-9.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/9.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-targeting-pack-9.0/copyright:

--- a/slices/dotnet-templates-8.0.yaml
+++ b/slices/dotnet-templates-8.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-templates-8.0
+
+essential:
+  - dotnet-templates-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/templates/8.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-templates-8.0/copyright:

--- a/slices/dotnet-templates-9.0.yaml
+++ b/slices/dotnet-templates-9.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-templates-9.0
+
+essential:
+  - dotnet-templates-9.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/templates/9.0*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-templates-9.0/copyright:

--- a/slices/netstandard-targeting-pack-2.1-9.0.yaml
+++ b/slices/netstandard-targeting-pack-2.1-9.0.yaml
@@ -1,0 +1,13 @@
+package: netstandard-targeting-pack-2.1-9.0
+
+essential:
+  - netstandard-targeting-pack-2.1-9.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/NETStandard.Library.Ref/2.1.0/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/netstandard-targeting-pack-2.1-9.0/copyright:

--- a/tests/spread/integration/aspnetcore-runtime-8.0/task.yaml
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/task.yaml
@@ -1,0 +1,38 @@
+summary: Integration tests for ASP.NET 8 Runtime
+
+execute: |
+  # install slices
+  rootfs="$(install-slices aspnetcore-runtime-8.0_libs base-files_base)"
+
+  # preparing the test data
+  apt update && apt install -y dotnet-sdk-8.0
+  cp -r web_helloworld "${rootfs}"/web_helloworld
+  dotnet publish "${rootfs}"/web_helloworld/Hello.csproj --no-self-contained
+
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+  mkdir -p "${rootfs}"/dev
+  head -c 500 /dev/urandom > "${rootfs}"/dev/random
+  head -c 500 /dev/urandom > "${rootfs}"/dev/urandom
+
+  # test the helloworld web app
+  chroot "${rootfs}" dotnet /web_helloworld/bin/Release/net8.0/Hello.dll --urls="http://0.0.0.0:5108" &
+  app_pid=$!
+
+  # Wait for the web app to start
+  while ! fuser 5108/tcp > /dev/null 2>&1; do
+    if ! test -d /proc/$app_pid; then
+      echo "dotnet exited quickly"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  # Send a request to the web app and verify the result
+  ret=0
+  curl http://localhost:5108/ | grep "Hello World!" || ret=1
+
+
+  # Cleanup
+  kill $app_pid
+  exit $ret

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Hello.csproj
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Hello.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Program.cs
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Properties/launchSettings.json
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+    "iisSettings": {
+        "windowsAuthentication": false,
+        "anonymousAuthentication": true,
+        "iisExpress": {
+            "applicationUrl": "http://localhost:65090",
+            "sslPort": 44311
+        }
+    },
+    "profiles": {
+        "Hello": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "https://localhost:7158;http://localhost:5108",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        "IIS Express": {
+            "commandName": "IISExpress",
+            "launchBrowser": true,
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
+    }
+}

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.Development.json
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    }
+}

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.json
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*"
+}

--- a/tests/spread/integration/dotnet-host-8.0/task.yaml
+++ b/tests/spread/integration/dotnet-host-8.0/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for .NET 8 Host 
+
+execute: |
+  # install slices
+  rootfs="$(install-slices dotnet-host-8.0_bins dotnet-hostfxr-8.0_libs base-files_base)"
+  
+  # smoking test the .NET host
+  chroot "${rootfs}" /usr/bin/dotnet --info

--- a/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Hello.csproj
+++ b/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Hello.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Program.cs
+++ b/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Hello, World!");

--- a/tests/spread/integration/dotnet-runtime-8.0/task.yaml
+++ b/tests/spread/integration/dotnet-runtime-8.0/task.yaml
@@ -1,0 +1,16 @@
+summary: Integration tests for .NET 8 Runtime 
+
+execute: |
+  # install slices
+  rootfs="$(install-slices dotnet-runtime-8.0_libs base-files_base)"
+
+  # preparing the test data
+  apt update && apt install -y dotnet-sdk-8.0
+  cp -r app_helloworld "${rootfs}"/app_helloworld
+  dotnet publish "${rootfs}"/app_helloworld/Hello.csproj --no-self-contained
+
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+
+  # test the helloworld app
+  chroot "${rootfs}" dotnet /app_helloworld/bin/Release/net8.0/Hello.dll

--- a/tests/spread/integration/dotnet-sdk-8.0/NuGet.Config
+++ b/tests/spread/integration/dotnet-sdk-8.0/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+    </packageSources>
+</configuration>

--- a/tests/spread/integration/dotnet-sdk-8.0/helloworld.fsx
+++ b/tests/spread/integration/dotnet-sdk-8.0/helloworld.fsx
@@ -1,0 +1,1 @@
+printfn "Hello from F#"

--- a/tests/spread/integration/dotnet-sdk-8.0/task.yaml
+++ b/tests/spread/integration/dotnet-sdk-8.0/task.yaml
@@ -1,0 +1,51 @@
+summary: Integration tests for .NET 8 SDK 
+
+execute: |
+  # install slices
+  rootfs="$(install-slices dotnet-sdk-8.0_libs base-files_base)"
+  
+  # needed by the SDK to determine system information
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+  
+  # needed by crypto libraries e.g. to generate a GUID's
+  mkdir -p "${rootfs}"/dev
+  head -c 500 /dev/urandom > "${rootfs}"/dev/random
+  head -c 500 /dev/urandom > "${rootfs}"/dev/urandom
+
+  # smoke test the .NET host:
+  chroot "${rootfs}" /usr/bin/dotnet --info
+
+  # smoke test the F# interpreter:
+  cp helloworld.fsx "${rootfs}"/helloworld.fsx
+  chroot "${rootfs}" /usr/bin/dotnet fsi /helloworld.fsx
+
+  # When building a .NET application MSBuild is used.
+  # MSBuild tries to read the username (see: https://github.com/dotnet/dotnet/blob/85778473549347b3e4bad3ea009e9438df7b11bb/src/msbuild/src/Shared/TempFileUtilities.cs#L44).
+  # On Unix systems (including Ubuntu) the implementation tries to read the username from /etc/passwd (see: https://github.com/dotnet/dotnet/blob/85778473549347b3e4bad3ea009e9438df7b11bb/src/runtime/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs#L27).
+  cp /etc/passwd "${rootfs}"/etc/passwd
+
+  # Disable noisy help text for users who run .NET for the first time.
+  export DOTNET_NOLOGO=true
+  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+
+  # The .NET SDK creates config files in the users home directory.
+  export HOME=/root
+  mkdir -p "${rootfs}${HOME}"
+
+  # Set the user config to not use nuget.org, because sometimes dotnet restore is
+  # flaky and hangs indefinitely. Also, we do not need depenencies from the internet.
+  mkdir -p "${rootfs}${HOME}/.nuget/NuGet"
+  cp NuGet.Config "${rootfs}${HOME}/.nuget/NuGet/NuGet.Config"
+
+  # Create a C# Hello World .NET app from templates
+  # Using --no-restore flag, because dotnet new hangs indefinitely at restoring (related to: https://github.com/dotnet/core/issues/8057)
+  chroot "${rootfs}" /usr/bin/dotnet new console --output /app_helloworld --no-restore
+
+  # Build the C# Hello World .NET app
+  chroot "${rootfs}" /usr/bin/dotnet restore /app_helloworld/app_helloworld.csproj
+  chroot "${rootfs}" /usr/bin/dotnet build /app_helloworld/app_helloworld.csproj --configuration Release --no-restore
+  chroot "${rootfs}" /usr/bin/dotnet publish /app_helloworld/app_helloworld.csproj --no-restore --no-build
+  
+  # Run the C# Hello World .NET app
+  chroot "${rootfs}" /usr/bin/dotnet /app_helloworld/bin/Release/net8.0/publish/app_helloworld.dll

--- a/tests/spread/integration/dotnet-sdk-9.0/NuGet.Config
+++ b/tests/spread/integration/dotnet-sdk-9.0/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+    </packageSources>
+</configuration>

--- a/tests/spread/integration/dotnet-sdk-9.0/helloworld.fsx
+++ b/tests/spread/integration/dotnet-sdk-9.0/helloworld.fsx
@@ -1,0 +1,1 @@
+printfn "Hello from F#"

--- a/tests/spread/integration/dotnet-sdk-9.0/task.yaml
+++ b/tests/spread/integration/dotnet-sdk-9.0/task.yaml
@@ -1,0 +1,53 @@
+summary: Integration tests for .NET 9 SDK 
+
+execute: |
+  # install slices
+  rootfs="$(install-slices dotnet-sdk-9.0_libs base-files_base)"
+  mv "${rootfs}"/usr/lib/dotnet/dotnet9 "${rootfs}"/usr/lib/dotnet/dotnet
+  ln -s ../lib/dotnet/dotnet "${rootfs}"/usr/bin/dotnet
+  
+  # needed by the SDK to determine system information
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+  
+  # needed by crypto libraries e.g. to generate a GUID's
+  mkdir -p "${rootfs}"/dev
+  head -c 500 /dev/urandom > "${rootfs}"/dev/random
+  head -c 500 /dev/urandom > "${rootfs}"/dev/urandom
+
+  # smoke test the .NET host:
+  chroot "${rootfs}" /usr/bin/dotnet --info
+
+  # smoke test the F# interpreter:
+  cp helloworld.fsx "${rootfs}"/helloworld.fsx
+  chroot "${rootfs}" /usr/bin/dotnet fsi /helloworld.fsx
+
+  # When building a .NET application MSBuild is used.
+  # MSBuild tries to read the username (see: https://github.com/dotnet/dotnet/blob/85778473549347b3e4bad3ea009e9438df7b11bb/src/msbuild/src/Shared/TempFileUtilities.cs#L44).
+  # On Unix systems (including Ubuntu) the implementation tries to read the username from /etc/passwd (see: https://github.com/dotnet/dotnet/blob/85778473549347b3e4bad3ea009e9438df7b11bb/src/runtime/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs#L27).
+  cp /etc/passwd "${rootfs}"/etc/passwd
+
+  # Disable noisy help text for users who run .NET for the first time.
+  export DOTNET_NOLOGO=true
+  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+
+  # The .NET SDK creates config files in the users home directory.
+  export HOME=/root
+  mkdir -p "${rootfs}${HOME}"
+
+  # Set the user config to not use nuget.org, because sometimes dotnet restore is
+  # flaky and hangs indefinitely. Also, we do not need depenencies from the internet.
+  mkdir -p "${rootfs}${HOME}/.nuget/NuGet"
+  cp NuGet.Config "${rootfs}${HOME}/.nuget/NuGet/NuGet.Config"
+
+  # Create a C# Hello World .NET app from templates
+  # Using --no-restore flag, because dotnet new hangs indefinitely at restoring (related to: https://github.com/dotnet/core/issues/8057)
+  chroot "${rootfs}" /usr/bin/dotnet new console --output /app_helloworld --no-restore
+
+  # Build the C# Hello World .NET app
+  chroot "${rootfs}" /usr/bin/dotnet restore /app_helloworld/app_helloworld.csproj
+  chroot "${rootfs}" /usr/bin/dotnet build /app_helloworld/app_helloworld.csproj --configuration Release --no-restore
+  chroot "${rootfs}" /usr/bin/dotnet publish /app_helloworld/app_helloworld.csproj --no-restore --no-build
+  
+  # Run the C# Hello World .NET app
+  chroot "${rootfs}" /usr/bin/dotnet /app_helloworld/bin/Release/net9.0/publish/app_helloworld.dll


### PR DESCRIPTION
# Proposed changes

Add .NET 8 & 9 SDK chisel slice definitions for Ubuntu 24.10.

## Related issues/PRs

N/A

### Forward porting

- #561 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Needed to create .NET SDK chiseled container images.