### PR TITLE
fix(25.10/apparmor): remove remmina and toybox

### DIFF
--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -261,7 +261,6 @@ slices:
       /etc/apparmor.d/qcam:
       /etc/apparmor.d/qmapshack:
       /etc/apparmor.d/qutebrowser:
-      /etc/apparmor.d/remmina:
       /etc/apparmor.d/ripd:
       /etc/apparmor.d/ripngd:
       /etc/apparmor.d/rootlesskit:

--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -294,7 +294,6 @@ slices:
       /etc/apparmor.d/thunderbird:
       /etc/apparmor.d/tinyproxy:
       /etc/apparmor.d/tnftp:
-      /etc/apparmor.d/toybox:
       /etc/apparmor.d/transmission:
       /etc/apparmor.d/trinity:
       /etc/apparmor.d/tshark:


### PR DESCRIPTION
# Proposed changes
As of 5.0.0~alpha1-0ubuntu1, the remmina and toybox profiles are disabled by default in apparmor.

https://launchpad.net/ubuntu/+source/apparmor/5.0.0~alpha1-0ubuntu1

## Related issues/PRs
- [25.04 SRU](https://github.com/canonical/chisel-releases/pull/641)

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->