### PR TITLE
feat(22.04): tomcat9 slices

### DIFF
--- a/slices/libeclipse-jdt-core-java.yaml
+++ b/slices/libeclipse-jdt-core-java.yaml
@@ -1,0 +1,6 @@
+package: libeclipse-jdt-core-java
+
+slices:
+  libs:
+    content:
+      /usr/share/java/eclipse-jdt-core*.jar:

--- a/slices/libeclipse-jdt-core-java.yaml
+++ b/slices/libeclipse-jdt-core-java.yaml
@@ -1,6 +1,13 @@
 package: libeclipse-jdt-core-java
 
+essential:
+  - libeclipse-jdt-core-java_copyright
+
 slices:
   libs:
     contents:
       /usr/share/java/eclipse-jdt-core*.jar:
+
+  copyright:
+    contents:
+      /usr/share/doc/libeclipse-jdt-core-java/copyright:

--- a/slices/libeclipse-jdt-core-java.yaml
+++ b/slices/libeclipse-jdt-core-java.yaml
@@ -2,5 +2,5 @@ package: libeclipse-jdt-core-java
 
 slices:
   libs:
-    content:
+    contents:
       /usr/share/java/eclipse-jdt-core*.jar:

--- a/slices/libtcnative-1.yaml
+++ b/slices/libtcnative-1.yaml
@@ -1,0 +1,10 @@
+package: libtcnative-1
+
+slices:
+  libs:
+    essential:
+      - libapr1_libs
+      - libc6_libs
+      - libssl3_libs
+    contents:
+      /usr/lib/*-linux-*/libtcnative-1.so*:

--- a/slices/libtcnative-1.yaml
+++ b/slices/libtcnative-1.yaml
@@ -14,4 +14,4 @@ slices:
 
   copyright:
     contents:
-      /usr/share/doc/libtcnative-1/copyright
+      /usr/share/doc/libtcnative-1/copyright:

--- a/slices/libtcnative-1.yaml
+++ b/slices/libtcnative-1.yaml
@@ -1,5 +1,8 @@
 package: libtcnative-1
 
+essential:
+  - libtcnative-1_copyright
+
 slices:
   libs:
     essential:
@@ -8,3 +11,7 @@ slices:
       - libssl3_libs
     contents:
       /usr/lib/*-linux-*/libtcnative-1.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtcnative-1/copyright

--- a/slices/libtomcat9-java.yaml
+++ b/slices/libtomcat9-java.yaml
@@ -1,6 +1,9 @@
 
 package: libtomcat9-java
 
+essential:
+  - libtomcat9-java_copyright
+
 slices:
   i18n-common:
     contents:
@@ -74,3 +77,7 @@ slices:
       /usr/share/java/tomcat9-websocket-api-9.*.jar:
       /usr/share/java/tomcat9-websocket-api.jar:
       /usr/share/java/tomcat9-websocket.jar:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtomcat9-java/copyright:

--- a/slices/libtomcat9-java.yaml
+++ b/slices/libtomcat9-java.yaml
@@ -69,9 +69,9 @@ slices:
       /usr/share/java/tomcat9-tribes-9.*.jar:
       /usr/share/java/tomcat9-tribes.jar:
       /usr/share/java/tomcat9-util-9.*.jar:
-      /usr/share/java/tomcat9-util.jar:
       /usr/share/java/tomcat9-util-scan-9.*.jar:
       /usr/share/java/tomcat9-util-scan.jar:
+      /usr/share/java/tomcat9-util.jar:
       /usr/share/java/tomcat9-websocket-9.*.jar:
       /usr/share/java/tomcat9-websocket-api-9.*.jar:
       /usr/share/java/tomcat9-websocket-api.jar:

--- a/slices/libtomcat9-java.yaml
+++ b/slices/libtomcat9-java.yaml
@@ -1,0 +1,76 @@
+
+package: libtomcat9-java
+
+slices:
+  i18n-common:
+    contents:
+      /usr/share/java/tomcat9-i18n-es-9.*.jar:
+      /usr/share/java/tomcat9-i18n-es.jar:
+      /usr/share/java/tomcat9-i18n-fr-9.*.jar:
+      /usr/share/java/tomcat9-i18n-fr.jar:
+      /usr/share/java/tomcat9-i18n-ja-9.*.jar:
+      /usr/share/java/tomcat9-i18n-ja.jar:
+      /usr/share/java/tomcat9-i18n-ru-9.*.jar:
+      /usr/share/java/tomcat9-i18n-ru.jar:
+
+  i18n-extra:
+    contents:
+      /usr/share/java/tomcat9-i18n-cs-9.*.jar:
+      /usr/share/java/tomcat9-i18n-cs.jar:
+      /usr/share/java/tomcat9-i18n-de-9.*.jar:
+      /usr/share/java/tomcat9-i18n-de.jar:
+      /usr/share/java/tomcat9-i18n-ko-9.*.jar:
+      /usr/share/java/tomcat9-i18n-ko.jar:
+      /usr/share/java/tomcat9-i18n-pt-BR-9.*.jar:
+      /usr/share/java/tomcat9-i18n-pt-BR.jar:
+      /usr/share/java/tomcat9-i18n-zh-CN-9.*.jar:
+      /usr/share/java/tomcat9-i18n-zh-CN.jar:
+
+  libs:
+    essential:
+      - libeclipse-jdt-core-java_libs
+    contents:
+      /usr/share/java/tomcat9-annotations-api-9*.jar:
+      /usr/share/java/tomcat9-annotations-api.jar:
+      /usr/share/java/tomcat9-api-9.*.jar:
+      /usr/share/java/tomcat9-api.jar:
+      /usr/share/java/tomcat9-catalina-9.*.jar:
+      /usr/share/java/tomcat9-catalina-ant-9.*.jar:
+      /usr/share/java/tomcat9-catalina-ant.jar:
+      /usr/share/java/tomcat9-catalina-ha-9.*.jar:
+      /usr/share/java/tomcat9-catalina-ha.jar:
+      /usr/share/java/tomcat9-catalina.jar:
+      /usr/share/java/tomcat9-coyote-9.*.jar:
+      /usr/share/java/tomcat9-coyote.jar:
+      /usr/share/java/tomcat9-dbcp-9.*.jar:
+      /usr/share/java/tomcat9-dbcp.jar:
+      /usr/share/java/tomcat9-el-api-9.*.jar:
+      /usr/share/java/tomcat9-el-api.jar:
+      /usr/share/java/tomcat9-jasper-9.*.jar:
+      /usr/share/java/tomcat9-jasper-el-9.*.jar:
+      /usr/share/java/tomcat9-jasper-el.jar:
+      /usr/share/java/tomcat9-jasper.jar:
+      /usr/share/java/tomcat9-jaspic-api-9.*.jar:
+      /usr/share/java/tomcat9-jaspic-api.jar:
+      /usr/share/java/tomcat9-jdbc-9.*.jar:
+      /usr/share/java/tomcat9-jdbc.jar:
+      /usr/share/java/tomcat9-jni-9.*.jar:
+      /usr/share/java/tomcat9-jni.jar:
+      /usr/share/java/tomcat9-jsp-api-9.*.jar:
+      /usr/share/java/tomcat9-jsp-api.jar:
+      /usr/share/java/tomcat9-juli-9.*.jar:
+      /usr/share/java/tomcat9-juli.jar:
+      /usr/share/java/tomcat9-servlet-api-9.*.jar:
+      /usr/share/java/tomcat9-servlet-api.jar:
+      /usr/share/java/tomcat9-storeconfig-9.*.jar:
+      /usr/share/java/tomcat9-storeconfig.jar:
+      /usr/share/java/tomcat9-tribes-9.*.jar:
+      /usr/share/java/tomcat9-tribes.jar:
+      /usr/share/java/tomcat9-util-9.*.jar:
+      /usr/share/java/tomcat9-util.jar:
+      /usr/share/java/tomcat9-util-scan-9.*.jar:
+      /usr/share/java/tomcat9-util-scan.jar:
+      /usr/share/java/tomcat9-websocket-9.*.jar:
+      /usr/share/java/tomcat9-websocket-api-9.*.jar:
+      /usr/share/java/tomcat9-websocket-api.jar:
+      /usr/share/java/tomcat9-websocket.jar:

