### PR TITLE
ci: allow for release-specific chisel versions

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -22,9 +22,15 @@ on:
 env:
   # Package architectures and chisel-releases branches to test on.
   ARCHES: '["amd64","arm64","armhf","ppc64el","riscv64","s390x"]'
-  # This env should be dynamic once the `maintenance` field is added to chisel.yaml
-  UNMAINTAINED_RELEASES: 'ubuntu-22.10 ubuntu-23.04 ubuntu-23.10 ubuntu-24.10'
-  CHISEL_VERSIONS: '["v1.1.0","v1.2.0","main"]'
+  DEFAULT_CHISEL_VERSION: "main"
+  RELEASES_COMPATIBILITY: |
+    [
+      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-25.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","main"]}
+    ]
 
 jobs:
   prepare-install:
@@ -73,37 +79,44 @@ jobs:
             # be installed together so using a single version of chisel is
             # enough.
             all_branches="$(git branch --all | grep -E "remotes.*ubuntu-[0-9]{2}\.[0-9]{2}$" | cut -d '/' -f 3)"
-            for unmaintained in $UNMAINTAINED_RELEASES; do
-              all_branches="$(echo "${all_branches//$unmaintained}")"
-            done
 
             RELEASES="[]"
             for branch in $all_branches; do
-              RELEASES="$(echo "$RELEASES" | jq --arg ref "$branch" '. += [{"ref": $ref, "chisel-versions": ["main"]}]')"
+              # Only add to RELEASES when ref is equal to $branch from RELEASES_COMPATIBILITY
+              ref="$(echo "$RELEASES_COMPATIBILITY" | jq --arg ref "$branch" '[.[] | select(.ref == $ref)]')"
+              RELEASES="$(echo "$RELEASES" | jq --argjson ref "$ref" '. + $ref')"
             done
 
-            export RELEASES
-            
-            MATRIX=$(./version-matrix)
-            echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
-
             echo "install_all=true" >> $GITHUB_OUTPUT
-          elif [[
-            "${{ github.event_name }}" == "create" &&
-            "${{ github.ref_name }}" != "main"
-          ]]; then
-            # This happens when a new branch/tag is created, so we'll want to
-            # install all the slices for that release only
-            export RELEASES="[{\"ref\": \"${{ github.ref_name }}\", \"chisel-versions\": ${CHISEL_VERSIONS}}]"
-            MATRIX=$(./version-matrix)
-            echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
           else
-            # Filter the releases to only the affected branch, then swap the ref
-            # such that the correct branch is tested.
-            export RELEASES="[{\"ref\": \"\", \"chisel-versions\": ${CHISEL_VERSIONS}}]"
-            MATRIX=$(./version-matrix)
-            echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
+            if [[
+              "${{ github.event_name }}" == "create" &&
+              "${{ github.ref_name }}" != "main"
+            ]]; then
+              # This happens when a new branch/tag is created, so we'll want to
+              # install all the slices for that release only
+              targetref="${{ github.ref_name }}"
+              RELEASES="$(echo $RELEASES_COMPATIBILITY | jq --arg ref "$ref" '[.[] | select(.ref == $ref)]')"
+            else
+              # Filter the releases to only the affected branch, then swap the ref
+              # such that the correct branch is tested.
+              targetref=""
+              RELEASES="$(echo $RELEASES_COMPATIBILITY | jq --arg ref "${{ github.base_ref }}" \
+                --arg targetref "$targetref" '[.[] | select(.ref == $ref) | .ref = "$targetref"]')"
+            fi
+
+            # If the {{ github.ref_name }} is not in RELEASES_COMPATIBILITY,
+            # then we default to using the main branch of chisel.
+            if [[ $(echo $RELEASES | jq 'length') -eq 0 ]]
+            then
+              RELEASES="[{\"ref\": \"${targetref}\", \"chisel-versions\": [\"main\"]}]"
+            fi
           fi
+
+          export RELEASES
+     
+          MATRIX=$(./version-matrix)
+          echo "matrix={\"include\": $MATRIX}" >> $GITHUB_OUTPUT
 
   # The "install" job tests the slices by installing them.
   # It installs **all** slices if:


### PR DESCRIPTION
In the previous PR (#635), the installability tests were made dynamic by removing the boilerplate RELEASE matrix.

However, newer Chisel releases may be constrained to work only with more recent version of Chisel, so we still need a compatibility matrix to inform the CI how to map the branch being tested to the list of Chisel versions to test against.