### PR TITLE
feat(25.04): systemd portforward

### DIFF
--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -1,0 +1,692 @@
+package: systemd
+
+essential:
+  - systemd_copyright
+
+slices:
+  bins:
+    essential:
+      - libacl1_libs
+      - libapparmor1_libs
+      - libaudit1_libs
+      - libblkid1_libs
+      - libc6_libs
+      - libcap2_libs
+      - libcryptsetup12_libs
+      - libfdisk1_libs
+      - libgcrypt20_libs
+      - libkmod2_libs
+      - liblz4-1_libs
+      - liblzma5_libs
+      - libmount1_libs
+      - libpam0g_libs
+      - libseccomp2_libs
+      - libselinux1_libs
+      - libssl3t64_libs
+      - libsystemd-shared_libs
+      - libsystemd0_libs
+      - libzstd1_libs
+      - mount_bins
+      - systemd_catalog
+      - systemd_config
+      - systemd_kernel-parameters
+      - systemd_libs
+      - systemd_network
+      - systemd_pcrlock
+      - systemd_repart
+      - systemd_system-generators
+      - systemd_system-services
+      - systemd_user-services
+    contents:
+      /usr/bin/busctl:
+      /usr/bin/hostnamectl:
+      /usr/bin/journalctl:
+      /usr/bin/kernel-install:
+      /usr/bin/localectl:
+      /usr/bin/loginctl:
+      /usr/bin/networkctl:
+      /usr/bin/systemctl:
+      /usr/bin/systemd:
+      /usr/bin/systemd-ac-power:
+      /usr/bin/systemd-analyze:
+      /usr/bin/systemd-ask-password:
+      /usr/bin/systemd-cat:
+      /usr/bin/systemd-cgls:
+      /usr/bin/systemd-cgtop:
+      /usr/bin/systemd-confext:
+      /usr/bin/systemd-creds:
+      /usr/bin/systemd-cryptenroll:
+      /usr/bin/systemd-cryptsetup:
+      /usr/bin/systemd-delta:
+      /usr/bin/systemd-detect-virt:
+      /usr/bin/systemd-escape:
+      /usr/bin/systemd-firstboot:
+      /usr/bin/systemd-id128:
+      /usr/bin/systemd-inhibit:
+      /usr/bin/systemd-machine-id-setup:
+      /usr/bin/systemd-mount:
+      /usr/bin/systemd-notify:
+      /usr/bin/systemd-path:
+      /usr/bin/systemd-repart:
+      /usr/bin/systemd-run:
+      /usr/bin/systemd-socket-activate:
+      /usr/bin/systemd-stdio-bridge:
+      /usr/bin/systemd-sysext:
+      /usr/bin/systemd-sysusers:
+      /usr/bin/systemd-tmpfiles:
+      /usr/bin/systemd-tty-ask-password-agent:
+      /usr/bin/systemd-umount:
+      /usr/bin/timedatectl:
+      /usr/bin/varlinkctl:
+      /usr/lib/lsb/init-functions.d/40-systemd:
+      /usr/lib/systemd/systemd:
+      /usr/lib/systemd/systemd-backlight:
+      /usr/lib/systemd/systemd-battery-check:
+      /usr/lib/systemd/systemd-binfmt:
+      /usr/lib/systemd/systemd-boot-check-no-failures:
+      /usr/lib/systemd/systemd-bsod:
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
+      /usr/lib/systemd/systemd-cgroups-agent:
+      /usr/lib/systemd/systemd-cryptsetup:
+      /usr/lib/systemd/systemd-executor:
+      /usr/lib/systemd/systemd-fsck:
+      /usr/lib/systemd/systemd-fsckd:
+      /usr/lib/systemd/systemd-growfs:
+      /usr/lib/systemd/systemd-hibernate-resume:
+      /usr/lib/systemd/systemd-hostnamed:
+      /usr/lib/systemd/systemd-initctl:
+      /usr/lib/systemd/systemd-integritysetup:
+      /usr/lib/systemd/systemd-journald:
+      /usr/lib/systemd/systemd-localed:
+      /usr/lib/systemd/systemd-logind:
+      /usr/lib/systemd/systemd-makefs:
+      /usr/lib/systemd/systemd-measure: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-modules-load:
+      /usr/lib/systemd/systemd-network-generator:
+      /usr/lib/systemd/systemd-networkd:
+      /usr/lib/systemd/systemd-networkd-wait-online:
+      /usr/lib/systemd/systemd-pcrextend: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-pcrlock: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-pstore:
+      /usr/lib/systemd/systemd-quotacheck:
+      /usr/lib/systemd/systemd-random-seed:
+      /usr/lib/systemd/systemd-remount-fs:
+      /usr/lib/systemd/systemd-reply-password:
+      /usr/lib/systemd/systemd-rfkill:
+      /usr/lib/systemd/systemd-shutdown:
+      /usr/lib/systemd/systemd-sleep:
+      /usr/lib/systemd/systemd-socket-proxyd:
+      /usr/lib/systemd/systemd-storagetm:
+      /usr/lib/systemd/systemd-sulogin-shell:
+      /usr/lib/systemd/systemd-sysctl:
+      /usr/lib/systemd/systemd-sysroot-fstab-check:
+      /usr/lib/systemd/systemd-sysupdate:
+      /usr/lib/systemd/systemd-sysv-install:
+      /usr/lib/systemd/systemd-time-wait-sync:
+      /usr/lib/systemd/systemd-timedated:
+      /usr/lib/systemd/systemd-tpm2-setup: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-update-done:
+      /usr/lib/systemd/systemd-update-utmp:
+      /usr/lib/systemd/systemd-user-runtime-dir:
+      /usr/lib/systemd/systemd-user-sessions:
+      /usr/lib/systemd/systemd-veritysetup:
+      /usr/lib/systemd/systemd-volatile-root:
+      /usr/lib/systemd/systemd-xdg-autostart-condition:
+
+  catalog:
+    contents:
+      /usr/lib/systemd/catalog/systemd.be.catalog:
+      /usr/lib/systemd/catalog/systemd.be@latin.catalog:
+      /usr/lib/systemd/catalog/systemd.bg.catalog:
+      /usr/lib/systemd/catalog/systemd.catalog:
+      /usr/lib/systemd/catalog/systemd.da.catalog:
+      /usr/lib/systemd/catalog/systemd.de.catalog:
+      /usr/lib/systemd/catalog/systemd.fr.catalog:
+      /usr/lib/systemd/catalog/systemd.hr.catalog:
+      /usr/lib/systemd/catalog/systemd.hu.catalog:
+      /usr/lib/systemd/catalog/systemd.it.catalog:
+      /usr/lib/systemd/catalog/systemd.ko.catalog:
+      /usr/lib/systemd/catalog/systemd.pl.catalog:
+      /usr/lib/systemd/catalog/systemd.pt_BR.catalog:
+      /usr/lib/systemd/catalog/systemd.ru.catalog:
+      /usr/lib/systemd/catalog/systemd.sr.catalog:
+      /usr/lib/systemd/catalog/systemd.zh_CN.catalog:
+      /usr/lib/systemd/catalog/systemd.zh_TW.catalog:
+
+  config:
+    essential:
+      - systemd_modprobe-config
+      - systemd_pam-profile
+      - systemd_sysusers-config
+      - systemd_tmpfiles-config
+    contents:
+      /etc/systemd/journald.conf:
+      /etc/systemd/logind.conf:
+      /etc/systemd/networkd.conf:
+      /etc/systemd/pstore.conf:
+      /etc/systemd/sleep.conf:
+      /etc/systemd/system.conf:
+      /etc/systemd/user.conf:
+      /etc/xdg/systemd/user:
+      /usr/lib/environment.d/99-environment.conf:
+      /usr/lib/systemd/journald.conf.d/syslog.conf:
+      /usr/lib/systemd/resolv.conf:
+      /var/log/journal/: {make: true}
+
+  network:
+    contents:
+      /usr/lib/systemd/network/80-6rd-tunnel.network:
+      /usr/lib/systemd/network/80-container-host0.network:
+      /usr/lib/systemd/network/80-container-vb.network:
+      /usr/lib/systemd/network/80-container-ve.network:
+      /usr/lib/systemd/network/80-container-vz.network:
+      /usr/lib/systemd/network/80-vm-vt.network:
+      /usr/lib/systemd/network/80-wifi-adhoc.network:
+
+  repart:
+    contents:
+      /usr/lib/systemd/repart/definitions/confext.repart.d/10-root.conf:
+      /usr/lib/systemd/repart/definitions/confext.repart.d/20-root-verity.conf:
+      /usr/lib/systemd/repart/definitions/confext.repart.d/30-root-verity-sig.conf:
+      /usr/lib/systemd/repart/definitions/portable.repart.d/10-root.conf:
+      /usr/lib/systemd/repart/definitions/portable.repart.d/20-root-verity.conf:
+      /usr/lib/systemd/repart/definitions/portable.repart.d/30-root-verity-sig.conf:
+      /usr/lib/systemd/repart/definitions/sysext.repart.d/10-root.conf:
+      /usr/lib/systemd/repart/definitions/sysext.repart.d/20-root-verity.conf:
+      /usr/lib/systemd/repart/definitions/sysext.repart.d/30-root-verity-sig.conf:
+      /usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-repart.service:
+      /usr/lib/systemd/system/systemd-repart.service:
+
+  system-generators:
+    contents:
+      /etc/systemd/system-generators/systemd-gpt-auto-generator:
+      /usr/lib/systemd/system-generators/systemd-cryptsetup-generator:
+      /usr/lib/systemd/system-generators/systemd-debug-generator:
+      /usr/lib/systemd/system-generators/systemd-fstab-generator:
+      /usr/lib/systemd/system-generators/systemd-getty-generator:
+      /usr/lib/systemd/system-generators/systemd-gpt-auto-generator:
+      /usr/lib/systemd/system-generators/systemd-hibernate-resume-generator:
+      /usr/lib/systemd/system-generators/systemd-integritysetup-generator:
+      /usr/lib/systemd/system-generators/systemd-rc-local-generator:
+      /usr/lib/systemd/system-generators/systemd-run-generator:
+      /usr/lib/systemd/system-generators/systemd-system-update-generator:
+      /usr/lib/systemd/system-generators/systemd-sysv-generator:
+      /usr/lib/systemd/system-generators/systemd-veritysetup-generator:
+
+  system-services:
+    essential:
+      - systemd_generated-services
+    contents:
+      /usr/lib/systemd/system-preset/90-systemd.preset:
+      /usr/lib/systemd/system/autovt@.service:
+      /usr/lib/systemd/system/basic.target:
+      /usr/lib/systemd/system/blockdev@.target:
+      /usr/lib/systemd/system/bluetooth.target:
+      /usr/lib/systemd/system/boot-complete.target:
+      /usr/lib/systemd/system/console-getty.service:
+      /usr/lib/systemd/system/container-getty@.service:
+      /usr/lib/systemd/system/cryptdisks-early.service:
+      /usr/lib/systemd/system/cryptdisks.service:
+      /usr/lib/systemd/system/cryptsetup-pre.target:
+      /usr/lib/systemd/system/cryptsetup.target:
+      /usr/lib/systemd/system/ctrl-alt-del.target:
+      /usr/lib/systemd/system/dbus-org.freedesktop.hostname1.service:
+      /usr/lib/systemd/system/dbus-org.freedesktop.locale1.service:
+      /usr/lib/systemd/system/dbus-org.freedesktop.login1.service:
+      /usr/lib/systemd/system/dbus-org.freedesktop.timedate1.service:
+      /usr/lib/systemd/system/debug-shell.service:
+      /usr/lib/systemd/system/default.target:
+      /usr/lib/systemd/system/dev-hugepages.mount:
+      /usr/lib/systemd/system/dev-mqueue.mount:
+      /usr/lib/systemd/system/emergency.service:
+      /usr/lib/systemd/system/emergency.target:
+      /usr/lib/systemd/system/exit.target:
+      /usr/lib/systemd/system/factory-reset.target:
+      /usr/lib/systemd/system/final.target:
+      /usr/lib/systemd/system/first-boot-complete.target:
+      /usr/lib/systemd/system/getty-pre.target:
+      /usr/lib/systemd/system/getty-static.service:
+      /usr/lib/systemd/system/getty.target:
+      /usr/lib/systemd/system/getty.target.wants/getty-static.service:
+      /usr/lib/systemd/system/getty@.service:
+      /usr/lib/systemd/system/graphical.target:
+      /usr/lib/systemd/system/graphical.target.wants/systemd-update-utmp-runlevel.service:
+      /usr/lib/systemd/system/halt.target:
+      /usr/lib/systemd/system/hibernate.target:
+      /usr/lib/systemd/system/hwclock.service:
+      /usr/lib/systemd/system/hybrid-sleep.target:
+      /usr/lib/systemd/system/initrd-cleanup.service:
+      /usr/lib/systemd/system/initrd-fs.target:
+      /usr/lib/systemd/system/initrd-parse-etc.service:
+      /usr/lib/systemd/system/initrd-root-device.target:
+      /usr/lib/systemd/system/initrd-root-device.target.wants/remote-cryptsetup.target:
+      /usr/lib/systemd/system/initrd-root-device.target.wants/remote-veritysetup.target:
+      /usr/lib/systemd/system/initrd-root-fs.target:
+      /usr/lib/systemd/system/initrd-switch-root.service:
+      /usr/lib/systemd/system/initrd-switch-root.target:
+      /usr/lib/systemd/system/initrd-udevadm-cleanup-db.service:
+      /usr/lib/systemd/system/initrd-usr-fs.target:
+      /usr/lib/systemd/system/initrd.target:
+      /usr/lib/systemd/system/initrd.target.wants/systemd-battery-check.service:
+      /usr/lib/systemd/system/initrd.target.wants/systemd-bsod.service:
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
+      /usr/lib/systemd/system/initrd.target.wants/systemd-pcrphase-initrd.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/integritysetup-pre.target:
+      /usr/lib/systemd/system/integritysetup.target:
+      /usr/lib/systemd/system/kexec.target:
+      /usr/lib/systemd/system/kmod-static-nodes.service:
+      /usr/lib/systemd/system/kmod.service:
+      /usr/lib/systemd/system/ldconfig.service:
+      /usr/lib/systemd/system/local-fs-pre.target:
+      /usr/lib/systemd/system/local-fs.target:
+      /usr/lib/systemd/system/machine.slice:
+      /usr/lib/systemd/system/modprobe@.service:
+      /usr/lib/systemd/system/multi-user.target:
+      /usr/lib/systemd/system/multi-user.target.wants/getty.target:
+      /usr/lib/systemd/system/multi-user.target.wants/systemd-ask-password-wall.path:
+      /usr/lib/systemd/system/multi-user.target.wants/systemd-logind.service:
+      /usr/lib/systemd/system/multi-user.target.wants/systemd-update-utmp-runlevel.service:
+      /usr/lib/systemd/system/multi-user.target.wants/systemd-user-sessions.service:
+      /usr/lib/systemd/system/network-online.target:
+      /usr/lib/systemd/system/network-pre.target:
+      /usr/lib/systemd/system/network.target:
+      /usr/lib/systemd/system/nss-lookup.target:
+      /usr/lib/systemd/system/nss-user-lookup.target:
+      /usr/lib/systemd/system/paths.target:
+      /usr/lib/systemd/system/poweroff.target:
+      /usr/lib/systemd/system/printer.target:
+      /usr/lib/systemd/system/proc-sys-fs-binfmt_misc.automount:
+      /usr/lib/systemd/system/proc-sys-fs-binfmt_misc.mount:
+      /usr/lib/systemd/system/procps.service:
+      /usr/lib/systemd/system/quotaon.service:
+      /usr/lib/systemd/system/rc-local.service:
+      /usr/lib/systemd/system/rc-local.service.d/debian.conf:
+      /usr/lib/systemd/system/reboot.target:
+      /usr/lib/systemd/system/remote-cryptsetup.target:
+      /usr/lib/systemd/system/remote-fs-pre.target:
+      /usr/lib/systemd/system/remote-fs.target:
+      /usr/lib/systemd/system/remote-veritysetup.target:
+      /usr/lib/systemd/system/rescue.service:
+      /usr/lib/systemd/system/rescue.target:
+      /usr/lib/systemd/system/rescue.target.wants/systemd-update-utmp-runlevel.service:
+      /usr/lib/systemd/system/rpcbind.target:
+      /usr/lib/systemd/system/runlevel0.target:
+      /usr/lib/systemd/system/runlevel1.target:
+      /usr/lib/systemd/system/runlevel2.target:
+      /usr/lib/systemd/system/runlevel3.target:
+      /usr/lib/systemd/system/runlevel4.target:
+      /usr/lib/systemd/system/runlevel5.target:
+      /usr/lib/systemd/system/runlevel6.target:
+      /usr/lib/systemd/system/serial-getty@.service:
+      /usr/lib/systemd/system/shutdown.target:
+      /usr/lib/systemd/system/sigpwr.target:
+      /usr/lib/systemd/system/sleep.target:
+      /usr/lib/systemd/system/slices.target:
+      /usr/lib/systemd/system/smartcard.target:
+      /usr/lib/systemd/system/sockets.target:
+      /usr/lib/systemd/system/sockets.target.wants/systemd-initctl.socket:
+      /usr/lib/systemd/system/sockets.target.wants/systemd-journald-dev-log.socket:
+      /usr/lib/systemd/system/sockets.target.wants/systemd-journald.socket:
+      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sockets.target.wants/systemd-sysext.socket:
+      /usr/lib/systemd/system/soft-reboot.target:
+      /usr/lib/systemd/system/sound.target:
+      /usr/lib/systemd/system/storage-target-mode.target:
+      /usr/lib/systemd/system/suspend-then-hibernate.target:
+      /usr/lib/systemd/system/suspend.target:
+      /usr/lib/systemd/system/swap.target:
+      /usr/lib/systemd/system/sys-fs-fuse-connections.mount:
+      /usr/lib/systemd/system/sys-kernel-config.mount:
+      /usr/lib/systemd/system/sys-kernel-debug.mount:
+      /usr/lib/systemd/system/sys-kernel-tracing.mount:
+      /usr/lib/systemd/system/sysinit.target:
+      /usr/lib/systemd/system/sysinit.target.wants/cryptsetup.target:
+      /usr/lib/systemd/system/sysinit.target.wants/dev-hugepages.mount:
+      /usr/lib/systemd/system/sysinit.target.wants/dev-mqueue.mount:
+      /usr/lib/systemd/system/sysinit.target.wants/integritysetup.target:
+      /usr/lib/systemd/system/sysinit.target.wants/kmod-static-nodes.service:
+      /usr/lib/systemd/system/sysinit.target.wants/ldconfig.service:
+      /usr/lib/systemd/system/sysinit.target.wants/proc-sys-fs-binfmt_misc.automount:
+      /usr/lib/systemd/system/sysinit.target.wants/sys-fs-fuse-connections.mount:
+      /usr/lib/systemd/system/sysinit.target.wants/sys-kernel-config.mount:
+      /usr/lib/systemd/system/sysinit.target.wants/sys-kernel-debug.mount:
+      /usr/lib/systemd/system/sysinit.target.wants/sys-kernel-tracing.mount:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-ask-password-console.path:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-binfmt.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-journal-catalog-update.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-journal-flush.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-journald.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-machine-id-commit.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-modules-load.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrmachine.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase-sysinit.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-random-seed.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-sysctl.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-sysusers.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup-early.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-update-done.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-update-utmp.service:
+      /usr/lib/systemd/system/sysinit.target.wants/veritysetup.target:
+      /usr/lib/systemd/system/syslog.socket:
+      /usr/lib/systemd/system/system-systemd\x2dcryptsetup.slice:
+      /usr/lib/systemd/system/system-systemd\x2dveritysetup.slice:
+      /usr/lib/systemd/system/system-update-cleanup.service:
+      /usr/lib/systemd/system/system-update-pre.target:
+      /usr/lib/systemd/system/system-update.target:
+      /usr/lib/systemd/system/systemd-ask-password-console.path:
+      /usr/lib/systemd/system/systemd-ask-password-console.service:
+      /usr/lib/systemd/system/systemd-ask-password-wall.path:
+      /usr/lib/systemd/system/systemd-ask-password-wall.service:
+      /usr/lib/systemd/system/systemd-backlight@.service:
+      /usr/lib/systemd/system/systemd-battery-check.service:
+      /usr/lib/systemd/system/systemd-binfmt.service:
+      /usr/lib/systemd/system/systemd-boot-check-no-failures.service:
+      /usr/lib/systemd/system/systemd-bsod.service:
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
+      /usr/lib/systemd/system/systemd-confext.service:
+      /usr/lib/systemd/system/systemd-exit.service:
+      /usr/lib/systemd/system/systemd-firstboot.service:
+      /usr/lib/systemd/system/systemd-fsck-root.service:
+      /usr/lib/systemd/system/systemd-fsck@.service:
+      /usr/lib/systemd/system/systemd-fsckd.service:
+      /usr/lib/systemd/system/systemd-fsckd.socket:
+      /usr/lib/systemd/system/systemd-growfs-root.service:
+      /usr/lib/systemd/system/systemd-growfs@.service:
+      /usr/lib/systemd/system/systemd-halt.service:
+      /usr/lib/systemd/system/systemd-hibernate-resume.service:
+      /usr/lib/systemd/system/systemd-hibernate.service:
+      /usr/lib/systemd/system/systemd-hostnamed.service:
+      /usr/lib/systemd/system/systemd-hybrid-sleep.service:
+      /usr/lib/systemd/system/systemd-initctl.service:
+      /usr/lib/systemd/system/systemd-initctl.socket:
+      /usr/lib/systemd/system/systemd-journal-catalog-update.service:
+      /usr/lib/systemd/system/systemd-journal-flush.service:
+      /usr/lib/systemd/system/systemd-journald-audit.socket:
+      /usr/lib/systemd/system/systemd-journald-dev-log.socket:
+      /usr/lib/systemd/system/systemd-journald-varlink@.socket:
+      /usr/lib/systemd/system/systemd-journald.service:
+      /usr/lib/systemd/system/systemd-journald.service.d/nice.conf:
+      /usr/lib/systemd/system/systemd-journald.socket:
+      /usr/lib/systemd/system/systemd-journald@.service:
+      /usr/lib/systemd/system/systemd-journald@.socket:
+      /usr/lib/systemd/system/systemd-kexec.service:
+      /usr/lib/systemd/system/systemd-localed.service:
+      /usr/lib/systemd/system/systemd-localed.service.d/x11-keyboard.conf:
+      /usr/lib/systemd/system/systemd-logind.service:
+      /usr/lib/systemd/system/systemd-logind.service.d/dbus.conf:
+      /usr/lib/systemd/system/systemd-machine-id-commit.service:
+      /usr/lib/systemd/system/systemd-modules-load.service:
+      /usr/lib/systemd/system/systemd-network-generator.service:
+      /usr/lib/systemd/system/systemd-networkd-wait-online.service:
+      /usr/lib/systemd/system/systemd-networkd-wait-online@.service:
+      /usr/lib/systemd/system/systemd-networkd.service:
+      /usr/lib/systemd/system/systemd-networkd.socket:
+      /usr/lib/systemd/system/systemd-poweroff.service:
+      /usr/lib/systemd/system/systemd-pstore.service:
+      /usr/lib/systemd/system/systemd-quotacheck.service:
+      /usr/lib/systemd/system/systemd-random-seed.service:
+      /usr/lib/systemd/system/systemd-reboot.service:
+      /usr/lib/systemd/system/systemd-remount-fs.service:
+      /usr/lib/systemd/system/systemd-rfkill.service:
+      /usr/lib/systemd/system/systemd-rfkill.socket:
+      /usr/lib/systemd/system/systemd-soft-reboot.service:
+      /usr/lib/systemd/system/systemd-storagetm.service:
+      /usr/lib/systemd/system/systemd-suspend-then-hibernate.service:
+      /usr/lib/systemd/system/systemd-suspend.service:
+      /usr/lib/systemd/system/systemd-sysctl.service:
+      /usr/lib/systemd/system/systemd-sysext.service:
+      /usr/lib/systemd/system/systemd-sysext.socket:
+      /usr/lib/systemd/system/systemd-sysext@.service:
+      /usr/lib/systemd/system/systemd-sysupdate-reboot.service:
+      /usr/lib/systemd/system/systemd-sysupdate-reboot.timer:
+      /usr/lib/systemd/system/systemd-sysupdate.service:
+      /usr/lib/systemd/system/systemd-sysupdate.timer:
+      /usr/lib/systemd/system/systemd-sysusers.service:
+      /usr/lib/systemd/system/systemd-time-wait-sync.service:
+      /usr/lib/systemd/system/systemd-timedated.service:
+      /usr/lib/systemd/system/systemd-tmpfiles-clean.service:
+      /usr/lib/systemd/system/systemd-tmpfiles-clean.timer:
+      /usr/lib/systemd/system/systemd-tmpfiles-setup-dev-early.service:
+      /usr/lib/systemd/system/systemd-tmpfiles-setup-dev.service:
+      /usr/lib/systemd/system/systemd-tmpfiles-setup.service:
+      /usr/lib/systemd/system/systemd-tpm2-setup-early.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-tpm2-setup.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-update-done.service:
+      /usr/lib/systemd/system/systemd-update-utmp-runlevel.service:
+      /usr/lib/systemd/system/systemd-update-utmp.service:
+      /usr/lib/systemd/system/systemd-user-sessions.service:
+      /usr/lib/systemd/system/systemd-volatile-root.service:
+      /usr/lib/systemd/system/time-set.target:
+      /usr/lib/systemd/system/time-sync.target:
+      /usr/lib/systemd/system/timers.target:
+      /usr/lib/systemd/system/timers.target.wants/systemd-tmpfiles-clean.timer:
+      /usr/lib/systemd/system/umount.target:
+      /usr/lib/systemd/system/usb-gadget.target:
+      /usr/lib/systemd/system/user-.slice.d/10-defaults.conf:
+      /usr/lib/systemd/system/user-runtime-dir@.service:
+      /usr/lib/systemd/system/user.slice:
+      /usr/lib/systemd/system/user@.service:
+      /usr/lib/systemd/system/user@.service.d/10-login-barrier.conf:
+      /usr/lib/systemd/system/user@.service.d/timeout.conf:
+      /usr/lib/systemd/system/user@0.service.d/10-login-barrier.conf:
+      /usr/lib/systemd/system/veritysetup-pre.target:
+      /usr/lib/systemd/system/veritysetup.target:
+      /usr/lib/systemd/system/x11-common.service:
+
+  user-services:
+    contents:
+      /usr/lib/systemd/user-environment-generators/30-systemd-environment-d-generator:
+      /usr/lib/systemd/user-generators/systemd-xdg-autostart-generator:
+      /usr/lib/systemd/user-preset/90-systemd.preset:
+      /usr/lib/systemd/user/app.slice:
+      /usr/lib/systemd/user/background.slice:
+      /usr/lib/systemd/user/basic.target:
+      /usr/lib/systemd/user/bluetooth.target:
+      /usr/lib/systemd/user/default.target:
+      /usr/lib/systemd/user/exit.target:
+      /usr/lib/systemd/user/graphical-session-pre.target:
+      /usr/lib/systemd/user/graphical-session.target:
+      /usr/lib/systemd/user/paths.target:
+      /usr/lib/systemd/user/printer.target:
+      /usr/lib/systemd/user/session.slice:
+      /usr/lib/systemd/user/shutdown.target:
+      /usr/lib/systemd/user/smartcard.target:
+      /usr/lib/systemd/user/sockets.target:
+      /usr/lib/systemd/user/sound.target:
+      /usr/lib/systemd/user/systemd-exit.service:
+      /usr/lib/systemd/user/systemd-tmpfiles-clean.service:
+      /usr/lib/systemd/user/systemd-tmpfiles-clean.timer:
+      /usr/lib/systemd/user/systemd-tmpfiles-setup.service:
+      /usr/lib/systemd/user/timers.target:
+      /usr/lib/systemd/user/xdg-desktop-autostart.target:
+
+  dbus-services:
+    essential:
+      - systemd-dev_dbus-interfaces
+    contents:
+      /usr/share/dbus-1/services/org.freedesktop.systemd1.service:
+      /usr/share/dbus-1/system-services/org.freedesktop.hostname1.service:
+      /usr/share/dbus-1/system-services/org.freedesktop.locale1.service:
+      /usr/share/dbus-1/system-services/org.freedesktop.login1.service:
+      /usr/share/dbus-1/system-services/org.freedesktop.network1.service:
+      /usr/share/dbus-1/system-services/org.freedesktop.systemd1.service:
+      /usr/share/dbus-1/system-services/org.freedesktop.timedate1.service:
+      /usr/share/dbus-1/system.d/org.freedesktop.hostname1.conf:
+      /usr/share/dbus-1/system.d/org.freedesktop.locale1.conf:
+      /usr/share/dbus-1/system.d/org.freedesktop.login1.conf:
+      /usr/share/dbus-1/system.d/org.freedesktop.network1.conf:
+      /usr/share/dbus-1/system.d/org.freedesktop.systemd1.conf:
+      /usr/share/dbus-1/system.d/org.freedesktop.timedate1.conf:
+
+  extras:
+    contents:
+      /etc/modules-load.d/modules.conf:
+      /etc/sysctl.d/99-sysctl.conf:
+      /usr/share/systemd/kbd-model-map:
+      /usr/share/systemd/language-fallback-map:
+      /usr/share/systemd/tmp.mount:
+
+  # Generated services slice is to emulate symlinks or initial state
+  # config generated by systemd upon install.
+  # Systemd performs a lot of initialization upon install, however since systemd
+  # does actually not rely on these install actions (since all of these are run as
+  # a part of the first install / early setup upon first boot), a lot of this is
+  # left out. It's done like that because systemd needs to be usable after install
+  # on a running system, but this is not the case here.
+  # These are the few that seems to be not emulated
+  generated-services:
+    contents:
+      /etc/systemd/system/getty.target.wants/getty@tty1.service:
+        symlink: /usr/lib/systemd/system/getty@.service
+      /etc/systemd/system/multi-user.target.wants/remote-fs.target:
+        symlink: /usr/lib/systemd/system/remote-fs.target
+      /etc/systemd/system/sysinit.target.wants/systemd-pstore.service:
+        symlink: /usr/lib/systemd/system/systemd-pstore.service
+
+  kernel-install:
+    contents:
+      /usr/lib/kernel/install.conf:
+      /usr/lib/kernel/install.d/50-depmod.install:
+      /usr/lib/kernel/install.d/55-initrd.install:
+      /usr/lib/kernel/install.d/90-loaderentry.install:
+      /usr/lib/kernel/install.d/90-uki-copy.install:
+
+  kernel-parameters:
+    contents:
+      /usr/lib/sysctl.d/50-pid-max.conf:
+        arch: [amd64, arm64, riscv64, s390x, ppc64el]
+
+  libs:
+    contents:
+      /usr/lib/*-linux-*/cryptsetup/libcryptsetup-token-systemd-fido2.so:
+      /usr/lib/*-linux-*/cryptsetup/libcryptsetup-token-systemd-pkcs11.so:
+      /usr/lib/*-linux-*/cryptsetup/libcryptsetup-token-systemd-tpm2.so:
+        arch: [amd64, arm64, riscv64]
+
+  modprobe-config:
+    contents:
+      /usr/lib/modprobe.d/systemd.conf:
+
+  pam-profile:
+    contents:
+      /usr/lib/pam.d/systemd-user:
+
+  pcrlock:
+    contents:
+      /usr/lib/pcrlock.d/350-action-efi-application.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/400-secureboot-separator.pcrlock.d/300-0x00000000.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/400-secureboot-separator.pcrlock.d/600-0xffffffff.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/500-separator.pcrlock.d/300-0x00000000.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/500-separator.pcrlock.d/600-0xffffffff.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/700-action-efi-exit-boot-services.pcrlock.d/300-present.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/700-action-efi-exit-boot-services.pcrlock.d/600-absent.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/750-enter-initrd.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/800-leave-initrd.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/850-sysinit.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/900-ready.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/950-shutdown.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/pcrlock.d/990-final.pcrlock:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrextend.socket:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrextend@.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrfs-root.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrfs@.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-file-system.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-firmware-code.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-firmware-config.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-machine-id.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-make-policy.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-secureboot-authority.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock-secureboot-policy.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrmachine.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrphase-initrd.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrphase-sysinit.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrphase.service:
+        arch: [amd64, arm64, riscv64]
+
+  polkit:
+    contents:
+      /usr/share/polkit-1/actions/org.freedesktop.hostname1.policy:
+      /usr/share/polkit-1/actions/org.freedesktop.locale1.policy:
+      /usr/share/polkit-1/actions/org.freedesktop.login1.policy:
+      /usr/share/polkit-1/actions/org.freedesktop.network1.policy:
+      /usr/share/polkit-1/actions/org.freedesktop.systemd1.policy:
+      /usr/share/polkit-1/actions/org.freedesktop.timedate1.policy:
+      /usr/share/polkit-1/actions/org.freedesktop.timesync1.policy:
+      /usr/share/polkit-1/rules.d/systemd-networkd.rules:
+
+  sysusers-config:
+    contents:
+      /usr/lib/sysusers.d/basic.conf:
+      /usr/lib/sysusers.d/systemd-journal.conf:
+      /usr/lib/sysusers.d/systemd-network.conf:
+
+  tmpfiles-config:
+    contents:
+      /usr/lib/tmpfiles.d/credstore.conf:
+      /usr/lib/tmpfiles.d/debian.conf:
+      /usr/lib/tmpfiles.d/home.conf:
+      /usr/lib/tmpfiles.d/journal-nocow.conf:
+      /usr/lib/tmpfiles.d/legacy.conf:
+      /usr/lib/tmpfiles.d/provision.conf:
+      /usr/lib/tmpfiles.d/systemd-network.conf:
+      /usr/lib/tmpfiles.d/systemd-nologin.conf:
+      /usr/lib/tmpfiles.d/systemd-pstore.conf:
+      /usr/lib/tmpfiles.d/systemd-tmp.conf:
+      /usr/lib/tmpfiles.d/systemd.conf:
+      /usr/lib/tmpfiles.d/tmp.conf:
+      /usr/lib/tmpfiles.d/var.conf:
+      /usr/lib/tmpfiles.d/x11.conf:
+
+  udev-rules:
+    contents:
+      /usr/lib/udev/rules.d/70-uaccess.rules:
+      /usr/lib/udev/rules.d/71-seat.rules:
+      /usr/lib/udev/rules.d/73-seat-late.rules:
+      /usr/lib/udev/rules.d/99-systemd.rules:
+
+  copyright:
+    contents:
+      /usr/share/doc/systemd/copyright:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -30,10 +30,8 @@ slices:
       - systemd_catalog
       - systemd_config
       - systemd_kernel-parameters