--- a/slices/libtomcat9-java.yaml
+++ b/slices/libtomcat9-java.yaml
@@ -1,4 +1,3 @@
-
 package: libtomcat9-java
 
 essential:

--- a/slices/tomcat9-common.yaml
+++ b/slices/tomcat9-common.yaml
@@ -22,10 +22,8 @@ slices:
 
   core:
     essential:
-      - libapr1_libs
       - libtomcat9-java_i18n-common
       - libtomcat9-java_libs
-      - openssl_bins
     contents:
       /usr/share/tomcat9/bin/bootstrap.jar:
       /usr/share/tomcat9/bin/catalina-tasks.xml:

--- a/slices/tomcat9-common.yaml
+++ b/slices/tomcat9-common.yaml
@@ -4,6 +4,22 @@ essential:
   - tomcat9-common_copyright
 
 slices:
+  # additional shell scripts
+  bins:
+    essential:
+      - tomcat9-common_core
+    contents:
+      /usr/libexec/tomcat9/tomcat-locate-java.sh:
+      /usr/share/tomcat9/bin/ciphers.sh:
+      /usr/share/tomcat9/bin/configtest.sh:
+      /usr/share/tomcat9/bin/daemon.sh:
+      /usr/share/tomcat9/bin/digest.sh:
+      /usr/share/tomcat9/bin/makebase.sh:
+      /usr/share/tomcat9/bin/shutdown.sh:
+      /usr/share/tomcat9/bin/startup.sh:
+      /usr/share/tomcat9/bin/tool-wrapper.sh:
+      /usr/share/tomcat9/bin/version.sh:
+
   core:
     essential:
       - libapr1_libs
@@ -11,21 +27,11 @@ slices:
       - libtomcat9-java_libs
       - openssl_bins
     contents:
-      /usr/libexec/tomcat9/tomcat-locate-java.sh:
       /usr/share/tomcat9/bin/bootstrap.jar:
       /usr/share/tomcat9/bin/catalina-tasks.xml:
       /usr/share/tomcat9/bin/catalina.sh:
-      /usr/share/tomcat9/bin/ciphers.sh:
-      /usr/share/tomcat9/bin/configtest.sh:
-      /usr/share/tomcat9/bin/daemon.sh:
-      /usr/share/tomcat9/bin/digest.sh:
-      /usr/share/tomcat9/bin/makebase.sh:
-      /usr/share/tomcat9/bin/setclasspath.sh:
-      /usr/share/tomcat9/bin/shutdown.sh:
-      /usr/share/tomcat9/bin/startup.sh:
       /usr/share/tomcat9/bin/tomcat-juli.jar:
-      /usr/share/tomcat9/bin/tool-wrapper.sh:
-      /usr/share/tomcat9/bin/version.sh:
+      /usr/share/tomcat9/bin/setclasspath.sh:
       /usr/share/tomcat9/lib/annotations-api.jar:
       /usr/share/tomcat9/lib/catalina-ant.jar:
       /usr/share/tomcat9/lib/catalina-ha.jar:

--- a/slices/tomcat9-common.yaml
+++ b/slices/tomcat9-common.yaml
@@ -30,8 +30,8 @@ slices:
       /usr/share/tomcat9/bin/bootstrap.jar:
       /usr/share/tomcat9/bin/catalina-tasks.xml:
       /usr/share/tomcat9/bin/catalina.sh:
-      /usr/share/tomcat9/bin/tomcat-juli.jar:
       /usr/share/tomcat9/bin/setclasspath.sh:
+      /usr/share/tomcat9/bin/tomcat-juli.jar:
       /usr/share/tomcat9/lib/annotations-api.jar:
       /usr/share/tomcat9/lib/catalina-ant.jar:
       /usr/share/tomcat9/lib/catalina-ha.jar:

