### PR TITLE
ci: update compatibility matrix with newer Chisel versions

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -24,10 +24,10 @@ env:
   ARCHES: '["amd64","arm64","armhf","ppc64el","riscv64","s390x"]'
   RELEASES: |
     [
-      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.0.0","main"]},
-      {"ref": "ubuntu-22.04", "chisel-versions": ["v1.0.0","main"]},
-      {"ref": "ubuntu-24.04", "chisel-versions": ["v1.0.0","main"]},
-      {"ref": "ubuntu-25.04", "chisel-versions": ["v1.0.0","main"]}
+      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-25.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]}
     ]
 
 jobs:


### PR DESCRIPTION
v1.0.0 is slow when compared with more recent versions of Chisel (example: https://github.com/canonical/chisel-releases/actions/runs/16933587495/job/47984768366?pr=577)

It is also old enough that we can restrict our compatibility matrix to the newer minor versions and `main`.