### PR TITLE
feat(25.04): add polkitd and dependencies

### DIFF
--- a/slices/dbus-broker.yaml
+++ b/slices/dbus-broker.yaml
@@ -1,0 +1,38 @@
+package: dbus-broker
+
+essential:
+  - dbus-broker_copyright
+
+slices:
+  bins:
+    essential:
+      - dbus-broker_catalog
+      - dbus-system-bus-common_config
+      - init-system-helpers_bins
+      - libapparmor1_libs
+      - libaudit1_libs
+      - libc6_libs
+      - libcap-ng0_libs
+      - libexpat1_libs
+      - libselinux1_libs
+      - libsystemd0_libs
+      - systemd-sysv_bins
+    contents:
+      /usr/bin/dbus-broker:
+      /usr/bin/dbus-broker-launch:
+
+  catalog:
+    contents:
+      /usr/lib/systemd/catalog/dbus-broker-launch.catalog:
+      /usr/lib/systemd/catalog/dbus-broker.catalog:
+
+  services:
+    essential:
+      - dbus-broker_bins
+    contents:
+      /usr/lib/systemd/system/dbus-broker.service:
+      /usr/lib/systemd/user/dbus-broker.service:
+
+  copyright:
+    contents:
+      /usr/share/doc/dbus-broker/copyright:

--- a/slices/libpolkit-agent-1-0.yaml
+++ b/slices/libpolkit-agent-1-0.yaml
@@ -1,0 +1,17 @@
+package: libpolkit-agent-1-0
+
+essential:
+  - libpolkit-agent-1-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libglib2.0-0t64_libs
+      - libpolkit-gobject-1-0_libs
+    contents:
+      /usr/lib/*-linux-*/libpolkit-agent-1.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpolkit-agent-1-0/copyright:

--- a/slices/libpolkit-gobject-1-0.yaml
+++ b/slices/libpolkit-gobject-1-0.yaml
@@ -1,0 +1,17 @@
+package: libpolkit-gobject-1-0
+
+essential:
+  - libpolkit-gobject-1-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libglib2.0-0t64_libs
+      - libsystemd0_libs
+    contents:
+      /usr/lib/*-linux-*/libpolkit-gobject-1.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpolkit-gobject-1-0/copyright:

--- a/slices/opensysusers.yaml
+++ b/slices/opensysusers.yaml
@@ -1,0 +1,27 @@
+package: opensysusers
+
+essential:
+  - opensysusers_copyright
+
+slices:
+# /usr/bin/systemd-sysusers is actually part of this package
+# aswell but conflicts with the systemd-sysusers inside the systemd
+# package.
+  scripts:
+    # These are shell scripts requiring a symlink from /usr/bin/dash to
+    # /usr/bin/sh.
+    essential:
+      - coreutils_sort
+      - dash_bins
+      - grep_bins
+      - passwd_bins
+    contents:
+      /usr/bin/opensysusers-sysusers:
+
+  initd:
+    contents:
+      /etc/init.d/opensysusers:
+
+  copyright:
+    contents:
+      /usr/share/doc/opensysusers/copyright:

--- a/slices/polkitd.yaml
+++ b/slices/polkitd.yaml
@@ -1,0 +1,72 @@
+package: polkitd
+
+essential:
+  - polkitd_copyright
+
+slices:
+  agent:
+    essential:
+      - dbus-broker_bins
+      - libc6_gconv
+      - libc6_libs
+      - libduktape207_libs
+      - libexpat1_libs
+      - libglib2.0-0t64_libs
+      - libpam0g_libs
+      - libpolkit-agent-1-0_libs
+      - libpolkit-gobject-1-0_libs
+      - libsystemd0_libs
+      - login_bins
+      - opensysusers_scripts
+      - polkitd_config
+      - polkitd_pam-profile
+      - polkitd_rules
+      - xml-core_catalog
+    contents:
+      /usr/lib/policykit-1/polkit-agent-helper-1:
+      /usr/lib/polkit-1/polkit-agent-helper-1:
+      /usr/lib/polkit-1/polkitd:
+      /usr/libexec/polkit-agent-helper-1:
+
+  # the polkit applications use the polkit agent
+  bins:
+    essential:
+      - polkitd_agent
+      - polkitd_services
+    contents:
+      /usr/bin/pkaction:
+      /usr/bin/pkcheck:
+      /usr/bin/pkttyagent:
+
+  config:
+    contents:
+      /usr/lib/sysusers.d/polkit.conf:
+      /usr/lib/tmpfiles.d/polkitd.conf:
+      /var/lib/polkit-1/: { make: true, mode: 0700 }
+
+  dbus-interface:
+    contents:
+      /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.service:
+      /usr/share/dbus-1/system.d/org.freedesktop.PolicyKit1.conf:
+
+  pam-profile:
+    contents:
+      /usr/lib/pam.d/polkit-1:
+
+  rules:
+    contents:
+      /etc/polkit-1/rules.d/: { make: true, mode: 0755 }
+      /usr/share/polkit-1/actions/org.freedesktop.policykit.policy:
+      /usr/share/polkit-1/policyconfig-1.dtd:
+      /usr/share/polkit-1/rules.d/49-ubuntu-admin.rules:
+      /usr/share/polkit-1/rules.d/50-default.rules:
+
+  services:
+    essential:
+      - polkitd_agent
+    contents:
+      /usr/lib/systemd/system/polkit.service:
+
+  copyright:
+    contents:
+      /usr/share/doc/polkitd/copyright:

--- a/slices/sgml-base.yaml
+++ b/slices/sgml-base.yaml
@@ -1,0 +1,47 @@
+package: sgml-base
+
+slices:
+  # also contains some binary debian helpers, they are
+  # used only to generate or update the xml catalogue.
+  # /usr/sbin/install-sgmlcatalog
+  # /usr/sbin/update-catalog
+
+  catalog:
+    contents:
+      /etc/sgml/catalog: { symlink: /var/lib/sgml-base/supercatalog }
+      /usr/share/sgml-base/catalog.centralized:
+      /usr/share/sgml-base/catalog.super:
+      /usr/share/sgml-base/transitional.cat:
+      /var/lib/sgml-base/supercatalog: {text: '', mutable: true}
+    mutate: |
+      supercat_path = "/var/lib/sgml-base/supercatalog"
+      def check_catalog(path):
+        # ignore the one we generate
+        if path == "/etc/sgml/catalog":
+          return False
+        return True
+
+      def write_super(catalogs):
+        super = "--\n"
+        super += "## This file is created by update-catalog with update-super.\n"
+        super += "## Please see update-catalog(8) for how to modify this file.\n"
+        super += "--\n"
+        for c in catalogs:
+          super += "CATALOG " + c + "\n"
+        content.write(supercat_path, super)
+
+      def update_super():
+        cat_dir = "/etc/sgml/"
+        catalogs = content.list(cat_dir)
+        filtered = []
+        for c in catalogs:
+          if check_catalog(cat_dir + c):
+            filtered.append(c)
+        write_super(filtered)
+
+      # emulate the actions done by postinst
+      update_super()
+
+  copyright:
+    contents:
+      /usr/share/doc/sgml-base/copyright:

--- a/slices/systemd-sysv.yaml
+++ b/slices/systemd-sysv.yaml
@@ -1,0 +1,68 @@
+package: systemd-sysv
+
+essential:
+  - systemd-sysv_copyright
+
+slices:
+  bins:
+    essential:
+      - systemd-sysv_halt
+      - systemd-sysv_init
+      - systemd-sysv_poweroff
+      - systemd-sysv_reboot
+      - systemd-sysv_runlevel
+      - systemd-sysv_shutdown
+      - systemd-sysv_telinit
+
+  # symlink to systemctl
+  halt:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/halt:
+
+  # symlink to systemd
+  init:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/init:
+
+  # symlink to systemctl
+  poweroff:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/poweroff:
+
+  # symlink to systemctl
+  reboot:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/reboot:
+
+  # symlink to systemctl
+  runlevel:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/runlevel:
+
+  # symlink to systemctl
+  shutdown:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/shutdown:
+
+  # symlink to systemctl
+  telinit:
+    essential:
+      - systemd_bins
+    contents:
+      /usr/sbin/telinit:
+
+  copyright:
+    contents:
+      /usr/share/doc/systemd-sysv/copyright:

--- a/slices/xml-core.yaml
+++ b/slices/xml-core.yaml
@@ -1,0 +1,205 @@
+package: xml-core
+
+essential:
+  - xml-core_copyright
+
+slices:
+  # also contains some binary debian helpers, they are
+  # used only to generate or update the xml catalogue.
+  # /usr/bin/dh_installxmlcatalogs
+  # /usr/sbin/update-xmlcatalog
+
+  # this package depends officially on the 'sed' tool, but
+  # this is afaict only used by the above perl scripts that
+  # we have taken care of in this slice by the mutation script.
+  catalog:
+    essential:
+      - sgml-base_catalog
+    contents:
+      /etc/sgml/xml-core.cat:
+      /etc/xml/catalog: {text: '', mutable: true}
+      /etc/xml/xml-core.xml: {text: '', mutable: true}
+      /usr/share/sgml/dtd/xml-core/catalog:
+      /usr/share/sgml/dtd/xml-core/catalog.dtd:
+      /usr/share/xml-core/catalog.footer: { until: mutate }
+      /usr/share/xml-core/catalog.header: { until: mutate }
+      /usr/share/xml/schema/xml-core/catalog.dtd:
+      /usr/share/xml/schema/xml-core/catalog.xml:
+      /usr/share/xml/schema/xml-core/tr9401.dtd:
+      /var/lib/xml-core/catalog: {text: '', mutable: true}
+      /var/lib/xml-core/xml-core: {text: '', mutable: true}
+    mutate: |
+      catalog_dir = "/etc/xml/"
+      catalog_data_dir = "/var/lib/xml-core/"
+
+      def read_catalog_data(path):
+        catalog = {}
+        data = content.read(path)
+        lines = data.splitlines()
+        for l in lines:
+          tokens = l.split('>', 1)
+          key = tokens[0].strip("> <")
+          entry = tokens[1].strip("> <")
+          catalog[key] = entry
+        return catalog
+
+      def write_catalog(catalog, path):
+        header = content.read("/usr/share/xml-core/catalog.header")
+        footer = content.read("/usr/share/xml-core/catalog.footer")
+        for k in catalog:
+          v = catalog[k]
+          header += "<" + k + " " + v + "/>\n"
+        header += footer
+        content.write(path, header)
+
+      def write_catalog_data(catalog, path):
+        updated_catalog = ""
+        for k in catalog:
+          v = catalog[k]
+          updated_catalog += "<" + k + "><" + v + ">\n"
+        content.write(path, updated_catalog)
+
+      def add_entry(catalog, key, entry):
+        if key in catalog:
+          if catalog[key] != entry:
+            return False
+          else:
+            fail("key was already registered")
+        catalog[key] = entry
+        return True
+
+      def generate_key(typ, id):
+        start = typ;
+        if typ != "uri":
+          start += "Id"
+        start += "StartString"
+        nid = start + "=\"" + id + "\""
+        ntype = ""
+        if typ == "uri":
+          ntype = typ.upper()
+        else:
+          ntype = typ.title()
+        ntype = "delegate" + ntype;
+        return ntype + " " + nid
+
+      def add_xmlcatalog(typ, id, package, local, root):
+        if root:
+          if package == "":
+            fail("package must be given if root is provided")
+          if local != "":
+            fail("cannot add a local file to root")
+        elif package != "":
+          if local == "":
+            fail("local catalog file must be provided")
+        elif local == "":
+          fail("catalog not given")
+
+        if typ != "":
+          if typ != "public" and typ != "system" and typ != "uri":
+            fail("unsupported type provided")
+        else:
+          fail("type must be provided")
+
+        if id == "":
+          fail("id must be provided")
+
+        catalog_path = ""
+        catalog_data_path = ""
+        key = ""
+        entry = ""
+        if root:
+          catalog_data_path = catalog_data_dir + "catalog"
+          catalog_path = catalog_dir + "catalog"
+          key = generate_key(typ, id);
+          entry = "catalog=\"file:///etc/xml/" + package + "\""
+        elif package != "":
+          catalog_data_path = catalog_data_dir + package
+          catalog_path = catalog_dir + package + ".xml"
+          key = generate_key(typ, id);
+          entry = "catalog=\"file://" + local + "\""
+        elif local != "":
+          translated = local.replace("/", "_")
+          catalog_data_path = catalog_data_dir + translated
+          catalog_path = local
+
+          start = ""
+          if typ == "uri":
+            start = "name"
+          else:
+            start = typ
+          nid = start + "=\"" + id + "\""
+
+          key = typ + " " + nid
+          entry = "uri=\"" + local + "\""
+
+        entries = read_catalog_data(catalog_data_path)
+        if add_entry(entries, key, entry):
+          write_catalog_data(entries, catalog_data_path)
+          write_catalog(entries, catalog_path)
+
+      # replicate actions in the postinst, for now we are just supporting
+      # the 'add' operation as we don't support the removal of packages as
+      # a concept in chisel.
+      add_xmlcatalog(
+        "system",
+        "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd",
+        "xml-core",
+        "/usr/share/xml/schema/xml-core/catalog.xml",
+        False)
+
+      add_xmlcatalog(
+        "public",
+        "-//OASIS//DTD XML Catalogs V1.0//EN",
+        "xml-core",
+        "/usr/share/xml/schema/xml-core/catalog.xml",
+        False)
+
+      add_xmlcatalog(
+        "system",
+        "http://globaltranscorp.org/oasis/catalog/xml/tr9401.dtd",
+        "xml-core",
+        "/usr/share/xml/schema/xml-core/catalog.xml",
+        False)
+
+      add_xmlcatalog(
+        "public",
+        "-//GlobalTransCorp//DTD XML Catalogs V1.0-Based Extension V1.0//EN",
+        "xml-core",
+        "/usr/share/xml/schema/xml-core/catalog.xml",
+        False)
+
+      add_xmlcatalog(
+        "system",
+        "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd",
+        "xml-core",
+        "",
+        True)
+
+      add_xmlcatalog(
+        "public",
+        "-//OASIS//DTD XML Catalogs V1.0//EN",
+        "xml-core",
+        "",
+        True)
+
+      add_xmlcatalog(
+        "system",
+        "http://globaltranscorp.org/oasis/catalog/xml/tr9401.dtd",
+        "xml-core",
+        "",
+        True)
+
+      add_xmlcatalog(
+        "public",
+        "-//GlobalTransCorp//DTD XML Catalogs V1.0-Based Extension V1.0//EN",
+        "xml-core",
+        "",
+        True)
+
+  perl-modules:
+    contents:
+      /usr/share/perl5/Debian/Debhelper/Sequence/xml_core.pm:
+
+  copyright:
+    contents:
+      /usr/share/doc/xml-core/copyright:

--- a/tests/spread/integration/libpolkit-agent-1-0/task.yaml
+++ b/tests/spread/integration/libpolkit-agent-1-0/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libpolkit-agent-1-0
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices polkitd_bins)"
+
+  # This will fail if loading of the agent module fails.
+  chroot "${rootfs}/" /usr/bin/pkcheck --help

--- a/tests/spread/integration/libpolkit-gobject-1-0/task.yaml
+++ b/tests/spread/integration/libpolkit-gobject-1-0/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libpolkit-gobject-1-0
+
+execute: |
+  # Chisel a minimum number of slices to give us a runnable system that we can
+  # test in.
+  rootfs="$(install-slices polkitd_bins)"
+
+  # This will fail if loading of the gobject module fails.
+  chroot "${rootfs}/" /usr/lib/polkit-1/polkitd --help

--- a/tests/spread/integration/opensysusers/basic.conf
+++ b/tests/spread/integration/opensysusers/basic.conf
@@ -1,0 +1,41 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+# The superuser
+g root    0       -            -
+u root    0:0     "Super User" /root
+
+# The nobody user/group for NFS file systems
+g nobody 65534       -            -
+u! nobody 65534:65534 "Kernel Overflow User"     -
+
+# Administrator group: can *see* more than normal users
+g adm     -     -            -
+
+# Administrator group: can *do* more than normal users
+g wheel   -     -            -
+
+# Access to shared database of users on the system
+g utmp    -     -            -
+
+# Physical and virtual hardware access groups
+g audio   -     -            -
+g disk    -     -            -
+g input   -     -            -
+g kmem    -     -            -
+g kvm     -     -            -
+g lp      -     -            -
+g optical -     -            -
+g render  -     -            -
+g sgx     -     -            -
+g storage -     -            -
+g tty     5     -            -
+g uucp    -     -            -
+g video   -     -            -
+
+# Default group for normal users
+g users   -     -            -

