### PR TITLE
feat(25.04): add SONiC docker-database related slices #603

### DIFF
--- a/slices/libboost-serialization1.83.0.yaml
+++ b/slices/libboost-serialization1.83.0.yaml
@@ -1,0 +1,18 @@
+package: libboost-serialization1.83.0
+
+essential:
+  - libboost-serialization1.83.0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libboost_serialization.so.1.83.0:
+      /usr/lib/*-linux-*/libboost_wserialization.so.1.83.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libboost-serialization1.83.0/copyright:

--- a/slices/libestr0.yaml
+++ b/slices/libestr0.yaml
@@ -1,0 +1,15 @@
+package: libestr0
+
+essential:
+  - libestr0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libestr.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libestr0/copyright:

--- a/slices/libfastjson4.yaml
+++ b/slices/libfastjson4.yaml
@@ -1,0 +1,15 @@
+package: libfastjson4
+
+essential:
+  - libfastjson4_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libfastjson.so.4*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfastjson4/copyright:

--- a/slices/libnl-3-200.yaml
+++ b/slices/libnl-3-200.yaml
@@ -1,0 +1,22 @@
+package: libnl-3-200
+
+essential:
+  - libnl-3-200_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnl-3-200_config
+    contents:
+      /usr/lib/*-linux-*/libnl-3.so.200:
+      /usr/lib/*-linux-*/libnl-3.so.200.26.0:
+
+  config:
+    contents:
+      /etc/libnl-3/classid:
+      /etc/libnl-3/pktloc:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-3-200/copyright:

--- a/slices/libnl-cli-3-200.yaml
+++ b/slices/libnl-cli-3-200.yaml
@@ -1,0 +1,22 @@
+package: libnl-cli-3-200
+
+essential:
+  - libnl-cli-3-200_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnl-3-200_libs
+      - libnl-genl-3-200_libs
+      - libnl-nf-3-200_libs
+      - libnl-route-3-200_libs
+    contents:
+      /usr/lib/*-linux-*/libnl-3/cli/cls/*.so:
+      /usr/lib/*-linux-*/libnl-3/cli/qdisc/*.so:
+      /usr/lib/*-linux-*/libnl-cli-3.so.200:
+      /usr/lib/*-linux-*/libnl-cli-3.so.200.26.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-cli-3-200/copyright:

--- a/slices/libnl-genl-3-200.yaml
+++ b/slices/libnl-genl-3-200.yaml
@@ -1,0 +1,17 @@
+package: libnl-genl-3-200
+
+essential:
+  - libnl-genl-3-200_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnl-3-200_libs
+    contents:
+      /usr/lib/*-linux-*/libnl-genl-3.so.200:
+      /usr/lib/*-linux-*/libnl-genl-3.so.200.26.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-genl-3-200/copyright:

--- a/slices/libnl-nf-3-200.yaml
+++ b/slices/libnl-nf-3-200.yaml
@@ -1,0 +1,18 @@
+package: libnl-nf-3-200
+
+essential:
+  - libnl-nf-3-200_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnl-3-200_libs
+      - libnl-route-3-200_libs
+    contents:
+      /usr/lib/*-linux-*/libnl-nf-3.so.200:
+      /usr/lib/*-linux-*/libnl-nf-3.so.200.26.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-nf-3-200/copyright:

--- a/slices/libnl-route-3-200.yaml
+++ b/slices/libnl-route-3-200.yaml
@@ -1,0 +1,17 @@
+package: libnl-route-3-200
+
+essential:
+  - libnl-route-3-200_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libnl-3-200_libs
+    contents:
+      /usr/lib/*-linux-*/libnl-route-3.so.200:
+      /usr/lib/*-linux-*/libnl-route-3.so.200.26.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-route-3-200/copyright:

--- a/slices/libpython3.12t64.yaml
+++ b/slices/libpython3.12t64.yaml
@@ -1,0 +1,12 @@
+package: libpython3.12t64
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libexpat1_libs
+      - libpython3.12-stdlib_core
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libpython3.12.so.1:
+      /usr/lib/*-linux-*/libpython3.12.so.1.0:

--- a/slices/rsyslog.yaml
+++ b/slices/rsyslog.yaml
@@ -1,0 +1,46 @@
+package: rsyslog
+
+essential:
+  - rsyslog_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libestr0_libs
+      - libfastjson4_libs
+      - libsystemd0_libs
+      - libuuid1_libs
+      - libzstd1_libs
+      - rsyslog_config
+      - rsyslog_data
+      - zlib1g_libs
+    contents:
+      /usr/sbin/rsyslogd:
+
+  data:
+    contents:
+      /var/spool/rsyslog/:
+
+  config:
+    essential:
+      - rsyslog_libs
+    contents:
+      /etc/logcheck/ignore.d.server/rsyslog:
+      /etc/logrotate.d/rsyslog:
+      /etc/rsyslog.conf:
+      /etc/rsyslog.d/50-default.conf:
+        copy: /usr/share/rsyslog/50-default.conf
+      /etc/systemd/system/multi-user.target.wants/rsyslog.service:
+        symlink: /usr/lib/systemd/system/rsyslog.service
+
+  libs:
+    contents:
+      /usr/lib/*-linux-*/rsyslog/*.so:
+      /usr/lib/rsyslog/rsyslog-rotate:
+      /usr/lib/systemd/system/rsyslog.service:
+      /usr/lib/tmpfiles.d/00rsyslog.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/rsyslog/copyright:

--- a/tests/spread/integration/libbpf1/task.yaml
+++ b/tests/spread/integration/libbpf1/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for libbpf1
+
+execute: |
+  rootfs="$(install-slices libbpf1_libs)"
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+  test -f ${rootfs}/usr/lib/${arch}/libbpf.so.1

--- a/tests/spread/integration/libestr0/task.yaml
+++ b/tests/spread/integration/libestr0/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for libestr0
+
+execute: |
+  rootfs="$(install-slices libestr0_libs)"
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+  test -f ${rootfs}/usr/lib/${arch}/libestr.so.0

--- a/tests/spread/integration/libfastjson4/task.yaml
+++ b/tests/spread/integration/libfastjson4/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for libfastjson4
+
+execute: |
+  rootfs="$(install-slices libfastjson4_libs)"
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+  test -f ${rootfs}/usr/lib/${arch}/libfastjson.so.4

--- a/tests/spread/integration/rsyslog/task.yaml
+++ b/tests/spread/integration/rsyslog/task.yaml
@@ -1,0 +1,21 @@
+summary: Integration tests for rsyslog
+
+execute: |
+  rootfs="$(install-slices base-passwd_data base-files_base rsyslog_bins)"
+  
+  mkdir "${rootfs}"/proc
+  mount --bind /proc ${rootfs}/proc
+  
+  mkdir "${rootfs}"/dev
+  mount --bind /dev ${rootfs}/dev
+  sed -i 's/^\($FileOwner[[:space:]]\+\)syslog/\1root/' "${rootfs}/etc/rsyslog.conf"
+  sed -i 's/^\($PrivDropToUser[[:space:]]\+\)syslog/\1root/' "${rootfs}/etc/rsyslog.conf"
+  sed -i 's/^\($PrivDropToGroup[[:space:]]\+\)syslog/\1root/' "${rootfs}/etc/rsyslog.conf"
+  
+  chroot ${rootfs} /usr/sbin/rsyslogd
+  pkill rsyslogd
+  # pkill is asynchronous because it sends a Linux signal to kill the process
+  # Sleep for a while to ensure rsyslogd has time to terminate before `umount`
+  sleep 1
+  umount ${rootfs}/proc
+  umount ${rootfs}/dev


### PR DESCRIPTION
# Proposed changes

This PR add slices for the packages used in [docker database](https://github.com/canonical/sonic-buildimage/blob/refract/rock/dockers/docker-database/rockcraft.yaml), used by SONiC on Ubuntu. These are the SDF(s) included in this PR:

* iproute2
  * libbpf1
* rsyslog
  * libestr0
  * libfastjson4
* libpcre3
* libnl-cli-3-200
  * libnl-3-200
  * libnl-route-3-200
  * libnl-nf-3-200
  * libnl-genl-3-200
* libboost-serialization1.83.0
* libpython3.12t64 (see additional context below)

### Forward porting
https://github.com/canonical/chisel-releases/pull/603

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