--- a/slices/tomcat9-common.yaml
+++ b/slices/tomcat9-common.yaml
@@ -1,0 +1,57 @@
+package: tomcat9-common
+
+slices:
+  core:
+    essential:
+      - libtomcat9-java_libs
+      - libtomcat9-java_i18n-common
+      - openssl_bins
+      - libapr1_libs
+    contents:
+      /usr/libexec/tomcat9/tomcat-locate-java.sh:
+      /usr/share/tomcat9/bin/bootstrap.jar:
+      /usr/share/tomcat9/bin/catalina.sh:
+      /usr/share/tomcat9/bin/catalina-tasks.xml:
+      /usr/share/tomcat9/bin/ciphers.sh:
+      /usr/share/tomcat9/bin/configtest.sh:
+      /usr/share/tomcat9/bin/daemon.sh:
+      /usr/share/tomcat9/bin/digest.sh:
+      /usr/share/tomcat9/bin/makebase.sh:
+      /usr/share/tomcat9/bin/setclasspath.sh:
+      /usr/share/tomcat9/bin/shutdown.sh:
+      /usr/share/tomcat9/bin/startup.sh:
+      /usr/share/tomcat9/bin/tomcat-juli.jar:
+      /usr/share/tomcat9/bin/tool-wrapper.sh:
+      /usr/share/tomcat9/bin/version.sh:
+      /usr/share/tomcat9/lib/annotations-api.jar:
+      /usr/share/tomcat9/lib/catalina-ant.jar:
+      /usr/share/tomcat9/lib/catalina-ha.jar:
+      /usr/share/tomcat9/lib/catalina.jar:
+      /usr/share/tomcat9/lib/catalina-storeconfig.jar:
+      /usr/share/tomcat9/lib/catalina-tribes.jar:
+      /usr/share/tomcat9/lib/el-api.jar:
+      /usr/share/tomcat9/lib/jasper-el.jar:
+      /usr/share/tomcat9/lib/jasper.jar:
+      /usr/share/tomcat9/lib/jaspic-api.jar:
+      /usr/share/tomcat9/lib/jsp-api.jar:
+      /usr/share/tomcat9/lib/servlet-api.jar:
+      /usr/share/tomcat9/lib/tomcat-api.jar:
+      /usr/share/tomcat9/lib/tomcat-coyote.jar:
+      /usr/share/tomcat9/lib/tomcat-dbcp.jar:
+      /usr/share/tomcat9/lib/tomcat-i18n-es.jar:
+      /usr/share/tomcat9/lib/tomcat-i18n-fr.jar:
+      /usr/share/tomcat9/lib/tomcat-i18n-ja.jar:
+      /usr/share/tomcat9/lib/tomcat-i18n-ru.jar:
+      /usr/share/tomcat9/lib/tomcat-jdbc.jar:
+      /usr/share/tomcat9/lib/tomcat-jni.jar:
+      /usr/share/tomcat9/lib/tomcat-util.jar:
+      /usr/share/tomcat9/lib/tomcat-util-scan.jar:
+      /usr/share/tomcat9/lib/tomcat-websocket.jar:
+      /usr/share/tomcat9/lib/websocket-api.jar:
+  doc :
+    contents:
+      /usr/share/doc/tomcat9-common/changelog.Debian.gz:
+      /usr/share/doc/tomcat9-common/copyright:
+      /usr/share/doc/tomcat9-common/README.Debian:
+      /usr/share/doc/tomcat9-common/RELEASE-NOTES.gz:
+      /usr/share/doc/tomcat9-common/RUNNING.txt.gz:

--- a/slices/tomcat9-common.yaml
+++ b/slices/tomcat9-common.yaml
@@ -6,15 +6,15 @@ essential:
 slices:
   core:
     essential:
-      - libtomcat9-java_libs
-      - libtomcat9-java_i18n-common
-      - openssl_bins
       - libapr1_libs
+      - libtomcat9-java_i18n-common
+      - libtomcat9-java_libs
+      - openssl_bins
     contents:
       /usr/libexec/tomcat9/tomcat-locate-java.sh:
       /usr/share/tomcat9/bin/bootstrap.jar:
-      /usr/share/tomcat9/bin/catalina.sh:
       /usr/share/tomcat9/bin/catalina-tasks.xml:
+      /usr/share/tomcat9/bin/catalina.sh:
       /usr/share/tomcat9/bin/ciphers.sh:
       /usr/share/tomcat9/bin/configtest.sh:
       /usr/share/tomcat9/bin/daemon.sh:
@@ -29,9 +29,9 @@ slices:
       /usr/share/tomcat9/lib/annotations-api.jar:
       /usr/share/tomcat9/lib/catalina-ant.jar:
       /usr/share/tomcat9/lib/catalina-ha.jar:
-      /usr/share/tomcat9/lib/catalina.jar:
       /usr/share/tomcat9/lib/catalina-storeconfig.jar:
       /usr/share/tomcat9/lib/catalina-tribes.jar:
+      /usr/share/tomcat9/lib/catalina.jar:
       /usr/share/tomcat9/lib/el-api.jar:
       /usr/share/tomcat9/lib/jasper-el.jar:
       /usr/share/tomcat9/lib/jasper.jar:
@@ -47,8 +47,8 @@ slices:
       /usr/share/tomcat9/lib/tomcat-i18n-ru.jar:
       /usr/share/tomcat9/lib/tomcat-jdbc.jar:
       /usr/share/tomcat9/lib/tomcat-jni.jar:
-      /usr/share/tomcat9/lib/tomcat-util.jar:
       /usr/share/tomcat9/lib/tomcat-util-scan.jar:
+      /usr/share/tomcat9/lib/tomcat-util.jar:
       /usr/share/tomcat9/lib/tomcat-websocket.jar:
       /usr/share/tomcat9/lib/websocket-api.jar:
 

--- a/slices/tomcat9-common.yaml
+++ b/slices/tomcat9-common.yaml
@@ -1,5 +1,8 @@
 package: tomcat9-common
 
+essential:
+  - tomcat9-common_copyright
+
 slices:
   core:
     essential:
@@ -48,10 +51,7 @@ slices:
       /usr/share/tomcat9/lib/tomcat-util-scan.jar:
       /usr/share/tomcat9/lib/tomcat-websocket.jar:
       /usr/share/tomcat9/lib/websocket-api.jar:
-  doc :
+
+  copyright:
     contents:
-      /usr/share/doc/tomcat9-common/changelog.Debian.gz:
       /usr/share/doc/tomcat9-common/copyright:
-      /usr/share/doc/tomcat9-common/README.Debian:
-      /usr/share/doc/tomcat9-common/RELEASE-NOTES.gz:
-      /usr/share/doc/tomcat9-common/RUNNING.txt.gz:

--- a/slices/tomcat9.yaml
+++ b/slices/tomcat9.yaml
@@ -24,21 +24,31 @@ slices:
       /usr/share/tomcat9/logrotate.template:
       /usr/share/tomcat9-root/default_root/META-INF/context.xml:
       /usr/share/tomcat9-root/default_root/index.html:
-      /var/lib/tomcat9/conf: { symlink: /etc/tomcat9}
-      /var/lib/tomcat9/logs: { symlink: /var/log/tomcat9/}
-      /var/lib/tomcat9/work: { symlink: /var/cache/tomcat9/}
+      /var/lib/tomcat9/conf:
+        {symlink: /etc/tomcat9}
+      /var/lib/tomcat9/logs:
+        {symlink: /var/log/tomcat9/}
+      /var/lib/tomcat9/work:
+        {symlink: /var/cache/tomcat9/}
       /var/lib/tomcat9/lib/: {make: true}
       /var/lib/tomcat9/webapps/: {make: true}
       /var/cache/tomcat9/: {make: true}
       /var/log/tomcat9/: {make: true}
       /etc/tomcat9/Catalina/: {make: true}
-      /etc/tomcat9/catalina.properties: {symlink: /usr/share/tomcat9/etc/catalina.properties}
-      /etc/tomcat9/context.xml: {symlink: /usr/share/tomcat9/etc/context.xml}
-      /etc/tomcat9/jaspic-providers.xml: {symlink: /usr/share/tomcat9/etc/jaspic-providers.xml}
-      /etc/tomcat9/logging.properties: {symlink: /usr/share/tomcat9/etc/logging.properties}
-      /etc/tomcat9/server.xml: {symlink: /usr/share/tomcat9/etc/server.xml}
-      /etc/tomcat9/tomcat-users.xml: {symlink: /usr/share/tomcat9/etc/tomcat-users.xml}
-      /etc/tomcat9/web.xml: {symlink: /usr/share/tomcat9/etc/web.xml}
+      /etc/tomcat9/catalina.properties:
+        {symlink: /usr/share/tomcat9/etc/catalina.properties}
+      /etc/tomcat9/context.xml:
+        {symlink: /usr/share/tomcat9/etc/context.xml}
+      /etc/tomcat9/jaspic-providers.xml:
+        {symlink: /usr/share/tomcat9/etc/jaspic-providers.xml}
+      /etc/tomcat9/logging.properties:
+        {symlink: /usr/share/tomcat9/etc/logging.properties}
+      /etc/tomcat9/server.xml:
+        {symlink: /usr/share/tomcat9/etc/server.xml}
+      /etc/tomcat9/tomcat-users.xml:
+        {symlink: /usr/share/tomcat9/etc/tomcat-users.xml}
+      /etc/tomcat9/web.xml:
+        {symlink: /usr/share/tomcat9/etc/web.xml}
 
   copyright:
     content:

--- a/slices/tomcat9.yaml
+++ b/slices/tomcat9.yaml
@@ -8,11 +8,29 @@ slices:
     essential:
       - tomcat9-common_core
     contents:
+      /etc/tomcat9/Catalina/:
+        make: true
+      /etc/tomcat9/catalina.properties:
+        symlink: /usr/share/tomcat9/etc/catalina.properties
+      /etc/tomcat9/context.xml:
+        symlink: /usr/share/tomcat9/etc/context.xml
+      /etc/tomcat9/jaspic-providers.xml:
+        symlink: /usr/share/tomcat9/etc/jaspic-providers.xml
+      /etc/tomcat9/logging.properties:
+        symlink: /usr/share/tomcat9/etc/logging.properties
       /etc/tomcat9/policy.d/01system.policy:
       /etc/tomcat9/policy.d/02debian.policy:
       /etc/tomcat9/policy.d/03catalina.policy:
       /etc/tomcat9/policy.d/04webapps.policy:
       /etc/tomcat9/policy.d/50local.policy:
+      /etc/tomcat9/server.xml:
+        symlink: /usr/share/tomcat9/etc/server.xml
+      /etc/tomcat9/tomcat-users.xml:
+        symlink: /usr/share/tomcat9/etc/tomcat-users.xml
+      /etc/tomcat9/web.xml:
+        symlink: /usr/share/tomcat9/etc/web.xml
+      /usr/share/tomcat9-root/default_root/META-INF/context.xml:
+      /usr/share/tomcat9-root/default_root/index.html:
       /usr/share/tomcat9/default.template:
       /usr/share/tomcat9/etc/catalina.properties:
       /usr/share/tomcat9/etc/context.xml:
@@ -22,33 +40,20 @@ slices:
       /usr/share/tomcat9/etc/tomcat-users.xml:
       /usr/share/tomcat9/etc/web.xml:
       /usr/share/tomcat9/logrotate.template:
-      /usr/share/tomcat9-root/default_root/META-INF/context.xml:
-      /usr/share/tomcat9-root/default_root/index.html:
+      /var/cache/tomcat9/:
+        make: true
       /var/lib/tomcat9/conf:
-        {symlink: /etc/tomcat9}
+        symlink: /etc/tomcat9
+      /var/lib/tomcat9/lib/:
+        make: true
       /var/lib/tomcat9/logs:
-        {symlink: /var/log/tomcat9/}
+        symlink: /var/log/tomcat9/
+      /var/lib/tomcat9/webapps/:
+        make: true
       /var/lib/tomcat9/work:
-        {symlink: /var/cache/tomcat9/}
-      /var/lib/tomcat9/lib/: {make: true}
-      /var/lib/tomcat9/webapps/: {make: true}
-      /var/cache/tomcat9/: {make: true}
-      /var/log/tomcat9/: {make: true}
-      /etc/tomcat9/Catalina/: {make: true}
-      /etc/tomcat9/catalina.properties:
-        {symlink: /usr/share/tomcat9/etc/catalina.properties}
-      /etc/tomcat9/context.xml:
-        {symlink: /usr/share/tomcat9/etc/context.xml}
-      /etc/tomcat9/jaspic-providers.xml:
-        {symlink: /usr/share/tomcat9/etc/jaspic-providers.xml}
-      /etc/tomcat9/logging.properties:
-        {symlink: /usr/share/tomcat9/etc/logging.properties}
-      /etc/tomcat9/server.xml:
-        {symlink: /usr/share/tomcat9/etc/server.xml}
-      /etc/tomcat9/tomcat-users.xml:
-        {symlink: /usr/share/tomcat9/etc/tomcat-users.xml}
-      /etc/tomcat9/web.xml:
-        {symlink: /usr/share/tomcat9/etc/web.xml}
+        symlink: /var/cache/tomcat9/
+      /var/log/tomcat9/:
+        make: true
 
   copyright:
     content:

--- a/slices/tomcat9.yaml
+++ b/slices/tomcat9.yaml
@@ -1,0 +1,45 @@
+package: tomcat9
+
+essential:
+  - tomcat9_copyright
+
+slices:
+  core:
+    essential:
+      - tomcat9-common_core
+    contents:
+      /etc/tomcat9/policy.d/01system.policy:
+      /etc/tomcat9/policy.d/02debian.policy:
+      /etc/tomcat9/policy.d/03catalina.policy:
+      /etc/tomcat9/policy.d/04webapps.policy:
+      /etc/tomcat9/policy.d/50local.policy:
+      /usr/share/tomcat9/default.template:
+      /usr/share/tomcat9/etc/catalina.properties:
+      /usr/share/tomcat9/etc/context.xml:
+      /usr/share/tomcat9/etc/jaspic-providers.xml:
+      /usr/share/tomcat9/etc/logging.properties:
+      /usr/share/tomcat9/etc/server.xml:
+      /usr/share/tomcat9/etc/tomcat-users.xml:
+      /usr/share/tomcat9/etc/web.xml:
+      /usr/share/tomcat9/logrotate.template:
+      /usr/share/tomcat9-root/default_root/META-INF/context.xml:
+      /usr/share/tomcat9-root/default_root/index.html:
+      /var/lib/tomcat9/conf: { symlink: /etc/tomcat9}
+      /var/lib/tomcat9/logs: { symlink: /var/log/tomcat9/}
+      /var/lib/tomcat9/work: { symlink: /var/cache/tomcat9/}
+      /var/lib/tomcat9/lib/: {make: true}
+      /var/lib/tomcat9/webapps/: {make: true}
+      /var/cache/tomcat9/: {make: true}
+      /var/log/tomcat9/: {make: true}
+      /etc/tomcat9/Catalina/: {make: true}
+      /etc/tomcat9/catalina.properties: {symlink: /usr/share/tomcat9/etc/catalina.properties}
+      /etc/tomcat9/context.xml: {symlink: /usr/share/tomcat9/etc/context.xml}
+      /etc/tomcat9/jaspic-providers.xml: {symlink: /usr/share/tomcat9/etc/jaspic-providers.xml}
+      /etc/tomcat9/logging.properties: {symlink: /usr/share/tomcat9/etc/logging.properties}
+      /etc/tomcat9/server.xml: {symlink: /usr/share/tomcat9/etc/server.xml}
+      /etc/tomcat9/tomcat-users.xml: {symlink: /usr/share/tomcat9/etc/tomcat-users.xml}
+      /etc/tomcat9/web.xml: {symlink: /usr/share/tomcat9/etc/web.xml}
+
+  copyright:
+    content:
+      /usr/share/doc/tomcat9/copyright:

--- a/slices/tomcat9.yaml
+++ b/slices/tomcat9.yaml
@@ -29,9 +29,6 @@ slices:
         symlink: /usr/share/tomcat9/etc/tomcat-users.xml
       /etc/tomcat9/web.xml:
         symlink: /usr/share/tomcat9/etc/web.xml
-      /usr/share/tomcat9-root/default_root/META-INF/context.xml:
-      /usr/share/tomcat9-root/default_root/index.html:
-      /usr/share/tomcat9/default.template:
       /usr/share/tomcat9/etc/catalina.properties:
       /usr/share/tomcat9/etc/context.xml:
       /usr/share/tomcat9/etc/jaspic-providers.xml:
@@ -39,7 +36,6 @@ slices:
       /usr/share/tomcat9/etc/server.xml:
       /usr/share/tomcat9/etc/tomcat-users.xml:
       /usr/share/tomcat9/etc/web.xml:
-      /usr/share/tomcat9/logrotate.template:
       /var/cache/tomcat9/:
         make: true
       /var/lib/tomcat9/conf:

