### PR TITLE
feat(25.04) subslice coreutils for php

### DIFF
--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -152,8 +152,8 @@ slices:
   directory-listing:
     essential:
       - libc6_libs
-      - libselinux1_libs
       - libcap2_libs
+      - libselinux1_libs
     contents:
       /usr/bin/dir:
       /usr/bin/dircolors:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -402,6 +402,12 @@ slices:
     contents:
       /usr/bin/sort:
 
+  dirname:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/dirname:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -168,12 +168,12 @@ slices:
       - libattr1_libs
       - libc6_libs
       - libselinux1_libs
+      - coreutils_rm-utility
     contents:
       /usr/bin/cp:
       /usr/bin/dd:
       /usr/bin/install:
       /usr/bin/mv:
-      /usr/bin/rm:
       /usr/bin/shred:
 
   # Special file types -- This slice contains commands which create special
@@ -184,10 +184,10 @@ slices:
     essential:
       - libc6_libs
       - libselinux1_libs
+      - coreutils_mkdir
+      - coreutils_ln-utility
     contents:
       /usr/bin/link:
-      /usr/bin/ln:
-      /usr/bin/mkdir:
       /usr/bin/mkfifo:
       /usr/bin/mknod:
       /usr/bin/readlink:
@@ -225,8 +225,8 @@ slices:
   printing-text:
     essential:
       - libc6_libs
+      - coreutils_echo
     contents:
-      /usr/bin/echo:
       /usr/bin/printf:
       /usr/bin/yes:
 

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -377,6 +377,13 @@ slices:
     contents:
       /usr/bin/echo:
 
+  # NOTE: slice names must have at least 3 characters, so we can't just call this `ln`
+  ln-utility:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/ln:
+      
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -408,6 +408,12 @@ slices:
     contents:
       /usr/bin/dirname:
 
+  touch:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/touch:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -414,6 +414,12 @@ slices:
     contents:
       /usr/bin/touch:
 
+  printf:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/printf:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -164,11 +164,11 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/Basic-operations.html
   basic-operations:
     essential:
+      - coreutils_rm-utility
       - libacl1_libs
       - libattr1_libs
       - libc6_libs
       - libselinux1_libs
-      - coreutils_rm-utility
     contents:
       /usr/bin/cp:
       /usr/bin/dd:
@@ -182,11 +182,11 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/Special-file-types.html
   special-file-types:
     essential:
+      - coreutils_ln-utility
+      - coreutils_mkdir
+      - coreutils_readlink
       - libc6_libs
       - libselinux1_libs
-      - coreutils_mkdir
-      - coreutils_ln-utility
-      - coreutils_readlink
     contents:
       /usr/bin/link:
       /usr/bin/mkfifo:
@@ -198,8 +198,8 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/Changing-file-attributes.html
   changing-file-attributes:
     essential:
-      - libc6_libs
       - coreutils_touch
+      - libc6_libs
     contents:
       /usr/bin/chgrp:
       /usr/bin/chmod:
@@ -224,9 +224,9 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/Printing-text.html
   printing-text:
     essential:
-      - libc6_libs
       - coreutils_echo
       - coreutils_printf
+      - libc6_libs
     contents:
       /usr/bin/yes:
 
@@ -236,9 +236,9 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/Conditions.html
   conditions:
     essential:
+      - coreutils_expr
       - libc6_libs
       - libgmp10_libs
