### PR TITLE
feat: add maintenance

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,5 +1,11 @@
 format: v1
 
+maintenance:
+  standard: 2020-04-23
+  expanded: 2025-05-29
+  legacy: 2030-04-23
+  end-of-life: 2032-04-27
+
 archives:
   # archive.ubuntu.com/ubuntu/      (amd64, i386)
   # ports.ubuntu.com/ubuntu-ports/  (other arch)


### PR DESCRIPTION
# Proposed changes
Add the new `maintenance` key to the release yaml to specify that dates for the different stages of official support. Together with the changes in Chisel itself this will allow users to use unmaintained releases (e.g. 23.10) if they choose to do so acknowledging the consequences.

## Related issues/PRs


### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
N/A