### PR TITLE
ci: add support for 'create' events

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -80,6 +80,15 @@ jobs:
             echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
 
             echo "install_all=true" >> $GITHUB_OUTPUT
+          elif [[
+            "${{ github.event_name }}" == "create" &&
+            "${{ github.ref_name }}" != "main"
+          ]]; then
+            # This happens when a new branch/tag is created, so we'll want to
+            # install all the slices for that release only
+            export RELEASES=$(echo "$RELEASES" | jq '[.[] | select(.ref == "${{ github.ref_name }}")]')
+            MATRIX=$(./version-matrix)
+            echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
           else
             # Filter the releases to only the affected branch, then swap the ref
             # such that the correct branch is tested.


### PR DESCRIPTION
The release branches will, from now on, also get triggered on the `create` event, such that we can test the opening of a new chisel-release.

This PR adds a condition to the install-slices workflow, such that the CI runs on those events, but only for the branch/release that is being opened.

See a test run at: https://github.com/cjdcordeiro/chisel-releases/actions/runs/16960290838