### PR TITLE
fix(25.04): remove inexistent paths from apparmor

### DIFF
--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -261,7 +261,6 @@ slices:
       /etc/apparmor.d/qcam:
       /etc/apparmor.d/qmapshack:
       /etc/apparmor.d/qutebrowser:
-      /etc/apparmor.d/remmina:
       /etc/apparmor.d/ripd:
       /etc/apparmor.d/ripngd:
       /etc/apparmor.d/rootlesskit:


### PR DESCRIPTION
Fixes the CI, eg. https://github.com/canonical/chisel-releases/actions/runs/17636158895/job/50112682850?pr=640

Apparently `apparmor` in 25.04 has a different fileset now.