### PR TITLE
fix(ci): PR triaging needs to happen on schedule

### DIFF
--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -1,8 +1,11 @@
 name: Triage PRs
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
+  # Using a schedule because events like pull_request only work if the workflow
+  # exists on the base (target) branch of the PR
+  schedule:
+    - cron: "* * * * *"
+  workflow_dispatch:
 
 jobs:
   add-reviewers:
@@ -13,12 +16,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ROCKSBOT_PR_TOKEN }}
           REVIEWERS: "slice-reviewers-guild"
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "team_reviewers[]=${{ env.REVIEWERS }}"
+          set -euxo pipefail
+          
+          for pr_number in `gh pr list -R ${{ github.repository }} \
+            --search "-review-requested:${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
+            || echo fail`
+            do
+              if [[ "$pr_number" == "fail" ]]
+              then
+                echo "ERR: couldn't search for PRs"
+                exit 1
+              fi
 
-          # Cannot use `gh pr edit`:
-          # https://github.com/cli/cli/issues/4844
+              echo "Requesting review from ${{ env.REVIEWERS }} on PR ${pr_number}"
+
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/${{ github.repository }}/pulls/${pr_number}/requested_reviewers \
+                -f "team_reviewers[]=${{ env.REVIEWERS }}"
+
+              # Cannot use `gh pr edit`:
+              # https://github.com/cli/cli/issues/4844
+          done

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.ROCKSBOT_PR_TOKEN }}
-          REVIEWERS: "slice-reviewers-guild"
+          REVIEWERS: "canonical/slice-reviewers-guild"
         run: |
           set -euxo pipefail
           
           for pr_number in `gh pr list -R ${{ github.repository }} \
-            --search "-review-requested:${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
+            --search "-team-review-requested:${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
             || echo fail`
             do
               if [[ "$pr_number" == "fail" ]]

--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -4,7 +4,7 @@ on:
   # Using a schedule because events like pull_request only work if the workflow
   # exists on the base (target) branch of the PR
   schedule:
-    - cron: "* * * * *"
+    - cron: "*/20 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

The triaging of PRs has only been running for `main`, because it relied on `pull_request_target` events, which very much like `pull_request`, only works if the workflow exists in the PR's base branch.

This fix makes the wf run on a schedule, adding the reviewers where they haven't been requested yet.

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Tested in https://github.com/cjdcordeiro/ci-playground/actions/runs/16298445252