### PR TITLE
25.04/add criu deps

### DIFF
--- a/slices/libjansson4.yaml
+++ b/slices/libjansson4.yaml
@@ -1,0 +1,15 @@
+package: libjansson4
+
+essential:
+  - libjansson4_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libjansson.so.4*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libjansson4/copyright:

--- a/slices/libnet1.yaml
+++ b/slices/libnet1.yaml
@@ -1,0 +1,15 @@
+package: libnet1
+
+essential:
+  - libnet1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnet.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnet1/copyright:

--- a/slices/libnftables1.yaml
+++ b/slices/libnftables1.yaml
@@ -1,0 +1,20 @@
+package: libnftables1
+
+essential:
+  - libnftables1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgmp10_libs
+      - libjansson4_libs
+      - libmnl0_libs
+      - libnftnl11_libs
+      - libxtables12_libs
+    contents:
+      /usr/lib/*-linux-*/libnftables.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnftables1/copyright:

--- a/slices/libnl-3-200.yaml
+++ b/slices/libnl-3-200.yaml
@@ -1,0 +1,20 @@
+package: libnl-3-200
+
+essential:
+  - libnl-3-200_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libnl-3.so.200*:
+
+  etc:
+    contents:
+      /etc/libnl-3/classid:
+      /etc/libnl-3/pktloc:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-3-200/copyright:

--- a/slices/libprotobuf-c1.yaml
+++ b/slices/libprotobuf-c1.yaml
@@ -1,0 +1,15 @@
+package: libprotobuf-c1
+
+essential:
+  - libprotobuf-c1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libprotobuf-c.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libprotobuf-c1/copyright:

--- a/tests/spread/integration/libnet1/task.yaml
+++ b/tests/spread/integration/libnet1/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libnet1
+
+execute: |
+  rootfs="$(install-slices libnet1_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libnet.so.1

--- a/tests/spread/integration/libnftables1/task.yaml
+++ b/tests/spread/integration/libnftables1/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libnftables1
+
+execute: |
+  rootfs="$(install-slices libnftables1_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libnftables.so.1

--- a/tests/spread/integration/libnjasson4/task.yaml
+++ b/tests/spread/integration/libnjasson4/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libjansson4
+
+execute: |
+  rootfs="$(install-slices libjansson4_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libjansson.so.4

--- a/tests/spread/integration/libnl-3-200/task.yaml
+++ b/tests/spread/integration/libnl-3-200/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libnl-3-200
+
+execute: |
+  rootfs="$(install-slices libnl-3-200_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libnl-3.so.200

--- a/tests/spread/integration/libprotobuf-c1/task.yaml
+++ b/tests/spread/integration/libprotobuf-c1/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libprotobuf-c1
+
+execute: |
+  rootfs="$(install-slices libprotobuf-c1_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libprotobuf-c.so.1


### PR DESCRIPTION
# Proposed changes

Add criu missing dependencies:

libjansson4_libs
libnet1_libs
libnftables1_libs
libnl-3-200_libs
libprotobuf-c1_libs

## Related issues/PRs

- #586 

### Forward porting

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
