### PR TITLE
chore: ubuntu-24.10 EOL

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -27,7 +27,6 @@ env:
       {"ref": "ubuntu-20.04", "chisel-versions": ["v1.0.0","main"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.0.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.0.0","main"]},
-      {"ref": "ubuntu-24.10", "chisel-versions": ["v1.0.0","main"]},
       {"ref": "ubuntu-25.04", "chisel-versions": ["v1.0.0","main"]}
     ]
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   # chisel-releases branches to lint on.
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-24.10","ubuntu-25.04"]') }}
+  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-25.04"]') }}
 
 jobs:
   prepare-lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ or when in doubt, you should simply reply and let the reviewers resolve it.
 
 > [!IMPORTANT]
 > All PRs must be forward ported! E.g. if opening a PR against
-> `ubuntu-24.04`, you must also forward port it to `ubuntu-24.10`, `ubuntu-25.04`,
+> `ubuntu-24.04`, you must also forward port it to `ubuntu-25.04`,
 > and so on, for all supported releases at the time of opening the PR.
 
 Please note that in order to get merged, PRs must first be approved at least by

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ the moment, the officially supported Chisel releases are:
 \- Mantic (EOL)
 - [ubuntu-24.04](https://github.com/canonical/chisel-releases/tree/ubuntu-24.04)
 \- Noble
-- [ubuntu-24.10](https://github.com/canonical/chisel-releases/tree/ubuntu-24.10)
-\- Oracular
 - [ubuntu-25.04](https://github.com/canonical/chisel-releases/tree/ubuntu-25.04)
 \- Plucky
 


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR removes Ubuntu 24.10 from the CI as it reached to its EOL

## Related issues/PRs
<!-- If any -->
N/A

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->
https://fridge.ubuntu.com/2025/07/10/ubuntu-24-10-oracular-oriole-reached-end-of-life-on-10th-july-2025/