### PR TITLE
ci: improve execution times for install-slices

### DIFF
--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -292,7 +292,7 @@ def install_slices(chunk: tuple, dry_run: bool, arch: str, release: str) -> None
         if dry_run:
             continue
         with tempfile.TemporaryDirectory() as tmpfs, tempfile.TemporaryDirectory() as cache_dir:
-            os.environ["CHISEL_PKG_CACHE"] = str(cache_dir)
+            os.environ["XDG_CACHE_HOME"] = str(cache_dir)
             res = subprocess.run(
                 args=[
                     "chisel",

--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -21,6 +21,8 @@ options:
 """
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import math
 from apt.debfile import DebPackage
 from dataclasses import dataclass
 import logging
@@ -31,7 +33,6 @@ import subprocess
 import tempfile
 import sys
 
-import apt_pkg
 import requests
 import yaml
 
@@ -46,11 +47,22 @@ class MissingCopyright(Exception):
 def configure_logging() -> None:
     """
     Configure the logging options for this script.
+    Logs INFO and above to stdout, and ERROR and above to error.log.
     """
-    logging.basicConfig(
-        format="%(levelname)s: %(message)s",
-        level=logging.INFO,
+    # Console handler for INFO and above
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+    # File handler for ERROR and above
+    file_handler = logging.FileHandler("error.log")
+    file_handler.setLevel(logging.ERROR)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
     )
+
+    # Root logger setup
+    logging.basicConfig(level=logging.INFO, handlers=[console_handler, file_handler])
 
 
 def parse_args() -> argparse.Namespace:
@@ -93,6 +105,13 @@ def parse_args() -> argparse.Namespace:
         metavar="file",
         help="Chisel slice definition file(s)",
         nargs="*",
+    )
+    parser.add_argument(
+        "--workers",
+        required=False,
+        default=5,
+        type=int,
+        help="Number of workers to use for parallel installation (default: 5)",
     )
     return parser.parse_args()
 
@@ -263,41 +282,48 @@ def ignore_missing_packages(
     return filtered, ignored
 
 
-def install_slice(
-    pkg: str, slice: str, arch: str, release: str, missing_copyright: set
-) -> None:
+def install_slices(chunk: tuple, dry_run: bool, arch: str, release: str) -> None:
     """
     Install the slice by running "chisel cut".
     """
-    slice_name = full_slice_name(pkg, slice)
-    logging.info("Installing %s on %s...", slice_name, arch)
-    with tempfile.TemporaryDirectory() as tmpfs:
-        res = subprocess.run(
-            args=[
-                "chisel",
-                "cut",
-                "--arch",
-                arch,
-                "--release",
-                release,
-                "--root",
-                tmpfs,
-                slice_name,
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if res.returncode != 0:
-            logging.error(
-                "==============================================\n%s",
-                res.stderr.rstrip(),
+    for pkg, slice in chunk:
+        slice_name = full_slice_name(pkg, slice)
+        logging.info("Installing %s on %s...", slice_name, arch)
+        if dry_run:
+            continue
+        with tempfile.TemporaryDirectory() as tmpfs:
+            res = subprocess.run(
+                args=[
+                    "chisel",
+                    "cut",
+                    "--arch",
+                    arch,
+                    "--release",
+                    release,
+                    "--root",
+                    tmpfs,
+                    slice_name,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
             )
-            sys.exit(res.returncode)
-        # Check if the copyright file has been installed with this slice
-        copyright_file = pathlib.Path(f"{tmpfs}/usr/share/doc/{pkg}/copyright")
-        if not copyright_file.is_file() and not copyright_file.is_symlink():
-            missing_copyright.add(slice_name)
+            if res.returncode != 0:
+                logging.error(
+                    "==============================================\n%s",
+                    res.stderr.rstrip(),
+                )
+                return
+
+            # Check if the copyright file has been installed with this slice
+            copyright_file = pathlib.Path(f"{tmpfs}/usr/share/doc/{pkg}/copyright")
+            if not copyright_file.is_file() and not copyright_file.is_symlink():
+                # Does the copyright file exist in the deb?
+                if deb_has_copyright_file(pkg):
+                    err = "{} has a copyright file but it wasn't installed.".format(
+                        pkg,
+                    )
+                    logging.error(err)
 
 
 def deb_has_copyright_file(pkg: str) -> bool:
@@ -359,43 +385,33 @@ def main() -> None:
                 logging.info("  - %s", pkg.package)
     #
     if len(packages) > 0:
-        logging.info("Slices of the following packages will be INSTALLED:")
+        logging.info(
+            "Slices of the following packages will be INSTALLED (parallelization=%s):",
+            cli_args.workers,
+        )
         for pkg in packages:
             logging.info("  - %s", pkg.package)
     else:
         logging.info("No slices will be installed.")
         return
-    # Install the slices in each package.
-    for pkg in packages:
-        # Keep track of whether the copyright file is installed on every "cut"
-        # This should always be the case, whether enforced by a global "essential"
-        # or Chisel itself. Exception: the copyright file will not be installed
-        # if it doesn't exist in the deb itself.
-        missing_copyright = set()
-        for slice in pkg.slices:
-            if cli_args.dry_run:
-                logging.info(
-                    "Installing %s on %s... (--dry-run)",
-                    full_slice_name(pkg.package, slice),
-                    cli_args.arch,
-                )
-            else:
-                install_slice(
-                    pkg.package,
-                    slice,
-                    cli_args.arch,
-                    cli_args.release,
-                    missing_copyright,
-                )
 
-        if len(missing_copyright) > 0:
-            # Does the copyright file exist in the deb?
-            if deb_has_copyright_file(pkg.package):
-                err = "{} has a copyright file but it wasn't installed with: {}".format(
-                    pkg.package,
-                    ",".join(missing_copyright),
-                )
-                raise MissingCopyright(err)
+    all_slices = [(pkg.package, slice) for slice in pkg.slices for pkg in packages]
+    chunk_size = math.ceil(len(all_slices) / cli_args.workers)
+    chunks_of_slices = [
+        (
+            all_slices[i : i + chunk_size],
+            cli_args.dry_run,
+            cli_args.arch,
+            cli_args.release,
+        )
+        for i in range(0, len(all_slices), chunk_size)
+    ]
+
+    with ProcessPoolExecutor() as executor:
+        futures = [
+            executor.submit(install_slices, *chunk) for chunk in chunks_of_slices
+        ]
+        _ = [future.result() for future in as_completed(futures)]
 
 
 if __name__ == "__main__":

--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -291,7 +291,8 @@ def install_slices(chunk: tuple, dry_run: bool, arch: str, release: str) -> None
         logging.info("Installing %s on %s...", slice_name, arch)
         if dry_run:
             continue
-        with tempfile.TemporaryDirectory() as tmpfs:
+        with tempfile.TemporaryDirectory() as tmpfs, tempfile.TemporaryDirectory() as cache_dir:
+            os.environ["CHISEL_PKG_CACHE"] = str(cache_dir)
             res = subprocess.run(
                 args=[
                     "chisel",
@@ -395,7 +396,7 @@ def main() -> None:
         logging.info("No slices will be installed.")
         return
 
-    all_slices = [(pkg.package, slice) for slice in pkg.slices for pkg in packages]
+    all_slices = [(pkg.package, slice) for pkg in packages for slice in pkg.slices]
     chunk_size = math.ceil(len(all_slices) / cli_args.workers)
     chunks_of_slices = [
         (

--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -308,6 +308,7 @@ def install_slices(chunk: tuple, dry_run: bool, arch: str, release: str) -> None
                 capture_output=True,
                 text=True,
                 check=False,
+                env=os.environ,
             )
             if res.returncode != 0:
                 logging.error(

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Check installation errors
         run: |
-          if [ ! -s error.log ]; then
+          if [ -s error.log ]; then
             echo "Installation errors found:"
             cat error.log
             exit 1

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -172,6 +172,8 @@ jobs:
       #   future and propose improvements.
       #   See also https://github.com/canonical/chisel-releases/pull/119#discussion_r1494785644
       - name: Install slices
+        env:
+          WORKERS: 20
         run: |
           set -ex
           if [[
@@ -184,11 +186,21 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
+              --workers "${WORKERS}" \
               slices/**/*.yaml
           elif [[ "${{ steps.changed-paths.outputs.slices }}" == "true" ]]; then
             # Install slices from changed files.
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
+              --workers "${WORKERS}" \
               ${{ steps.changed-paths.outputs.slices_files }}
+          fi
+
+      - name: Check installation errors
+        run: |
+          if [ ! -s error.log ]; then
+            echo "Installation errors found:"
+            cat error.log
+            exit 1
           fi


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR replaces https://github.com/canonical/chisel-releases/pull/564.
What's in it?
 - instead of a whole new tool, this reused the existing Python scripts to parallelize the installation of slices.
 - there are further optimizations we can do, but we'll leave that to a future pr (https://github.com/canonical/chisel-releases/compare/main...cjdcordeiro:chisel-releases:main?expand=1#diff-3d1d030d16f41ef850ab3f3c4d8fa472461eb30d6f92cf3f7ea4960162bbc496R409)


## Related issues/PRs
<!-- If any -->
https://github.com/canonical/chisel-releases/pull/564


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->

Here are the tests and results:
 - example of a failed test: https://github.com/cjdcordeiro/chisel-releases/pull/28
   - it installs all slices before printing the fail report
 - example of a successful test: https://github.com/cjdcordeiro/chisel-releases/pull/27
 - example of a scheduled test: https://github.com/cjdcordeiro/chisel-releases/actions/runs/16000802923/job/45134995297

We can use the latter to compare the improvement of the execution times with existing workflows. For example:
 - the "install slices" step takes ~8m [here](https://github.com/cjdcordeiro/chisel-releases/actions/runs/16000802923/job/45134995215), while it used to take [~58 min](https://github.com/canonical/chisel-releases/actions/runs/15986832243/job/45092790399)

a similar pattern is verified on all other matrix cells of this job, if compared with existing runs of https://github.com/canonical/chisel-releases/actions/workflows/install-slices.yaml. Even when a specif arch/archive is slow, this new workflow still finished execution much faster.