### PR TITLE
feat: add template for issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,14 @@
+### Description
+
+<!-- A clear and concise description of the bug. Please mark
+your issue as one of: bug, ci, request, docs. If, for example,
+you have an issue with the `coreutils` slice, title it:
+`bug(coreutils): ...`
+-->
+
+### Steps to Reproduce
+
+<!-- If possible, explain the steps to reproduce the issue.
+Include any chisel commands you used. For example:
+`chisel cut --release ubuntu-24.04 --root rootfs my-package_my-slice`.
+-->


### PR DESCRIPTION
# Proposed changes

~~There is a template for PRs, but not for issues. This PR adds a simple issue template.~~

EDIT:

We are using a template for PRs, but we are not using a template for issues. This PR adds such a template.

## Related issues/PRs

### Forward porting

N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context