-      - coreutils_expr
     contents:
       /usr/bin/[:
       /usr/bin/false:
@@ -258,8 +258,8 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/File-name-manipulation.html
   file-name-manipulation:
     essential:
-      - libc6_libs
       - coreutils_dirname
+      - libc6_libs
     contents:
       /usr/bin/basename:
       /usr/bin/mktemp:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -396,6 +396,12 @@ slices:
     contents:
       /usr/bin/readlink:
 
+  sort:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/sort:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -371,6 +371,12 @@ slices:
     contents:
       /usr/bin/mkdir:
 
+  echo:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/echo:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -186,11 +186,11 @@ slices:
       - libselinux1_libs
       - coreutils_mkdir
       - coreutils_ln-utility
+      - coreutils_readlink
     contents:
       /usr/bin/link:
       /usr/bin/mkfifo:
       /usr/bin/mknod:
-      /usr/bin/readlink:
       /usr/bin/rmdir:
       /usr/bin/unlink:
 
@@ -389,6 +389,12 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/rm:
+  
+  readlink:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/readlink:
 
   copyright:
     contents:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -118,11 +118,11 @@ slices:
     essential:
       - libc6_libs
       - libssl3t64_libs
+      - coreutils_sort
     contents:
       /usr/bin/comm:
       /usr/bin/ptx:
       /usr/bin/shuf:
-      /usr/bin/sort:
       /usr/bin/tsort:
       /usr/bin/uniq:
 
@@ -199,11 +199,11 @@ slices:
   changing-file-attributes:
     essential:
       - libc6_libs
+      - coreutils_touch
     contents:
       /usr/bin/chgrp:
       /usr/bin/chmod:
       /usr/bin/chown:
-      /usr/bin/touch:
 
   # File space usage -- These commands report how much storage is in use or
   # available, report other file and file status information, and write buffers
@@ -226,8 +226,8 @@ slices:
     essential:
       - libc6_libs
       - coreutils_echo
+      - coreutils_printf
     contents:
-      /usr/bin/printf:
       /usr/bin/yes:
 
   # Conditions -- This slice contains commands that are primarily useful for
@@ -259,9 +259,9 @@ slices:
   file-name-manipulation:
     essential:
       - libc6_libs
+      - coreutils_dirname
     contents:
       /usr/bin/basename:
-      /usr/bin/dirname:
       /usr/bin/mktemp:
       /usr/bin/pathchk:
       /usr/bin/realpath:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -153,6 +153,7 @@ slices:
     essential:
       - libc6_libs
       - libselinux1_libs
+      - libcap2_libs
     contents:
       /usr/bin/dir:
       /usr/bin/dircolors:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -383,7 +383,13 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/ln:
-      
+    
+  rm-utility:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/rm:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -383,13 +383,13 @@ slices:
       - libc6_libs
     contents:
       /usr/bin/ln:
-    
+
   rm-utility:
     essential:
       - libc6_libs
     contents:
       /usr/bin/rm:
-  
+
   readlink:
     essential:
       - libc6_libs

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -363,6 +363,14 @@ slices:
     contents:
       /usr/bin/expr:
 
+  mkdir:
+    essential:
+      - libc6_libs
+      - libpcre2-8-0_libs
+      - libselinux1_libs
+    contents:
+      /usr/bin/mkdir:
+
   copyright:
     contents:
       /usr/share/doc/coreutils/copyright:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -287,6 +287,7 @@ slices:
     essential:
       - libc6_libs
       - libselinux1_libs
+      - libsystemd0_libs
     contents:
       /usr/bin/groups:
       /usr/bin/id:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -116,9 +116,9 @@ slices:
   # https://www.gnu.org/software/coreutils/manual/html_node/Operating-on-sorted-files.html
   operating-on-sorted-files:
     essential:
+      - coreutils_sort
       - libc6_libs
       - libssl3t64_libs
-      - coreutils_sort
     contents:
       /usr/bin/comm:
       /usr/bin/ptx:

--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -238,9 +238,9 @@ slices:
     essential:
       - libc6_libs
       - libgmp10_libs
+      - coreutils_expr
     contents:
       /usr/bin/[:
-      /usr/bin/expr:
       /usr/bin/false:
       /usr/bin/test:
       /usr/bin/true:
@@ -353,6 +353,15 @@ slices:
       /usr/bin/factor:
       /usr/bin/numfmt:
       /usr/bin/seq:
+
+  # Single-binary slices
+
+  expr:
+    essential:
+      - libc6_libs
+      - libgmp10_libs
+    contents:
+      /usr/bin/expr:
 
   copyright:
     contents:

--- a/tests/spread/integration/coreutils/smoke.sh
+++ b/tests/spread/integration/coreutils/smoke.sh
@@ -26,12 +26,34 @@ run_command() {
 }
 
 all_cmds=()
-slices=$(yq '.slices | keys | .[]' "${SDF}")
-for s in ${slices[@]}; do
-    if [[ "$s" == "libs" || "$s" == "bins" || "$s" == "copyright" ]]; then
-        continue
-    fi
 
+slices=(
+  output-of-entire-files
+  formatting-file-contents
+  output-of-parts-of-files
+  summarizing-files
+  operating-on-sorted-files
+  operating-on-fields
+  operating-on-characters
+  directory-listing
+  basic-operations
+  special-file-types
+  changing-file-attributes
+  file-space-usage
+  printing-text
+  conditions
+  redirection
+  file-name-manipulation
+  working-context
+  user-information
+  system-context
+  selinux-context
+  modified-command-invocation
+  delaying
+  numeric-operations
+)
+
+for s in ${slices[@]}; do
     slice="coreutils_$s"
     echo "Testing $slice ..."
     install_slices "$slice"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -20,3 +20,8 @@ execute: |
   rootfs_env="$(install-slices coreutils_env)"
   chroot "$rootfs_env" env --version
 
+  # test expr binary
+  rootfs_expr="$(install-slices coreutils_expr)"
+  chroot "$rootfs_expr" expr --version
+
+

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -29,3 +29,6 @@ execute: |
   chroot "$rootfs_mkdir" mkdir test_dir
   test -d "$rootfs_mkdir/test_dir"
 
+  # test echo binary
+  rootfs_echo="$(install-slices coreutils_echo)"
+  chroot "$rootfs_echo" echo "Hello, World!"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -24,4 +24,8 @@ execute: |
   rootfs_expr="$(install-slices coreutils_expr)"
   chroot "$rootfs_expr" expr --version
 
+  # test mkdir binary
+  rootfs_mkdir="$(install-slices coreutils_mkdir)"
+  chroot "$rootfs_mkdir" mkdir test_dir
+  test -d "$rootfs_mkdir/test_dir"
 

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -12,3 +12,11 @@ prepare: |
 execute: |
   # Run smoke tests.
   ./smoke.sh
+
+  # Run single-binary slices tests
+  # Forward port from 24.04
+
+  # test env
+  rootfs_env="$(install-slices coreutils_env)"
+  chroot "$rootfs_env" env --version
+

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -57,3 +57,10 @@ execute: |
   chroot "$rootfs_sort" sort test_file > sorted_output
   # NOTE: sorted output has a trailing newline. replaced by hyphen to show better
   test "$(cat sorted_output | tr '\n' '-')" = "apple-banana-cherry-"
+
+  # test dirname binary
+  rootfs_dirname="$(install-slices coreutils_dirname)"
+  mkdir -p "$rootfs_dirname/foo/bar"
+  touch "$rootfs_dirname/foo/bar/baz.txt"
+  test "$(chroot "$rootfs_dirname" dirname /foo/bar/baz.txt)" = "/foo/bar"
+  test "$(chroot "$rootfs_dirname" dirname /foo/bar/)" = "/foo"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -38,3 +38,9 @@ execute: |
   touch "$rootfs_ln/test_file"
   chroot "$rootfs_ln" ln -s test_file test_link
   test -L "$rootfs_ln/test_link"
+
+  # test rm binary
+  rootfs_rm="$(install-slices coreutils_rm-utility)"
+  touch "$rootfs_rm/test_file"
+  chroot "$rootfs_rm" rm test_file
+  test ! -e "$rootfs_rm/test_file"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -69,3 +69,10 @@ execute: |
   rootfs_touch="$(install-slices coreutils_touch)"
   chroot "$rootfs_touch" touch test_file
   test -e "$rootfs_touch/test_file"
+
+  # test printf binary
+  rootfs_printf="$(install-slices coreutils_printf)"
+  test "$(chroot "$rootfs_printf" printf "hello\n" )" = "hello"
+  test "$(chroot "$rootfs_printf" printf "hello-%s\n" "world")" = "hello-world"
+  test "$(chroot "$rootfs_printf" printf "number: %d\n" 42)" = "number: 42"
+  test "$(chroot "$rootfs_printf" printf "float: %.2f\n" 3.14159)" = "float: 3.14"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -44,3 +44,9 @@ execute: |
   touch "$rootfs_rm/test_file"
   chroot "$rootfs_rm" rm test_file
   test ! -e "$rootfs_rm/test_file"
+
+  # test readlink binary
+  rootfs_readlink="$(install-slices coreutils_readlink)"
+  touch "$rootfs_readlink/test_file"
+  ln -s test_file "$rootfs_readlink/test_link"
+  chroot "$rootfs_readlink" readlink test_link | grep "test_file"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -64,3 +64,8 @@ execute: |
   touch "$rootfs_dirname/foo/bar/baz.txt"
   test "$(chroot "$rootfs_dirname" dirname /foo/bar/baz.txt)" = "/foo/bar"
   test "$(chroot "$rootfs_dirname" dirname /foo/bar/)" = "/foo"
+
+  # test touch binary
+  rootfs_touch="$(install-slices coreutils_touch)"
+  chroot "$rootfs_touch" touch test_file
+  test -e "$rootfs_touch/test_file"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -32,3 +32,9 @@ execute: |
   # test echo binary
   rootfs_echo="$(install-slices coreutils_echo)"
   chroot "$rootfs_echo" echo "Hello, World!"
+
+  # test ln binary
+  rootfs_ln="$(install-slices coreutils_ln-utility)"
+  touch "$rootfs_ln/test_file"
+  chroot "$rootfs_ln" ln -s test_file test_link
+  test -L "$rootfs_ln/test_link"

--- a/tests/spread/integration/coreutils/task.yaml
+++ b/tests/spread/integration/coreutils/task.yaml
@@ -50,3 +50,10 @@ execute: |
   touch "$rootfs_readlink/test_file"
   ln -s test_file "$rootfs_readlink/test_link"
   chroot "$rootfs_readlink" readlink test_link | grep "test_file"
+
+  # test sort binary
+  rootfs_sort="$(install-slices coreutils_sort)"
+  echo -e "banana\napple\ncherry" > "$rootfs_sort/test_file"
+  chroot "$rootfs_sort" sort test_file > sorted_output
+  # NOTE: sorted output has a trailing newline. replaced by hyphen to show better
+  test "$(cat sorted_output | tr '\n' '-')" = "apple-banana-cherry-"


### PR DESCRIPTION
# Proposed changes

Forward port of #605. coreutils in plucky seems to have already been sliced into groups according to the [GNU coreutils manual](https://www.gnu.org/software/coreutils/manual/html_node/index.html) chapter headings. I've added the single-binary slices as well as the tests, in the same format as in the noble pr.

Note:
 - i *have* gone through the bash script dependencies of the php 2.96 in plucky again, just to be sure. they are the same.
 - `sort` in plucky, unlike in noble, does *not* depend on `libssl3t64`

### Forward porting

N/A

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)