### PR TITLE
fix(25.04): Uncomment Chisel Manifest Generation Slice

### DIFF
--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -66,12 +66,12 @@ slices:
       /etc/os-release:
       /usr/lib/os-release:
 
-  # # Dedicated slice for generating the Chisel manifest.
-  # chisel:
-  #   essential:
-  #     - base-files_var
-  #   contents:
-  #     /var/lib/chisel/**: {generate: manifest}
+  # Dedicated slice for generating the Chisel manifest.
+  chisel:
+    essential:
+      - base-files_var
+    contents:
+      /var/lib/chisel/**: {generate: manifest}
 
   copyright:
     contents:


### PR DESCRIPTION
# Included in this PR:
-  Uncomment the base-files_chisel slice which was disabled during the release of 25.04.