--- a/tests/spread/integration/libtcnative-1/task.yaml
+++ b/tests/spread/integration/libtcnative-1/task.yaml
@@ -1,0 +1,22 @@
+summary: Integration tests for libtcnative-1
+
+execute: |
+  # libtcnative-1 installs tomcat native extensions. run
+  # tomcat version to validate that they are loaded
+  rootfs="$(install-slices tomcat9_core libtcnative-1_libs tomcat9-common_core coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
+  cd ${rootfs}
+  mkdir -p proc sys tmp dev
+  mount --bind /proc proc
+  mount --bind /sys sys
+  mount --bind /tmp tmp
+  mount --bind /dev dev
+  for java in `find usr/lib/jvm -name java`; do
+    export JAVA_HOME=/$(dirname $(dirname ${java}))
+    export CATALINA_BASE="/var/lib/tomcat9"
+    chroot . /usr/share/tomcat9/bin/catalina.sh version
+    nativeLines="$(chroot . /usr/share/tomcat9/bin/catalina.sh configtest 2>&1)"
+    if ! echo "$nativeLines" | grep 'Loaded Apache Tomcat Native library' >&2; then \
+        echo >&2 "$nativeLines"; \
+        exit 1; \
+    fi
+  done

--- a/tests/spread/integration/tomcat9-common/task.yaml
+++ b/tests/spread/integration/tomcat9-common/task.yaml
@@ -10,6 +10,7 @@ execute: |
   mount --bind /tmp tmp
   mount --bind /dev dev
   for java in `find usr/lib/jvm -name java`; do
-    export JAVA_HOME=/$(dirname $(dirname ${java}))
+    export JAVA_HOME="/$(dirname $(dirname ${java}))"
+    export CATALINA_BASE="/var/lib/tomcat9"
     chroot . /usr/share/tomcat9/bin/catalina.sh version
   done

--- a/tests/spread/integration/tomcat9-common/task.yaml
+++ b/tests/spread/integration/tomcat9-common/task.yaml
@@ -1,0 +1,15 @@
+summary: Integration tests for tomcat9-common
+
+execute: |
+  # tomcat needs an openjdk and shell
+  rootfs="$(install-slices tomcat9-common_core coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
+  cd ${rootfs}
+  mkdir -p proc sys tmp dev
+  mount --bind /proc proc
+  mount --bind /sys sys
+  mount --bind /tmp tmp
+  mount --bind /dev dev
+  for java in `find usr/lib/jvm -name java`; do
+    export JAVA_HOME=/$(dirname $(dirname ${java}))
+    chroot . /usr/share/tomcat9/bin/catalina.sh version
+  done

--- a/tests/spread/integration/tomcat9/task.yaml
+++ b/tests/spread/integration/tomcat9/task.yaml
@@ -1,0 +1,16 @@
+summary: Integration tests for tomcat9
+
+execute: |
+  # tomcat needs an openjdk and shell
+  rootfs="$(install-slices tomcat9_core coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
+  cd ${rootfs}
+  mkdir -p proc sys tmp dev
+  mount --bind /proc proc
+  mount --bind /sys sys
+  mount --bind /tmp tmp
+  mount --bind /dev dev
+  for java in `find usr/lib/jvm -name java`; do
+    export JAVA_HOME="/$(dirname $(dirname ${java}))"
+    export CATALINA_BASE="/var/lib/tomcat9"
+    chroot . /usr/share/tomcat9/bin/catalina.sh configtest
+  done


### PR DESCRIPTION
# Proposed changes

Add slices for tomcat9 package and its dependencies to build 22.04-based tomcat9 ROCKs

Packages added:
 - libeclipse-jdt-core-java:  Eclipse Java Development Tools Core (used as a compiler by Tomcat)
 - libtomcat9-java: tomcat9 jar libraries
 - tomcat9-common: tomcat9 scripts and symlinks to tomcat9 libraries
 - tomcat9: tomcat configuration and content root

Tomcat 9 is not supported in noble (only libraries package is present). 
Forward-porting is TBD.

## Related issues/PRs

Tomcat 10  https://github.com/canonical/chisel-releases/pull/636 needs to be merged to forward port this.

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->