### PR TITLE
feat(25.04): add dbus-user-session, libpam and additional dependencies

### DIFF
--- a/slices/dbus-user-session.yaml
+++ b/slices/dbus-user-session.yaml
@@ -1,0 +1,21 @@
+package: dbus-user-session
+
+essential:
+  - dbus-user-session_copyright
+
+slices:
+  services:
+    essential:
+      - dbus-daemon_bins
+      - dbus-session-bus-common_config
+      - libpam-systemd_libs
+      - systemd_bins
+    contents:
+      /etc/X11/Xsession.d/20dbus_xdg-runtime:
+      /usr/lib/systemd/user/dbus.service:
+      /usr/lib/systemd/user/dbus.socket:
+      /usr/lib/systemd/user/sockets.target.wants/dbus.socket:
+
+  copyright:
+    contents:
+      /usr/share/doc/dbus-user-session/copyright:

--- a/slices/libengine-pkcs11-openssl.yaml
+++ b/slices/libengine-pkcs11-openssl.yaml
@@ -1,0 +1,18 @@
+package: libengine-pkcs11-openssl
+
+essential:
+  - libengine-pkcs11-openssl_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libssl3t64_libs
+      - p11-kit_bins
+    contents:
+      /usr/lib/*-linux-*/engines-3/pkcs11.so:
+      /usr/lib/*-linux-*/engines-3/libpkcs11.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libengine-pkcs11-openssl/copyright:

--- a/slices/libopts25.yaml
+++ b/slices/libopts25.yaml
@@ -1,0 +1,15 @@
+package: libopts25
+
+essential:
+  - libopts25_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libopts.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libopts25/copyright:

--- a/slices/libp11-3t64.yaml
+++ b/slices/libp11-3t64.yaml
@@ -1,0 +1,16 @@
+package: libp11-3t64
+
+essential:
+  - libp11-3t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libssl3t64_libs
+    contents:
+      /usr/lib/*-linux-*/libp11.so.*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libp11-3t64/copyright:

--- a/slices/libpam-systemd.yaml
+++ b/slices/libpam-systemd.yaml
@@ -1,0 +1,28 @@
+package: libpam-systemd
+
+essential:
+  - libpam-systemd_copyright
+
+slices:
+  libs:
+    essential:
+      - dbus_bins
+      - libc6_libs
+      - libcap2_libs
+      - libpam-runtime_config
+      - libpam0g_libs
+      - systemd_bins
+      - systemd-dev_dbus-interfaces
+      - libpam-systemd_pam-config
+    contents:
+      /usr/lib/*-linux-*/security/pam_systemd.so:
+      /usr/lib/*-linux-*/security/pam_systemd_loadkey.so:
+
+  # Used by libpam-runtime to generate proper pam.d files.
+  pam-config:
+    contents:
+      /usr/share/pam-configs/systemd:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpam-systemd/copyright:

--- a/slices/libplymouth5.yaml
+++ b/slices/libplymouth5.yaml
@@ -1,0 +1,20 @@
+package: libplymouth5
+
+essential:
+  - libplymouth5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libpng16-16t64_libs
+      - libudev1_libs
+    contents:
+      /usr/lib/*-linux-*/libply-boot-client.so.5*:
+      /usr/lib/*-linux-*/libply-splash-core.so.5*:
+      /usr/lib/*-linux-*/libply-splash-graphics.so.5*:
+      /usr/lib/*-linux-*/libply.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libplymouth5/copyright:

--- a/tests/spread/integration/libengine-pkcs11-openssl/task.yaml
+++ b/tests/spread/integration/libengine-pkcs11-openssl/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for libengine-pkcs11-openssl
+
+execute: |
+  rootfs="$(install-slices libengine-pkcs11-openssl_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/engines-3/pkcs11.so
+  test -f ${rootfs}/usr/lib/${arch}/engines-3/libpkcs11.so

--- a/tests/spread/integration/libopts25/task.yaml
+++ b/tests/spread/integration/libopts25/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libopts25
+
+execute: |
+  rootfs="$(install-slices libopts25_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libopts.so.25

--- a/tests/spread/integration/libp11-3t64/task.yaml
+++ b/tests/spread/integration/libp11-3t64/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libp11-3t64
+
+execute: |
+  rootfs="$(install-slices libp11-3t64_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/libp11.so.3:

--- a/tests/spread/integration/libpam-systemd/task.yaml
+++ b/tests/spread/integration/libpam-systemd/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for libpam-systemd
+
+execute: |
+  rootfs="$(install-slices libpam-systemd_libs)"
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
+
+  test -f ${rootfs}/usr/lib/${arch}/security/pam_systemd.so
+  test -f ${rootfs}/usr/lib/${arch}/security/pam_systemd_loadkey.so


### PR DESCRIPTION
# Proposed changes

Needed by the Ubuntu Core base, add dbus-user-session, libpam for systemd and some additional library dependencies.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
