### PR TITLE
Revert "fix(ci): PR triaging needs to happen on schedule (#591)"

### DIFF
--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -1,11 +1,8 @@
 name: Triage PRs
 
 on:
-  # Using a schedule because events like pull_request only work if the workflow
-  # exists on the base (target) branch of the PR
-  schedule:
-    - cron: "*/20 * * * *"
-  workflow_dispatch:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   add-reviewers:
@@ -14,29 +11,14 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.ROCKSBOT_PR_TOKEN }}
-          REVIEWERS: "canonical/slice-reviewers-guild"
+          REVIEWERS: "slice-reviewers-guild"
         run: |
-          set -euxo pipefail
-          
-          for pr_number in `gh pr list -R ${{ github.repository }} \
-            --search "-team-review-requested:${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
-            || echo fail`
-            do
-              if [[ "$pr_number" == "fail" ]]
-              then
-                echo "ERR: couldn't search for PRs"
-                exit 1
-              fi
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -f "team_reviewers[]=${{ env.REVIEWERS }}"
 
-              echo "Requesting review from ${{ env.REVIEWERS }} on PR ${pr_number}"
-
-              gh api \
-                --method POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                /repos/${{ github.repository }}/pulls/${pr_number}/requested_reviewers \
-                -f "team_reviewers[]=${{ env.REVIEWERS }}"
-
-              # Cannot use `gh pr edit`:
-              # https://github.com/cli/cli/issues/4844
-          done
+          # Cannot use `gh pr edit`:
+          # https://github.com/cli/cli/issues/4844


### PR DESCRIPTION
This reverts commit 83ac328babae73e00fc509fc422cd15a3417be1b.

# Proposed changes
#591 causes [CI failures](https://github.com/canonical/chisel-releases/actions/workflows/triage-prs.yaml). here is a quick revert in case we want to go back on the changes now to stop the failures and try again later. reject/close if not needed

## Related issues/PRs
#591

### Forward porting
N/A

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)