-      - systemd_libs
       - systemd_network
       - systemd_pcrlock
-      - systemd_repart
       - systemd_system-generators
       - systemd_system-services
       - systemd_user-services
@@ -46,7 +44,6 @@ slices:
       /usr/bin/loginctl:
       /usr/bin/networkctl:
       /usr/bin/systemctl:
-      /usr/bin/systemd:
       /usr/bin/systemd-ac-power:
       /usr/bin/systemd-analyze:
       /usr/bin/systemd-ask-password:
@@ -55,8 +52,6 @@ slices:
       /usr/bin/systemd-cgtop:
       /usr/bin/systemd-confext:
       /usr/bin/systemd-creds:
-      /usr/bin/systemd-cryptenroll:
-      /usr/bin/systemd-cryptsetup:
       /usr/bin/systemd-delta:
       /usr/bin/systemd-detect-virt:
       /usr/bin/systemd-escape:
@@ -67,7 +62,6 @@ slices:
       /usr/bin/systemd-mount:
       /usr/bin/systemd-notify:
       /usr/bin/systemd-path:
-      /usr/bin/systemd-repart:
       /usr/bin/systemd-run:
       /usr/bin/systemd-socket-activate:
       /usr/bin/systemd-stdio-bridge:
@@ -78,6 +72,8 @@ slices:
       /usr/bin/systemd-umount:
       /usr/bin/timedatectl:
       /usr/bin/varlinkctl:
+      /usr/bin/run0:
+      /usr/bin/systemd-vpick:
       /usr/lib/lsb/init-functions.d/40-systemd:
       /usr/lib/systemd/systemd:
       /usr/lib/systemd/systemd-backlight:
@@ -87,7 +83,6 @@ slices:
       /usr/lib/systemd/systemd-bsod:
         arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
       /usr/lib/systemd/systemd-cgroups-agent:
-      /usr/lib/systemd/systemd-cryptsetup:
       /usr/lib/systemd/systemd-executor:
       /usr/lib/systemd/systemd-fsck:
       /usr/lib/systemd/systemd-fsckd:
@@ -95,7 +90,6 @@ slices:
       /usr/lib/systemd/systemd-hibernate-resume:
       /usr/lib/systemd/systemd-hostnamed:
       /usr/lib/systemd/systemd-initctl:
-      /usr/lib/systemd/systemd-integritysetup:
       /usr/lib/systemd/systemd-journald:
       /usr/lib/systemd/systemd-localed:
       /usr/lib/systemd/systemd-logind:
@@ -120,16 +114,12 @@ slices:
       /usr/lib/systemd/systemd-sulogin-shell:
       /usr/lib/systemd/systemd-sysctl:
       /usr/lib/systemd/systemd-sysroot-fstab-check:
-      /usr/lib/systemd/systemd-sysupdate:
       /usr/lib/systemd/systemd-sysv-install:
-      /usr/lib/systemd/systemd-time-wait-sync:
       /usr/lib/systemd/systemd-timedated:
       /usr/lib/systemd/systemd-tpm2-setup: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/systemd-update-done:
-      /usr/lib/systemd/systemd-update-utmp:
       /usr/lib/systemd/systemd-user-runtime-dir:
       /usr/lib/systemd/systemd-user-sessions:
-      /usr/lib/systemd/systemd-veritysetup:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
 
@@ -175,44 +165,37 @@ slices:
 
   network:
     contents:
+      /usr/lib/systemd/network/80-6rd-tunnel.link:
       /usr/lib/systemd/network/80-6rd-tunnel.network:
+      /usr/lib/systemd/network/80-auto-link-local.network.example:
+      /usr/lib/systemd/network/80-container-host0-tun.network:
       /usr/lib/systemd/network/80-container-host0.network:
+      /usr/lib/systemd/network/80-container-vb.link:
       /usr/lib/systemd/network/80-container-vb.network:
+      /usr/lib/systemd/network/80-container-ve.link:
       /usr/lib/systemd/network/80-container-ve.network:
+      /usr/lib/systemd/network/80-container-vz.link:
       /usr/lib/systemd/network/80-container-vz.network:
+      /usr/lib/systemd/network/80-vm-vt.link:
       /usr/lib/systemd/network/80-vm-vt.network:
       /usr/lib/systemd/network/80-wifi-adhoc.network:
-
-  repart:
-    contents:
-      /usr/lib/systemd/repart/definitions/confext.repart.d/10-root.conf:
-      /usr/lib/systemd/repart/definitions/confext.repart.d/20-root-verity.conf:
-      /usr/lib/systemd/repart/definitions/confext.repart.d/30-root-verity-sig.conf:
-      /usr/lib/systemd/repart/definitions/portable.repart.d/10-root.conf:
-      /usr/lib/systemd/repart/definitions/portable.repart.d/20-root-verity.conf:
-      /usr/lib/systemd/repart/definitions/portable.repart.d/30-root-verity-sig.conf:
-      /usr/lib/systemd/repart/definitions/sysext.repart.d/10-root.conf:
-      /usr/lib/systemd/repart/definitions/sysext.repart.d/20-root-verity.conf:
-      /usr/lib/systemd/repart/definitions/sysext.repart.d/30-root-verity-sig.conf:
-      /usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service:
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-repart.service:
-      /usr/lib/systemd/system/systemd-repart.service:
+      /usr/lib/systemd/network/80-wifi-ap.network.example:
+      /usr/lib/systemd/network/80-wifi-station.network.example:
+      /usr/lib/systemd/network/89-ethernet.network.example:
 
   system-generators:
     contents:
-      /etc/systemd/system-generators/systemd-gpt-auto-generator:
-      /usr/lib/systemd/system-generators/systemd-cryptsetup-generator:
       /usr/lib/systemd/system-generators/systemd-debug-generator:
       /usr/lib/systemd/system-generators/systemd-fstab-generator:
       /usr/lib/systemd/system-generators/systemd-getty-generator:
       /usr/lib/systemd/system-generators/systemd-gpt-auto-generator:
       /usr/lib/systemd/system-generators/systemd-hibernate-resume-generator:
-      /usr/lib/systemd/system-generators/systemd-integritysetup-generator:
       /usr/lib/systemd/system-generators/systemd-rc-local-generator:
       /usr/lib/systemd/system-generators/systemd-run-generator:
+      /usr/lib/systemd/system-generators/systemd-ssh-generator:
       /usr/lib/systemd/system-generators/systemd-system-update-generator:
       /usr/lib/systemd/system-generators/systemd-sysv-generator:
-      /usr/lib/systemd/system-generators/systemd-veritysetup-generator:
+      /usr/lib/systemd/system-generators/systemd-tpm2-generator:
 
   system-services:
     essential:
@@ -224,12 +207,12 @@ slices:
       /usr/lib/systemd/system/blockdev@.target:
       /usr/lib/systemd/system/bluetooth.target:
       /usr/lib/systemd/system/boot-complete.target:
+      /usr/lib/systemd/system/capsule.slice:
+      /usr/lib/systemd/system/capsule@.service:
       /usr/lib/systemd/system/console-getty.service:
       /usr/lib/systemd/system/container-getty@.service:
       /usr/lib/systemd/system/cryptdisks-early.service:
       /usr/lib/systemd/system/cryptdisks.service:
-      /usr/lib/systemd/system/cryptsetup-pre.target:
-      /usr/lib/systemd/system/cryptsetup.target:
       /usr/lib/systemd/system/ctrl-alt-del.target:
       /usr/lib/systemd/system/dbus-org.freedesktop.hostname1.service:
       /usr/lib/systemd/system/dbus-org.freedesktop.locale1.service:
@@ -251,7 +234,6 @@ slices:
       /usr/lib/systemd/system/getty.target.wants/getty-static.service:
       /usr/lib/systemd/system/getty@.service:
       /usr/lib/systemd/system/graphical.target:
-      /usr/lib/systemd/system/graphical.target.wants/systemd-update-utmp-runlevel.service:
       /usr/lib/systemd/system/halt.target:
       /usr/lib/systemd/system/hibernate.target:
       /usr/lib/systemd/system/hwclock.service:
@@ -260,8 +242,6 @@ slices:
       /usr/lib/systemd/system/initrd-fs.target:
       /usr/lib/systemd/system/initrd-parse-etc.service:
       /usr/lib/systemd/system/initrd-root-device.target:
-      /usr/lib/systemd/system/initrd-root-device.target.wants/remote-cryptsetup.target:
-      /usr/lib/systemd/system/initrd-root-device.target.wants/remote-veritysetup.target:
       /usr/lib/systemd/system/initrd-root-fs.target:
       /usr/lib/systemd/system/initrd-switch-root.service:
       /usr/lib/systemd/system/initrd-switch-root.target:
@@ -273,21 +253,20 @@ slices:
         arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
       /usr/lib/systemd/system/initrd.target.wants/systemd-pcrphase-initrd.service:
         arch: [amd64, arm64, riscv64]
-      /usr/lib/systemd/system/integritysetup-pre.target:
-      /usr/lib/systemd/system/integritysetup.target:
       /usr/lib/systemd/system/kexec.target:
       /usr/lib/systemd/system/kmod-static-nodes.service:
       /usr/lib/systemd/system/kmod.service:
       /usr/lib/systemd/system/ldconfig.service:
       /usr/lib/systemd/system/local-fs-pre.target:
       /usr/lib/systemd/system/local-fs.target:
+      /usr/lib/systemd/system/local-fs.target.wants/run-lock.mount:
+      /usr/lib/systemd/system/local-fs.target.wants/tmp.mount:
       /usr/lib/systemd/system/machine.slice:
       /usr/lib/systemd/system/modprobe@.service:
       /usr/lib/systemd/system/multi-user.target:
       /usr/lib/systemd/system/multi-user.target.wants/getty.target:
       /usr/lib/systemd/system/multi-user.target.wants/systemd-ask-password-wall.path:
       /usr/lib/systemd/system/multi-user.target.wants/systemd-logind.service:
-      /usr/lib/systemd/system/multi-user.target.wants/systemd-update-utmp-runlevel.service:
       /usr/lib/systemd/system/multi-user.target.wants/systemd-user-sessions.service:
       /usr/lib/systemd/system/network-online.target:
       /usr/lib/systemd/system/network-pre.target:
@@ -300,18 +279,17 @@ slices:
       /usr/lib/systemd/system/proc-sys-fs-binfmt_misc.automount:
       /usr/lib/systemd/system/proc-sys-fs-binfmt_misc.mount:
       /usr/lib/systemd/system/procps.service:
-      /usr/lib/systemd/system/quotaon.service:
+      /usr/lib/systemd/system/quotaon-root.service:
+      /usr/lib/systemd/system/quotaon@.service:
       /usr/lib/systemd/system/rc-local.service:
       /usr/lib/systemd/system/rc-local.service.d/debian.conf:
       /usr/lib/systemd/system/reboot.target:
-      /usr/lib/systemd/system/remote-cryptsetup.target:
       /usr/lib/systemd/system/remote-fs-pre.target:
       /usr/lib/systemd/system/remote-fs.target:
-      /usr/lib/systemd/system/remote-veritysetup.target:
       /usr/lib/systemd/system/rescue.service:
       /usr/lib/systemd/system/rescue.target:
-      /usr/lib/systemd/system/rescue.target.wants/systemd-update-utmp-runlevel.service:
       /usr/lib/systemd/system/rpcbind.target:
+      /usr/lib/systemd/system/run-lock.mount:
       /usr/lib/systemd/system/runlevel0.target:
       /usr/lib/systemd/system/runlevel1.target:
       /usr/lib/systemd/system/runlevel2.target:
@@ -326,10 +304,14 @@ slices:
       /usr/lib/systemd/system/slices.target:
       /usr/lib/systemd/system/smartcard.target:
       /usr/lib/systemd/system/sockets.target:
+      /usr/lib/systemd/system/sockets.target.wants/systemd-creds.socket:
+      /usr/lib/systemd/system/sockets.target.wants/systemd-hostnamed.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-initctl.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-journald-dev-log.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-journald.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrlock.socket:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/sockets.target.wants/systemd-sysext.socket:
       /usr/lib/systemd/system/soft-reboot.target:
@@ -343,10 +325,8 @@ slices:
       /usr/lib/systemd/system/sys-kernel-debug.mount:
       /usr/lib/systemd/system/sys-kernel-tracing.mount:
       /usr/lib/systemd/system/sysinit.target:
-      /usr/lib/systemd/system/sysinit.target.wants/cryptsetup.target:
       /usr/lib/systemd/system/sysinit.target.wants/dev-hugepages.mount:
       /usr/lib/systemd/system/sysinit.target.wants/dev-mqueue.mount:
-      /usr/lib/systemd/system/sysinit.target.wants/integritysetup.target:
       /usr/lib/systemd/system/sysinit.target.wants/kmod-static-nodes.service:
       /usr/lib/systemd/system/sysinit.target.wants/ldconfig.service:
       /usr/lib/systemd/system/sysinit.target.wants/proc-sys-fs-binfmt_misc.automount:
@@ -357,6 +337,7 @@ slices:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-ask-password-console.path:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-binfmt.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service:
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-hibernate-clear.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-journal-catalog-update.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-journal-flush.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-journald.service:
@@ -379,11 +360,7 @@ slices:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup.service:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/sysinit.target.wants/systemd-update-done.service:
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-update-utmp.service:
-      /usr/lib/systemd/system/sysinit.target.wants/veritysetup.target:
       /usr/lib/systemd/system/syslog.socket:
-      /usr/lib/systemd/system/system-systemd\x2dcryptsetup.slice:
-      /usr/lib/systemd/system/system-systemd\x2dveritysetup.slice:
       /usr/lib/systemd/system/system-update-cleanup.service:
       /usr/lib/systemd/system/system-update-pre.target:
       /usr/lib/systemd/system/system-update.target:
@@ -398,18 +375,23 @@ slices:
       /usr/lib/systemd/system/systemd-bsod.service:
         arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
       /usr/lib/systemd/system/systemd-confext.service:
+      /usr/lib/systemd/system/systemd-creds.socket:
+      /usr/lib/systemd/system/systemd-creds@.service:
       /usr/lib/systemd/system/systemd-exit.service:
       /usr/lib/systemd/system/systemd-firstboot.service:
       /usr/lib/systemd/system/systemd-fsck-root.service:
+      /usr/lib/systemd/system/systemd-fsck-root.service.d/10-skip-fsck-initramfs.conf:
       /usr/lib/systemd/system/systemd-fsck@.service:
       /usr/lib/systemd/system/systemd-fsckd.service:
       /usr/lib/systemd/system/systemd-fsckd.socket:
       /usr/lib/systemd/system/systemd-growfs-root.service:
       /usr/lib/systemd/system/systemd-growfs@.service:
       /usr/lib/systemd/system/systemd-halt.service:
+      /usr/lib/systemd/system/systemd-hibernate-clear.service:
       /usr/lib/systemd/system/systemd-hibernate-resume.service:
       /usr/lib/systemd/system/systemd-hibernate.service:
       /usr/lib/systemd/system/systemd-hostnamed.service:
+      /usr/lib/systemd/system/systemd-hostnamed.socket:
       /usr/lib/systemd/system/systemd-hybrid-sleep.service:
       /usr/lib/systemd/system/systemd-initctl.service:
       /usr/lib/systemd/system/systemd-initctl.socket:
@@ -417,6 +399,7 @@ slices:
       /usr/lib/systemd/system/systemd-journal-flush.service:
       /usr/lib/systemd/system/systemd-journald-audit.socket:
       /usr/lib/systemd/system/systemd-journald-dev-log.socket:
+      /usr/lib/systemd/system/systemd-journald-sync@.service:
       /usr/lib/systemd/system/systemd-journald-varlink@.socket:
       /usr/lib/systemd/system/systemd-journald.service:
       /usr/lib/systemd/system/systemd-journald.service.d/nice.conf:
@@ -431,13 +414,15 @@ slices:
       /usr/lib/systemd/system/systemd-machine-id-commit.service:
       /usr/lib/systemd/system/systemd-modules-load.service:
       /usr/lib/systemd/system/systemd-network-generator.service:
+      /usr/lib/systemd/system/systemd-networkd-persistent-storage.service:
       /usr/lib/systemd/system/systemd-networkd-wait-online.service:
       /usr/lib/systemd/system/systemd-networkd-wait-online@.service:
       /usr/lib/systemd/system/systemd-networkd.service:
       /usr/lib/systemd/system/systemd-networkd.socket:
       /usr/lib/systemd/system/systemd-poweroff.service:
       /usr/lib/systemd/system/systemd-pstore.service:
-      /usr/lib/systemd/system/systemd-quotacheck.service:
+      /usr/lib/systemd/system/systemd-quotacheck-root.service:
+      /usr/lib/systemd/system/systemd-quotacheck@.service:
       /usr/lib/systemd/system/systemd-random-seed.service:
       /usr/lib/systemd/system/systemd-reboot.service:
       /usr/lib/systemd/system/systemd-remount-fs.service:
@@ -451,12 +436,7 @@ slices:
       /usr/lib/systemd/system/systemd-sysext.service:
       /usr/lib/systemd/system/systemd-sysext.socket:
       /usr/lib/systemd/system/systemd-sysext@.service:
-      /usr/lib/systemd/system/systemd-sysupdate-reboot.service:
-      /usr/lib/systemd/system/systemd-sysupdate-reboot.timer:
-      /usr/lib/systemd/system/systemd-sysupdate.service:
-      /usr/lib/systemd/system/systemd-sysupdate.timer:
       /usr/lib/systemd/system/systemd-sysusers.service:
-      /usr/lib/systemd/system/systemd-time-wait-sync.service:
       /usr/lib/systemd/system/systemd-timedated.service:
       /usr/lib/systemd/system/systemd-tmpfiles-clean.service:
       /usr/lib/systemd/system/systemd-tmpfiles-clean.timer:
@@ -468,10 +448,10 @@ slices:
       /usr/lib/systemd/system/systemd-tpm2-setup.service:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/systemd-update-done.service:
-      /usr/lib/systemd/system/systemd-update-utmp-runlevel.service:
-      /usr/lib/systemd/system/systemd-update-utmp.service:
       /usr/lib/systemd/system/systemd-user-sessions.service:
       /usr/lib/systemd/system/systemd-volatile-root.service:
+      /usr/lib/systemd/system/tmp.mount:
+      /usr/lib/systemd/system/tpm2.target:
       /usr/lib/systemd/system/time-set.target:
       /usr/lib/systemd/system/time-sync.target:
       /usr/lib/systemd/system/timers.target:
@@ -485,8 +465,6 @@ slices:
       /usr/lib/systemd/system/user@.service.d/10-login-barrier.conf:
       /usr/lib/systemd/system/user@.service.d/timeout.conf:
       /usr/lib/systemd/system/user@0.service.d/10-login-barrier.conf:
-      /usr/lib/systemd/system/veritysetup-pre.target:
-      /usr/lib/systemd/system/veritysetup.target:
       /usr/lib/systemd/system/x11-common.service:
 
   user-services:
@@ -498,6 +476,7 @@ slices:
       /usr/lib/systemd/user/background.slice:
       /usr/lib/systemd/user/basic.target:
       /usr/lib/systemd/user/bluetooth.target:
+      /usr/lib/systemd/user/capsule@.target:
       /usr/lib/systemd/user/default.target:
       /usr/lib/systemd/user/exit.target:
       /usr/lib/systemd/user/graphical-session-pre.target:
@@ -516,6 +495,7 @@ slices:
       /usr/lib/systemd/user/timers.target:
       /usr/lib/systemd/user/xdg-desktop-autostart.target:
 
+
   dbus-services:
     essential:
       - systemd-dev_dbus-interfaces
@@ -533,14 +513,14 @@ slices:
       /usr/share/dbus-1/system.d/org.freedesktop.network1.conf:
       /usr/share/dbus-1/system.d/org.freedesktop.systemd1.conf:
       /usr/share/dbus-1/system.d/org.freedesktop.timedate1.conf:
+      /usr/share/dbus-1/system.d/systemd-localed-read-only.conf:
 
   extras:
     contents:
       /etc/modules-load.d/modules.conf:
-      /etc/sysctl.d/99-sysctl.conf:
+      /usr/share/mime/packages/io.systemd.xml:
       /usr/share/systemd/kbd-model-map:
       /usr/share/systemd/language-fallback-map:
-      /usr/share/systemd/tmp.mount:
 
   # Generated services slice is to emulate symlinks or initial state
   # config generated by systemd upon install.
@@ -572,12 +552,6 @@ slices:
       /usr/lib/sysctl.d/50-pid-max.conf:
         arch: [amd64, arm64, riscv64, s390x, ppc64el]
 
-  libs:
-    contents:
-      /usr/lib/*-linux-*/cryptsetup/libcryptsetup-token-systemd-fido2.so:
-      /usr/lib/*-linux-*/cryptsetup/libcryptsetup-token-systemd-pkcs11.so:
-      /usr/lib/*-linux-*/cryptsetup/libcryptsetup-token-systemd-tpm2.so:
-        arch: [amd64, arm64, riscv64]
 
   modprobe-config:
     contents:
@@ -637,6 +611,10 @@ slices:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/systemd-pcrlock-secureboot-policy.service:
         arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock.socket:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-pcrlock@.service:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/systemd-pcrmachine.service:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/systemd-pcrphase-initrd.service:
@@ -655,6 +633,8 @@ slices:
       /usr/share/polkit-1/actions/org.freedesktop.systemd1.policy:
       /usr/share/polkit-1/actions/org.freedesktop.timedate1.policy:
       /usr/share/polkit-1/actions/org.freedesktop.timesync1.policy:
+      /usr/share/polkit-1/actions/io.systemd.credentials.policy:
+      /usr/share/polkit-1/rules.d/10-systemd-logind-root-ignore-inhibitors.rules:
       /usr/share/polkit-1/rules.d/systemd-networkd.rules:
 
   sysusers-config:
@@ -665,6 +645,9 @@ slices:
 
   tmpfiles-config:
     contents:
+      /usr/lib/tmpfiles.d/20-systemd-shell-extra.conf:
+      /usr/lib/tmpfiles.d/20-systemd-ssh-generator.conf:
+      /usr/lib/tmpfiles.d/20-systemd-stub.conf:
       /usr/lib/tmpfiles.d/credstore.conf:
       /usr/lib/tmpfiles.d/debian.conf:
       /usr/lib/tmpfiles.d/home.conf:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -112,7 +112,7 @@ slices:
       /usr/lib/systemd/systemd-user-sessions:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
