### PR TITLE
fix(README): keep 24.10 ref as EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ the moment, the officially supported Chisel releases are:
 \- Mantic (EOL)
 - [ubuntu-24.04](https://github.com/canonical/chisel-releases/tree/ubuntu-24.04)
 \- Noble
+- [ubuntu-24.10](https://github.com/canonical/chisel-releases/tree/ubuntu-24.10)
+\- Oracular (EOL)
 - [ubuntu-25.04](https://github.com/canonical/chisel-releases/tree/ubuntu-25.04)
 \- Plucky
 


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This line was unintentionally removed in https://github.com/canonical/chisel-releases/pull/595 and flagged in https://github.com/canonical/chisel-releases/commit/5a7652a8b6f0ff674aa43bb60718a7a2eee593a7#r162272346

We should preserver EOL chisel-releases and mark them as such.

## Related issues/PRs
<!-- If any -->

https://github.com/canonical/chisel-releases/pull/595
