### PR TITLE
fix(ci): flawd designation of team names in diff API calls

### DIFF
--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.ROCKSBOT_PR_TOKEN }}
-          REVIEWERS: "canonical/slice-reviewers-guild"
+          REVIEWERS: "slice-reviewers-guild"
         run: |
           set -euxo pipefail
           
           for pr_number in `gh pr list -R ${{ github.repository }} \
-            --search "-team-review-requested:${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
+            --search "-team-review-requested:canonical/${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
             || echo fail`
             do
               if [[ "$pr_number" == "fail" ]]


### PR DESCRIPTION
Fixes https://github.com/canonical/chisel-releases/actions/workflows/triage-prs.yaml.

Tested locally. The issue we caused by https://github.com/canonical/chisel-releases/pull/591/commits/0fcafea8678e13f8618020a2a58a1361e8efd3ae, which in this case helped identify an inconsistency with the GH API, where sometimes a team needs to be prefixed with the ORG name, but not for all API calls.