-      /usr/lib/systemd/systemd: 
+      /usr/lib/systemd/systemd:
         arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
 
   catalog:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -176,7 +176,6 @@ slices:
       /usr/lib/systemd/system-generators/systemd-debug-generator:
       /usr/lib/systemd/system-generators/systemd-fstab-generator:
       /usr/lib/systemd/system-generators/systemd-getty-generator:
-      /usr/lib/systemd/system-generators/systemd-gpt-auto-generator:
       /usr/lib/systemd/system-generators/systemd-hibernate-resume-generator:
       /usr/lib/systemd/system-generators/systemd-rc-local-generator:
       /usr/lib/systemd/system-generators/systemd-run-generator:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -482,7 +482,6 @@ slices:
       /usr/lib/systemd/user/timers.target:
       /usr/lib/systemd/user/xdg-desktop-autostart.target:
 
-
   dbus-services:
     essential:
       - systemd-dev_dbus-interfaces
@@ -538,7 +537,6 @@ slices:
     contents:
       /usr/lib/sysctl.d/50-pid-max.conf:
         arch: [amd64, arm64, riscv64, s390x, ppc64el]
-
 
   modprobe-config:
     contents:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -118,7 +118,7 @@ slices:
       /usr/lib/systemd/systemd-user-sessions:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
-      
+
 
   catalog:
     contents:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -34,6 +34,7 @@ slices:
       /usr/bin/localectl:
       /usr/bin/loginctl:
       /usr/bin/networkctl:
+      /usr/bin/run0:
       /usr/bin/systemctl:
       /usr/bin/systemd-ac-power:
       /usr/bin/systemd-analyze:
@@ -61,18 +62,15 @@ slices:
       /usr/bin/systemd-tmpfiles:
       /usr/bin/systemd-tty-ask-password-agent:
       /usr/bin/systemd-umount:
+      /usr/bin/systemd-vpick:
       /usr/bin/timedatectl:
       /usr/bin/varlinkctl:
-      /usr/bin/run0:
-      /usr/bin/systemd-vpick:
       /usr/lib/lsb/init-functions.d/40-systemd:
-      /usr/lib/systemd/systemd:
       /usr/lib/systemd/systemd-backlight:
       /usr/lib/systemd/systemd-battery-check:
       /usr/lib/systemd/systemd-binfmt:
       /usr/lib/systemd/systemd-boot-check-no-failures:
       /usr/lib/systemd/systemd-bsod:
-        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
       /usr/lib/systemd/systemd-cgroups-agent:
       /usr/lib/systemd/systemd-executor:
       /usr/lib/systemd/systemd-fsck:
@@ -88,8 +86,8 @@ slices:
       /usr/lib/systemd/systemd-measure: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/systemd-modules-load:
       /usr/lib/systemd/systemd-network-generator:
-      /usr/lib/systemd/systemd-networkd:
       /usr/lib/systemd/systemd-networkd-wait-online:
+      /usr/lib/systemd/systemd-networkd:
       /usr/lib/systemd/systemd-pcrextend: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/systemd-pcrlock: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/systemd-pstore:
@@ -101,6 +99,7 @@ slices:
       /usr/lib/systemd/systemd-shutdown:
       /usr/lib/systemd/systemd-sleep:
       /usr/lib/systemd/systemd-socket-proxyd:
+      /usr/lib/systemd/systemd-ssh-proxy:
       /usr/lib/systemd/systemd-storagetm:
       /usr/lib/systemd/systemd-sulogin-shell:
       /usr/lib/systemd/systemd-sysctl:
@@ -113,6 +112,8 @@ slices:
       /usr/lib/systemd/systemd-user-sessions:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
+      /usr/lib/systemd/systemd: 
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
 
   catalog:
     contents:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -70,7 +70,7 @@ slices:
       /usr/lib/systemd/systemd-battery-check:
       /usr/lib/systemd/systemd-binfmt:
       /usr/lib/systemd/systemd-boot-check-no-failures:
-      /usr/lib/systemd/systemd-bsod:
+      /usr/lib/systemd/systemd-bsod: {arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]}
       /usr/lib/systemd/systemd-cgroups-agent:
       /usr/lib/systemd/systemd-executor:
       /usr/lib/systemd/systemd-fsck:
@@ -113,7 +113,6 @@ slices:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
       /usr/lib/systemd/systemd:
-        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
 
   catalog:
     contents:
@@ -236,10 +235,8 @@ slices:
       /usr/lib/systemd/system/initrd-usr-fs.target:
       /usr/lib/systemd/system/initrd.target:
       /usr/lib/systemd/system/initrd.target.wants/systemd-battery-check.service:
-      /usr/lib/systemd/system/initrd.target.wants/systemd-bsod.service:
-        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
-      /usr/lib/systemd/system/initrd.target.wants/systemd-pcrphase-initrd.service:
-        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/initrd.target.wants/systemd-bsod.service: {arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]}
+      /usr/lib/systemd/system/initrd.target.wants/systemd-pcrphase-initrd.service: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/system/kexec.target:
       /usr/lib/systemd/system/kmod-static-nodes.service:
       /usr/lib/systemd/system/kmod.service:
@@ -296,10 +293,8 @@ slices:
       /usr/lib/systemd/system/sockets.target.wants/systemd-initctl.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-journald-dev-log.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-journald.socket:
-      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket:
-        arch: [amd64, arm64, riscv64]
-      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrlock.socket:
-        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrlock.socket: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/system/sockets.target.wants/systemd-sysext.socket:
       /usr/lib/systemd/system/soft-reboot.target:
       /usr/lib/systemd/system/sound.target:
@@ -330,22 +325,17 @@ slices:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-journald.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-machine-id-commit.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-modules-load.service:
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrmachine.service:
-        arch: [amd64, arm64, riscv64]
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase-sysinit.service:
-        arch: [amd64, arm64, riscv64]
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase.service:
-        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrmachine.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase-sysinit.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase.service: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/system/sysinit.target.wants/systemd-random-seed.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-sysctl.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-sysusers.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup.service:
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup-early.service:
-        arch: [amd64, arm64, riscv64]
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup.service:
-        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup-early.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup.service: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/system/sysinit.target.wants/systemd-update-done.service:
       /usr/lib/systemd/system/syslog.socket:
       /usr/lib/systemd/system/system-update-cleanup.service:
@@ -359,8 +349,7 @@ slices:
       /usr/lib/systemd/system/systemd-battery-check.service:
       /usr/lib/systemd/system/systemd-binfmt.service:
       /usr/lib/systemd/system/systemd-boot-check-no-failures.service:
-      /usr/lib/systemd/system/systemd-bsod.service:
-        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
+      /usr/lib/systemd/system/systemd-bsod.service: {arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]}
       /usr/lib/systemd/system/systemd-confext.service:
       /usr/lib/systemd/system/systemd-creds.socket:
       /usr/lib/systemd/system/systemd-creds@.service:
@@ -430,19 +419,17 @@ slices:
       /usr/lib/systemd/system/systemd-tmpfiles-setup-dev-early.service:
       /usr/lib/systemd/system/systemd-tmpfiles-setup-dev.service:
       /usr/lib/systemd/system/systemd-tmpfiles-setup.service:
-      /usr/lib/systemd/system/systemd-tpm2-setup-early.service:
-        arch: [amd64, arm64, riscv64]
-      /usr/lib/systemd/system/systemd-tpm2-setup.service:
-        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/systemd-tpm2-setup-early.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/systemd-tpm2-setup.service: {arch: [amd64, arm64, riscv64]}
       /usr/lib/systemd/system/systemd-update-done.service:
       /usr/lib/systemd/system/systemd-user-sessions.service:
       /usr/lib/systemd/system/systemd-volatile-root.service:
-      /usr/lib/systemd/system/tmp.mount:
-      /usr/lib/systemd/system/tpm2.target:
       /usr/lib/systemd/system/time-set.target:
       /usr/lib/systemd/system/time-sync.target:
       /usr/lib/systemd/system/timers.target:
       /usr/lib/systemd/system/timers.target.wants/systemd-tmpfiles-clean.timer:
+      /usr/lib/systemd/system/tmp.mount:
+      /usr/lib/systemd/system/tpm2.target:
       /usr/lib/systemd/system/umount.target:
       /usr/lib/systemd/system/usb-gadget.target:
       /usr/lib/systemd/system/user-.slice.d/10-defaults.conf:
@@ -611,6 +598,7 @@ slices:
 
   polkit:
     contents:
+      /usr/share/polkit-1/actions/io.systemd.credentials.policy:
       /usr/share/polkit-1/actions/org.freedesktop.hostname1.policy:
       /usr/share/polkit-1/actions/org.freedesktop.locale1.policy:
       /usr/share/polkit-1/actions/org.freedesktop.login1.policy:
@@ -618,7 +606,6 @@ slices:
       /usr/share/polkit-1/actions/org.freedesktop.systemd1.policy:
       /usr/share/polkit-1/actions/org.freedesktop.timedate1.policy:
       /usr/share/polkit-1/actions/org.freedesktop.timesync1.policy:
-      /usr/share/polkit-1/actions/io.systemd.credentials.policy:
       /usr/share/polkit-1/rules.d/10-systemd-logind-root-ignore-inhibitors.rules:
       /usr/share/polkit-1/rules.d/systemd-networkd.rules:
 

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -119,7 +119,6 @@ slices:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
 