--- a/tests/spread/integration/opensysusers/task.yaml
+++ b/tests/spread/integration/opensysusers/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for opensysusers
+
+execute: |
+  rootfs="$(install-slices base-files_bin opensysusers_scripts)"
+
+  # needs /dev/null
+  mkdir "${rootfs}/dev"
+  mount --bind /dev "${rootfs}/dev"
+
+  # test using the basic.conf script from systemd
+  mkdir -p "${rootfs}/etc/sysusers.d"
+  cp ./basic.conf "${rootfs}/etc/sysusers.d/basic.conf"
+
+  # this will create additional users, ensure one of them dont exist
+  ! grep "storage:x:993:" < "${rootfs}/etc/group"
+
+  # should create groups
+  chroot "${rootfs}/" /usr/bin/opensysusers-sysusers
+
+  # should exist now
+  grep "storage:x:993:" < "${rootfs}/etc/group"
+
+  # cleanup
+  umount -l "${rootfs}/dev"

--- a/tests/spread/integration/polkitd/task.yaml
+++ b/tests/spread/integration/polkitd/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for polkit
+
+systems:
+  - -ubuntu-25.04-ppc64le
+  - -ubuntu-25.04-s390x
+
+execute: |
+  rootfs="$(install-slices libc-bin_nsswitch bash_bins coreutils_bins passwd_bins base-files_base polkitd_bins)"
+
+  # polkitd does a chdir("/") and that requires executable bit
+  chmod +x "$rootfs"
+
+  # add polkit user with same uid/gid as the host. This is created
+  # dynamically by /bin/systemd-sysusers from opensysusers
+  PK_UID="$(cat /etc/passwd | awk -F ':' '/polkitd/{print $3}')"
+  PK_GID="$(cat /etc/group | awk -F ':' '/polkitd/{print $3}')"
+  groupadd --root "$rootfs" --system -g "$PK_GID" polkitd
+  useradd --root "$rootfs" -s /usr/sbin/nologin --system -u "$PK_UID" -m -g polkitd polkitd
+
+  # execute the main polkitd daemon, this should semi-succeed, except it will shutdown
+  # again and give an error that it failed to register on the dbus system bus, which
+  # is not running.
+  # If it starts up correctly, it will print "Entering main event loop"
+  chroot "${rootfs}/" /usr/lib/polkit-1/polkitd | grep "Entering main event loop"

--- a/tests/spread/integration/sbsigntool/task.yaml
+++ b/tests/spread/integration/sbsigntool/task.yaml
@@ -1,8 +1,8 @@
 summary: Integration tests for sbsigntool
 
 systems:
-  - -ubuntu-24.04-ppc64le
-  - -ubuntu-24.04-s390x
+  - -ubuntu-25.04-ppc64le
+  - -ubuntu-25.04-s390x
 
 execute: |
   rootfs="$(install-slices sbsigntool_bins)"

--- a/tests/spread/integration/sgml-base/task.yaml
+++ b/tests/spread/integration/sgml-base/task.yaml
@@ -1,0 +1,16 @@
+summary: Integration tests for sgml-base
+
+systems:
+  - -ubuntu-25.04-ppc64le
+  - -ubuntu-25.04-s390x
+
+execute: |
+  rootfs="$(install-slices sgml-base_catalog)"
+
+  if cat "$rootfs/var/lib/sgml-base/supercatalog" | grep "/etc/sgml/catalog"; then
+    echo "the super catalog should not list itself"
+    exit 1
+  fi
+
+  # verify some of header was written
+  cat "$rootfs/var/lib/sgml-base/supercatalog" | grep "This file is created by update-catalog"

