### PR TITLE
feat(24.04) subslice coreutils for php

### DIFF
--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -24,6 +24,7 @@ slices:
       - libgmp10_libs
       - libpcre2-8-0_libs
       - libselinux1_libs
+      - coreutils_echo
     contents:
       /usr/bin/[:
       /usr/bin/arch:
@@ -49,7 +50,6 @@ slices:
       /usr/bin/dircolors:
       /usr/bin/dirname:
       /usr/bin/du:
-      /usr/bin/echo:
       /usr/bin/expand:
       /usr/bin/factor:
       /usr/bin/false:
@@ -149,6 +149,12 @@ slices:
       - libselinux1_libs
     contents:
       /usr/bin/mkdir:
+
+  echo:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/echo:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -87,7 +87,6 @@ slices:
       /usr/bin/pinky:
       /usr/bin/pr:
       /usr/bin/printenv:
-      /usr/bin/printf:
       /usr/bin/ptx:
       /usr/bin/pwd:
       /usr/bin/realpath:
@@ -194,6 +193,12 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/touch:
+
+  printf:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/printf:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -27,6 +27,7 @@ slices:
       - coreutils_echo
       - coreutils_ln-utility
       - coreutils_rm-utility
+      - coreutils_readlink
 
     contents:
       /usr/bin/[:
@@ -87,7 +88,6 @@ slices:
       /usr/bin/printf:
       /usr/bin/ptx:
       /usr/bin/pwd:
-      /usr/bin/readlink:
       /usr/bin/realpath:
       /usr/bin/rmdir:
       /usr/bin/runcon:
@@ -169,6 +169,12 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/rm:
+  
+  readlink:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/readlink:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -12,10 +12,17 @@ slices:
 
   bins:
     essential:
+      - coreutils_dirname
+      - coreutils_echo
       - coreutils_env
       - coreutils_expr
       - coreutils_libs
+      - coreutils_ln-utility
       - coreutils_mkdir
+      - coreutils_readlink
+      - coreutils_rm-utility
+      - coreutils_sort
+      - coreutils_touch
       - libacl1_libs
       - libattr1_libs
       - libc6_libs
@@ -24,13 +31,6 @@ slices:
       - libgmp10_libs
       - libpcre2-8-0_libs
       - libselinux1_libs
-      - coreutils_echo
-      - coreutils_ln-utility
-      - coreutils_rm-utility
-      - coreutils_readlink
-      - coreutils_sort
-      - coreutils_dirname
-      - coreutils_touch
 
     contents:
       /usr/bin/[:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -30,6 +30,7 @@ slices:
       - coreutils_readlink
       - coreutils_sort
       - coreutils_dirname
+      - coreutils_touch
 
     contents:
       /usr/bin/[:
@@ -112,7 +113,6 @@ slices:
       /usr/bin/tee:
       /usr/bin/test:
       /usr/bin/timeout:
-      /usr/bin/touch:
       /usr/bin/tr:
       /usr/bin/true:
       /usr/bin/truncate:
@@ -188,6 +188,12 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/dirname:
+
+  touch:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/touch:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -25,6 +25,8 @@ slices:
       - libpcre2-8-0_libs
       - libselinux1_libs
       - coreutils_echo
+      - coreutils_ln-utility
+
     contents:
       /usr/bin/[:
       /usr/bin/arch:
@@ -62,7 +64,6 @@ slices:
       /usr/bin/install:
       /usr/bin/join:
       /usr/bin/link:
-      /usr/bin/ln:
       /usr/bin/logname:
       /usr/bin/ls:
       /usr/bin/md5sum:
@@ -155,6 +156,13 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/echo:
+
+  # NOTE: slice names must have at least 3 characters, so we can't just call this `ln`
+  ln-utility:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/ln:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -28,6 +28,7 @@ slices:
       - coreutils_ln-utility
       - coreutils_rm-utility
       - coreutils_readlink
+      - coreutils_sort
 
     contents:
       /usr/bin/[:
@@ -100,7 +101,6 @@ slices:
       /usr/bin/shred:
       /usr/bin/shuf:
       /usr/bin/sleep:
-      /usr/bin/sort:
       /usr/bin/split:
       /usr/bin/stat:
       /usr/bin/stdbuf:
@@ -175,6 +175,13 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/readlink:
+
+  sort:
+    essential:
+      - libc6_libs
+      - libssl3t64_libcrypto
+    contents:
+      /usr/bin/sort:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -29,6 +29,7 @@ slices:
       - coreutils_rm-utility
       - coreutils_readlink
       - coreutils_sort
+      - coreutils_dirname
 
     contents:
       /usr/bin/[:
@@ -53,7 +54,6 @@ slices:
       /usr/bin/df:
       /usr/bin/dir:
       /usr/bin/dircolors:
-      /usr/bin/dirname:
       /usr/bin/du:
       /usr/bin/expand:
       /usr/bin/factor:
@@ -182,6 +182,12 @@ slices:
       - libssl3t64_libcrypto
     contents:
       /usr/bin/sort:
+
+  dirname:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/dirname:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -26,6 +26,7 @@ slices:
       - libselinux1_libs
       - coreutils_echo
       - coreutils_ln-utility
+      - coreutils_rm-utility
 
     contents:
       /usr/bin/[:
@@ -88,7 +89,6 @@ slices:
       /usr/bin/pwd:
       /usr/bin/readlink:
       /usr/bin/realpath:
-      /usr/bin/rm:
       /usr/bin/rmdir:
       /usr/bin/runcon:
       /usr/bin/seq:
@@ -163,6 +163,12 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/ln:
+  
+  rm-utility:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/rm:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -163,13 +163,13 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/ln:
-  
+
   rm-utility:
     essential:
       - libc6_libs
     contents:
       /usr/bin/rm:
-  
+
   readlink:
     essential:
       - libc6_libs

--- a/slices/libssl3t64.yaml
+++ b/slices/libssl3t64.yaml
@@ -14,7 +14,7 @@ slices:
       /usr/lib/*-linux-*/engines-3/padlock.so:
       /usr/lib/*-linux-*/libssl.so.*:
       /usr/lib/*-linux-*/ossl-modules/legacy.so:
-  
+
   libcrypto:
     essential:
       - libc6_libs

--- a/slices/libssl3t64.yaml
+++ b/slices/libssl3t64.yaml
@@ -7,13 +7,19 @@ slices:
   libs:
     essential:
       - libc6_libs
+      - libssl3t64_libcrypto
     contents:
       /usr/lib/*-linux-*/engines-3/afalg.so:
       /usr/lib/*-linux-*/engines-3/loader_attic.so:
       /usr/lib/*-linux-*/engines-3/padlock.so:
-      /usr/lib/*-linux-*/libcrypto.so.*:
       /usr/lib/*-linux-*/libssl.so.*:
       /usr/lib/*-linux-*/ossl-modules/legacy.so:
+  
+  libcrypto:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libcrypto.so.*:
 
   copyright:
     contents:

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -54,3 +54,10 @@ execute: |
   rootfs_touch="$(install-slices coreutils_touch)"
   chroot "$rootfs_touch" touch test_file
   test -e "$rootfs_touch/test_file"
+
+  # test printf binary
+  rootfs_printf="$(install-slices coreutils_printf)"
+  test "$(chroot "$rootfs_printf" printf "hello\n" )" = "hello"
+  test "$(chroot "$rootfs_printf" printf "hello-%s\n" "world")" = "hello-world"
+  test "$(chroot "$rootfs_printf" printf "number: %d\n" 42)" = "number: 42"
+  test "$(chroot "$rootfs_printf" printf "float: %.2f\n" 3.14159)" = "float: 3.14"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -48,7 +48,7 @@ execute: |
   mkdir -p "$rootfs_dirname/foo/bar"
   touch "$rootfs_dirname/foo/bar/baz.txt"
   test "$(chroot "$rootfs_dirname" dirname /foo/bar/baz.txt)" = "/foo/bar"
-  test "$(chroot "$rootfs_dirname" dirname /foo/bar/)" = "/foo/bar"
+  test "$(chroot "$rootfs_dirname" dirname /foo/bar/)" = "/foo"
 
   # test touch binary
   rootfs_touch="$(install-slices coreutils_touch)"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -17,3 +17,10 @@ execute: |
   # test echo binary
   rootfs_echo="$(install-slices coreutils_echo)"
   chroot "$rootfs_echo" echo "Hello, World!"
+
+  # test ln binary
+  rootfs_ln="$(install-slices coreutils_ln)"
+  touch "$rootfs_ln/test_file"
+  chroot "$rootfs_ln" ln -s test_file test_link
+  test -L "$rootfs_ln/test_link"
+

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -49,3 +49,8 @@ execute: |
   touch "$rootfs_dirname/foo/bar/baz.txt"
   test "$(chroot "$rootfs_dirname" dirname /foo/bar/baz.txt)" = "/foo/bar"
   test "$(chroot "$rootfs_dirname" dirname /foo/bar/)" = "/foo/bar"
+
+  # test touch binary
+  rootfs_touch="$(install-slices coreutils_touch)"
+  chroot "$rootfs_touch" touch test_file
+  test -e "$rootfs_touch/test_file"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -42,3 +42,10 @@ execute: |
   chroot "$rootfs_sort" sort test_file > sorted_output
   # NOTE: sorted output has a trailing newline. replaced by hyphen to show better
   test "$(cat sorted_output | tr '\n' '-')" = "apple-banana-cherry-"
+
+  # test dirname binary
+  rootfs_dirname="$(install-slices coreutils_dirname)"
+  mkdir -p "$rootfs_dirname/foo/bar"
+  touch "$rootfs_dirname/foo/bar/baz.txt"
+  test "$(chroot "$rootfs_dirname" dirname /foo/bar/baz.txt)" = "/foo/bar"
+  test "$(chroot "$rootfs_dirname" dirname /foo/bar/)" = "/foo/bar"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -13,3 +13,7 @@ execute: |
   # test env
   rootfs_env="$(install-slices coreutils_env)"
   chroot "$rootfs_env" env --version
+
+  # test echo binary
+  rootfs_echo="$(install-slices coreutils_echo)"
+  chroot "$rootfs_echo" echo "Hello, World!"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -35,3 +35,10 @@ execute: |
   touch "$rootfs_readlink/test_file"
   ln -s test_file "$rootfs_readlink/test_link"
   chroot "$rootfs_readlink" readlink test_link | grep "test_file"
+
+  # test sort binary
+  rootfs_sort="$(install-slices coreutils_sort)"
+  echo -e "banana\napple\ncherry" > "$rootfs_sort/test_file"
+  chroot "$rootfs_sort" sort test_file > sorted_output
+  # NOTE: sorted output has a trailing newline. replaced by hyphen to show better
+  test "$(cat sorted_output | tr '\n' '-')" = "apple-banana-cherry-"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -19,7 +19,7 @@ execute: |
   chroot "$rootfs_echo" echo "Hello, World!"
 
   # test ln binary
-  rootfs_ln="$(install-slices coreutils_ln)"
+  rootfs_ln="$(install-slices coreutils_ln-utility)"
   touch "$rootfs_ln/test_file"
   chroot "$rootfs_ln" ln -s test_file test_link
   test -L "$rootfs_ln/test_link"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -30,4 +30,8 @@ execute: |
   chroot "$rootfs_rm" rm test_file
   test ! -e "$rootfs_rm/test_file"
 
-
+  # test readlink binary
+  rootfs_readlink="$(install-slices coreutils_readlink)"
+  touch "$rootfs_readlink/test_file"
+  ln -s test_file "$rootfs_readlink/test_link"
+  chroot "$rootfs_readlink" readlink test_link | grep "test_file"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -24,3 +24,10 @@ execute: |
   chroot "$rootfs_ln" ln -s test_file test_link
   test -L "$rootfs_ln/test_link"
 
+  # test rm binary
+  rootfs_rm="$(install-slices coreutils_rm-utility)"
+  touch "$rootfs_rm/test_file"
+  chroot "$rootfs_rm" rm test_file
+  test ! -e "$rootfs_rm/test_file"
+
+


### PR DESCRIPTION
# Proposed changes

As discussed in #592, the `coreutils_bins` slice is bringing in a lot of binaries which are not necessarily needed on per-use basis. This PR adds coreuitls subslices to use in the php 8.3 slices (see below for how these were determined).

### Forward porting

25.04: #606

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional information

The php shell scripts in question are in the `php-common` slice. some are in `usr/sbin` and some others in `usr/lib/php`

```
/usr/sbin/phpdismod -> phpenmod (symlink)
/usr/sbin/phpenmod
/usr/sbin/phpquery
/usr/lib/php/php-fpm-socket-helper
/usr/lib/php/php-helper
/usr/lib/php/php-maintscript-helper
/usr/lib/php/sessionclean
```

The candidates have been triaged with the following script:

```bash
#!/bin/bash

# all the binaries from coreutils
BINS="\[ arch b2sum base32 base64 basename basenc cat chcon chgrp chmod chown cksum comm cp csplit cut date dd df dir dircolors dirname du echo expand factor false fmt fold groups head hostid id install join link ln logname ls md5sum md5sum.textutils mkfifo mknod mktemp mv nice nl nohup nproc numfmt od paste pathchk pinky pr printenv printf ptx pwd readlink realpath rm rmdir runcon seq sha1sum sha224sum sha256sum sha384sum sha512sum shred shuf sleep sort split stat stdbuf stty sum sync tac tail tee test timeout touch tr true truncate tsort tty uname unexpand uniq unlink users vdir wc who whoami yes chroot mkdir"
BINS=($BINS)

IN=$*
if [ -z "$IN" ]; then
    echo "Usage: $0 <file1> <file2> ..."
    exit 1
fi

for in in $IN; do
    [ -f "$in" ] || continue # not a file
    echo "--- $in ---"
    for bin in "${BINS[@]}"; do
        # NOTE: search for `$bin ` with the space to attempt to avoid false positives
        N=$(grep -c "$bin " "$in")
        if [ "$N" -gt 0 ]; then
            echo $N $bin
        fi
    done
done
```

and then examined manually with e.g. `cat /usr/sbin/phpenmod | grep 'echo'`.

The results are:

### `phpdismod` / `phpenmod`

|bin|N|needed|
|-|-|-|
|`\[`|18|no*|
|`echo`|3|yes|
|`link`|4|no|
|`ln`|1|yes|
|`od`|6|no|
|`rm`|1|yes|

### phpquery

|bin|N|needed|
|-|-|-|
|`\[`|28|no*|
|`dir`|4|no|
|`echo`|4|yes|
|`id`|3|no|
|`link`|3|no|
|`od`|4|no|
|`readlink`|1|yes|
|`sort`|1|yes|

### php-fpm-socket-helper

|bin|N|needed|
|-|-|-|
|`\[`|2|no*|
|`install`|1|no|

### php-helper

|bin|N|needed|
|-|-|-|
|`\[`|12|no*|
|`dir`|6|no|
|`dirname`|2|yes|
|`echo`|9|yes|
|`printf`|2|no**|
|`rm`|4|yes|
|`touch`|3|yes|
|`mkdir`|3|yes|

### php-maintscript-helper

|bin|N|needed|
|-|-|-|
|`\[`|21|no*|
|`echo`|4|yes|
|`id`|1|no|
|`tail`|1|no|

### sessionclean

|bin|N|needed|
|-|-|-|
|`\[`|2|no*|
|`echo`|5|yes|
|`id`|1|no|
|`printf`|1|yes**|
|`sort`|2|yes|
|`touch`|2|yes|


`*` - `dash`'s inbuilt test was determined to have sufficient funtionality for the use cases in those scripts. the most complicated use occurs in `phpenmod`: `if [ "$versions" = "ALL" -o \( "$OPTARG" = "ALL" -a -n "$versions" \) ]; then`

`**` - `printf` in `php-helper` is used only as flag `-printf` to `find`, while `sessionclean` *does* use the `printf` bin