-
   catalog:
     contents:
       /usr/lib/systemd/catalog/systemd.be.catalog:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -70,7 +70,8 @@ slices:
       /usr/lib/systemd/systemd-battery-check:
       /usr/lib/systemd/systemd-binfmt:
       /usr/lib/systemd/systemd-boot-check-no-failures:
-      /usr/lib/systemd/systemd-bsod: {arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]}
+      /usr/lib/systemd/systemd-bsod:
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
       /usr/lib/systemd/systemd-cgroups-agent:
       /usr/lib/systemd/systemd-executor:
       /usr/lib/systemd/systemd-fsck:
@@ -83,13 +84,16 @@ slices:
       /usr/lib/systemd/systemd-localed:
       /usr/lib/systemd/systemd-logind:
       /usr/lib/systemd/systemd-makefs:
-      /usr/lib/systemd/systemd-measure: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-measure:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-modules-load:
       /usr/lib/systemd/systemd-network-generator:
       /usr/lib/systemd/systemd-networkd-wait-online:
       /usr/lib/systemd/systemd-networkd:
-      /usr/lib/systemd/systemd-pcrextend: {arch: [amd64, arm64, riscv64]}
-      /usr/lib/systemd/systemd-pcrlock: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-pcrextend:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/systemd-pcrlock:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-pstore:
       /usr/lib/systemd/systemd-quotacheck:
       /usr/lib/systemd/systemd-random-seed:
@@ -106,7 +110,8 @@ slices:
       /usr/lib/systemd/systemd-sysroot-fstab-check:
       /usr/lib/systemd/systemd-sysv-install:
       /usr/lib/systemd/systemd-timedated:
-      /usr/lib/systemd/systemd-tpm2-setup: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/systemd-tpm2-setup:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-update-done:
       /usr/lib/systemd/systemd-user-runtime-dir:
       /usr/lib/systemd/systemd-user-sessions:
@@ -235,8 +240,10 @@ slices:
       /usr/lib/systemd/system/initrd-usr-fs.target:
       /usr/lib/systemd/system/initrd.target:
       /usr/lib/systemd/system/initrd.target.wants/systemd-battery-check.service:
-      /usr/lib/systemd/system/initrd.target.wants/systemd-bsod.service: {arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]}
-      /usr/lib/systemd/system/initrd.target.wants/systemd-pcrphase-initrd.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/initrd.target.wants/systemd-bsod.service:
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
+      /usr/lib/systemd/system/initrd.target.wants/systemd-pcrphase-initrd.service:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/kexec.target:
       /usr/lib/systemd/system/kmod-static-nodes.service:
       /usr/lib/systemd/system/kmod.service:
@@ -293,8 +300,10 @@ slices:
       /usr/lib/systemd/system/sockets.target.wants/systemd-initctl.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-journald-dev-log.socket:
       /usr/lib/systemd/system/sockets.target.wants/systemd-journald.socket:
-      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket: {arch: [amd64, arm64, riscv64]}
-      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrlock.socket: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrextend.socket:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sockets.target.wants/systemd-pcrlock.socket:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/sockets.target.wants/systemd-sysext.socket:
       /usr/lib/systemd/system/soft-reboot.target:
       /usr/lib/systemd/system/sound.target:
@@ -325,17 +334,22 @@ slices:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-journald.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-machine-id-commit.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-modules-load.service:
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrmachine.service: {arch: [amd64, arm64, riscv64]}
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase-sysinit.service: {arch: [amd64, arm64, riscv64]}
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrmachine.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase-sysinit.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-pcrphase.service:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/sysinit.target.wants/systemd-random-seed.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-sysctl.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-sysusers.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev.service:
       /usr/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup.service:
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup-early.service: {arch: [amd64, arm64, riscv64]}
-      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup.service: {arch: [amd64, arm64, riscv64]}
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup-early.service:
+        arch: [amd64, arm64, riscv64]
+      /usr/lib/systemd/system/sysinit.target.wants/systemd-tpm2-setup.service:
+        arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/system/sysinit.target.wants/systemd-update-done.service:
       /usr/lib/systemd/system/syslog.socket:
       /usr/lib/systemd/system/system-update-cleanup.service:
@@ -349,7 +363,8 @@ slices:
       /usr/lib/systemd/system/systemd-battery-check.service:
       /usr/lib/systemd/system/systemd-binfmt.service:
       /usr/lib/systemd/system/systemd-boot-check-no-failures.service:
-      /usr/lib/systemd/system/systemd-bsod.service: {arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]}
+      /usr/lib/systemd/system/systemd-bsod.service:
+        arch: [amd64, arm64, riscv64, ppc64el, armhf, s390x]
       /usr/lib/systemd/system/systemd-confext.service:
       /usr/lib/systemd/system/systemd-creds.socket:
       /usr/lib/systemd/system/systemd-creds@.service:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -159,7 +159,6 @@ slices:
     contents:
       /usr/lib/systemd/network/80-6rd-tunnel.link:
       /usr/lib/systemd/network/80-6rd-tunnel.network:
-      /usr/lib/systemd/network/80-auto-link-local.network.example:
       /usr/lib/systemd/network/80-container-host0-tun.network:
       /usr/lib/systemd/network/80-container-host0.network:
       /usr/lib/systemd/network/80-container-vb.link:
@@ -171,9 +170,6 @@ slices:
       /usr/lib/systemd/network/80-vm-vt.link:
       /usr/lib/systemd/network/80-vm-vt.network:
       /usr/lib/systemd/network/80-wifi-adhoc.network:
-      /usr/lib/systemd/network/80-wifi-ap.network.example:
-      /usr/lib/systemd/network/80-wifi-station.network.example:
-      /usr/lib/systemd/network/89-ethernet.network.example:
 
   system-generators:
     contents:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -8,15 +8,7 @@ slices:
     essential:
       - libacl1_libs
       - libapparmor1_libs
-      - libaudit1_libs
-      - libblkid1_libs
       - libc6_libs
-      - libcap2_libs
-      - libcryptsetup12_libs
-      - libfdisk1_libs
-      - libgcrypt20_libs
-      - libkmod2_libs
-      - liblz4-1_libs
       - liblzma5_libs
       - libmount1_libs
       - libpam0g_libs
@@ -25,7 +17,6 @@ slices:
       - libssl3t64_libs
       - libsystemd-shared_libs
       - libsystemd0_libs
-      - libzstd1_libs
       - mount_bins
       - systemd_catalog
       - systemd_config

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -88,9 +88,9 @@ slices:
       /usr/lib/systemd/systemd-measure:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-modules-load:
+      /usr/lib/systemd/systemd-network-generator:
       /usr/lib/systemd/systemd-networkd:
       /usr/lib/systemd/systemd-networkd-wait-online:
-      /usr/lib/systemd/systemd-network-generator:
       /usr/lib/systemd/systemd-pcrextend:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-pcrlock:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -66,6 +66,7 @@ slices:
       /usr/bin/timedatectl:
       /usr/bin/varlinkctl:
       /usr/lib/lsb/init-functions.d/40-systemd:
+      /usr/lib/systemd/systemd:
       /usr/lib/systemd/systemd-backlight:
       /usr/lib/systemd/systemd-battery-check:
       /usr/lib/systemd/systemd-binfmt:
@@ -87,9 +88,9 @@ slices:
       /usr/lib/systemd/systemd-measure:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-modules-load:
-      /usr/lib/systemd/systemd-network-generator:
-      /usr/lib/systemd/systemd-networkd-wait-online:
       /usr/lib/systemd/systemd-networkd:
+      /usr/lib/systemd/systemd-networkd-wait-online:
+      /usr/lib/systemd/systemd-network-generator:
       /usr/lib/systemd/systemd-pcrextend:
         arch: [amd64, arm64, riscv64]
       /usr/lib/systemd/systemd-pcrlock:
@@ -117,7 +118,7 @@ slices:
       /usr/lib/systemd/systemd-user-sessions:
       /usr/lib/systemd/systemd-volatile-root:
       /usr/lib/systemd/systemd-xdg-autostart-condition:
-      /usr/lib/systemd/systemd:
+      
 
   catalog:
     contents:

--- a/tests/spread/integration/systemd/task.yaml
+++ b/tests/spread/integration/systemd/task.yaml
@@ -1,0 +1,15 @@
+summary: Integration tests for systemd
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices bash_bins coreutils_bins passwd_config base-files_base systemd_bins)"
+  
+  # systemd needs proc mounted
+  mkdir "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+
+  cp test.sh "${rootfs}/"
+  chroot "${rootfs}/" /test.sh
+
+  umount "${rootfs}"/proc

--- a/tests/spread/integration/systemd/test.sh
+++ b/tests/spread/integration/systemd/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Run some smoke-tests by invoking a couple of commands
+# from systemd to verify it's doing exactly what we expect
+# it to
+systemctl disable getty@tty1.service
+! test -f "/etc/systemd/system/getty.target.wants/getty@tty1.service"
+
+systemctl enable getty@tty1.service
+test -f "/etc/systemd/system/getty.target.wants/getty@tty1.service"
+
+# run preset-all and test for one of the expected symlinks
+systemctl preset-all
+test -f "/etc/systemd/system/ctrl-alt-del.target"
+
+# Run some auxiliary commands to ensure they don't fail
+systemd --help
+journalctl --update-catalog


### PR DESCRIPTION
# Included in this PR:
- Portforward of systemd from `ubuntu-24.04`

**Note: These changes need a close second review. The current test coverage is not sufficient entirely certain these changes are correct**

### Diff: canonical:ubuntu-24.04 <--> clay-lake:25.04/systemd
- [slices/systemd.yaml](https://pastebin.ubuntu.com/p/SQKMdbtPhW/)