--- a/tests/spread/integration/systemd-sysv/task.yaml
+++ b/tests/spread/integration/systemd-sysv/task.yaml
@@ -1,0 +1,34 @@
+summary: Integration tests for systemd-sysv
+
+environment:
+  SLICE/halt: "halt"
+  SLICE/init: "init"
+  SLICE/poweroff: "poweroff"
+  SLICE/reboot: "reboot"
+  SLICE/runlevel: "runlevel"
+  SLICE/shutdown: "shutdown"
+  SLICE/telinit: "telinit"
+
+# commands that control system stuff like reboot and shutdown
+# are just smoke-tested using --help
+# init and telinit send commands to the init daemon, and let us avoid
+# that (like reboot, power off etc) and smoke instead
+execute: |
+  rootfs="$(install-slices base-files_base bash_bins systemd-sysv_${SLICE})"
+
+  case ${SLICE} in
+    halt|poweroff|reboot|shutdown)
+      chroot "${rootfs}" "/usr/sbin/${SLICE}" --help
+    ;;
+    init|telinit)
+      chroot "${rootfs}" "/usr/sbin/${SLICE}" --help
+    ;;
+    runlevel)
+      mkdir "${rootfs}"/proc
+      mount --bind /proc "${rootfs}"/proc
+
+      chroot "${rootfs}" "/usr/sbin/${SLICE}" 2>&1 | grep "Running in chroot"
+
+      umount -l "${rootfs}"/proc
+    ;;
+  esac

--- a/tests/spread/integration/xml-core/task.yaml
+++ b/tests/spread/integration/xml-core/task.yaml
@@ -1,0 +1,48 @@
+summary: Integration tests for xml-core
+
+systems:
+  - -ubuntu-25.04-ppc64le
+  - -ubuntu-25.04-s390x
+
+execute: |
+  rootfs="$(install-slices xml-core_catalog)"
+
+  if ! [ -e "$rootfs/etc/xml/catalog" ]; then
+    echo "expected /etc/xml/catalog to be created"
+    exit 1
+  fi
+
+  # ensure a marker was written that we can somewhat reliably
+  # expect
+  cat "$rootfs/etc/xml/catalog" | grep "delegateSystem systemIdStartString"
+  cat "$rootfs/etc/xml/catalog" | grep "delegatePublic publicIdStartString"
+
+  if ! [ -e "$rootfs/etc/xml/xml-core.xml" ]; then
+    echo "expected /etc/xml/xml-core.xml to be created"
+    exit 1
+  fi
+
+  # ensure a marker was written that we can somewhat reliably
+  # expect
+  cat "$rootfs/etc/xml/xml-core.xml" | grep "delegateSystem systemIdStartString"
+  cat "$rootfs/etc/xml/xml-core.xml" | grep "delegatePublic publicIdStartString"
+
+  if ! [ -e "$rootfs/var/lib/xml-core/catalog" ]; then
+    echo "expected /var/lib/xml-core/catalog to be created"
+    exit 1
+  fi
+
+  # ensure a marker was written that we can somewhat reliably
+  # expect
+  cat "$rootfs/var/lib/xml-core/catalog" | grep "delegateSystem systemIdStartString"
+  cat "$rootfs/var/lib/xml-core/catalog" | grep "delegatePublic publicIdStartString"
+
+  if ! [ -e "$rootfs/var/lib/xml-core/xml-core" ]; then
+    echo "expected /var/lib/xml-core/xml-core to be created"
+    exit 1
+  fi
+
+  # ensure a marker was written that we can somewhat reliably
+  # expect
+  cat "$rootfs/var/lib/xml-core/xml-core" | grep "delegateSystem systemIdStartString"
+  cat "$rootfs/var/lib/xml-core/xml-core" | grep "delegatePublic publicIdStartString"


### PR DESCRIPTION
# Proposed changes

Polkitd and it's dependencies are required for Ubuntu Core 26. Add the slices, and mutation scripts required to imitate what happens by postinst or perl scripts that are carried by included packages.

Two mutation scripts are added:
xml-core which handles updating the xml catalog
sgml-base which handles updating the sgml catalog

## Related issues/PRs
This is an updated version of https://github.com/canonical/chisel-releases/pull/325 for 25.04

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [ ] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [ ] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [ ] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
