### PR TITLE
fix(25.10): update openssh-client slices for openssh 10.0

### DIFF
--- a/slices/openssh-client.yaml
+++ b/slices/openssh-client.yaml
@@ -8,6 +8,8 @@ slices:
     # openssh-client depends on adduser as well to create or update
     # the ssh agent user during package install - however we
     # don't support this currently so adduser is not added here.
+    # Likewise, the init-system-helpers dependency is for the postinst
+    # script to configure systemd for the socket.
     essential:
       - libc6_libs
       - libedit2_libs
@@ -20,15 +22,11 @@ slices:
     contents:
       /usr/bin/scp:
       /usr/bin/sftp:
-      /usr/bin/slogin:
       /usr/bin/ssh:
       /usr/bin/ssh-add:
       /usr/bin/ssh-agent:
-      /usr/bin/ssh-argv0:
-      /usr/bin/ssh-copy-id:
       /usr/bin/ssh-keygen:
       /usr/bin/ssh-keyscan:
-      /usr/lib/openssh/agent-launch:
       /usr/lib/openssh/ssh-keysign:
       /usr/lib/openssh/ssh-pkcs11-helper:
       /usr/lib/openssh/ssh-sk-helper:
@@ -37,11 +35,49 @@ slices:
     contents:
       /etc/ssh/ssh_config:
       /etc/ssh/ssh_config.d/:
+      /usr/lib/tmpfiles.d/openssh-client.conf:
+
+  scripts:
+    essential:
+      - openssh-client_ssh-argv0
+      - openssh-client_ssh-copy-id
+
+  ssh-argv0:
+    # ssh-copy-id is a shell script that needs all of these
+    # None of these extra requirements are part of the openssh-client package's
+    # requirements.
+    essential:
+      - coreutils_conditions
+      - dash_bins
+      - openssh-client_bins
+    contents:
+      /usr/bin/ssh-argv0:
+
+  ssh-copy-id:
+    # ssh-copy-id is a shell script that needs all of these
+    # None of these extra requirements are part of the openssh-client package's
+    # requirements.
+    essential:
+      - coreutils_changing-file-attributes
+      - coreutils_expr
+      - coreutils_file-name-manipulation
+      - coreutils_operating-on-characters
+      - coreutils_output-of-entire-files
+      - coreutils_output-of-parts-of-files
+      - coreutils_rm-utility
+      - coreutils_summarizing-files
+      - dash_bins
+      - grep_bins
+      - openssh-client_bins
+      - sed_bins
+    contents:
+      /usr/bin/ssh-copy-id:
 
   services:
     contents:
       /usr/lib/systemd/user/graphical-session-pre.target.wants/ssh-agent.service:
       /usr/lib/systemd/user/ssh-agent.service:
+      /usr/lib/systemd/user/ssh-agent.socket:
 
   copyright:
     contents:

--- a/tests/spread/integration/openssh-client/task.yaml
+++ b/tests/spread/integration/openssh-client/task.yaml
@@ -1,0 +1,21 @@
+summary: Integration tests for openssh-client
+
+environment:
+  TEST_SCRIPT/bins: test_bins.sh
+  TEST_SCRIPT/ssh_copy_id: test_ssh-copy-id.sh
+  TEST_SCRIPT/ssh_argv0: test_ssh-argv0.sh
+
+prepare: |
+  # This may already be installed and active, but if it's not...
+  apt-get --yes install openssh-server
+  $(which sshd)
+
+  # If openssh-slice-test-user already exists, we'll allow it.
+  useradd -m openssh-slice-test-user || true
+
+execute: |
+  . "./$TEST_SCRIPT"
+
+restore: |
+  userdel -f -r openssh-slice-test-user || true
+  killall ssh-agent || true

--- a/tests/spread/integration/openssh-client/test_bins.sh
+++ b/tests/spread/integration/openssh-client/test_bins.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Tests for openssh-client binaries.
+
+## Setup
+rootfs="$(install-slices openssh-client_bins)"
+
+mkdir -p "${rootfs}/dev"
+touch "${rootfs}/dev/null"
+mkdir "${rootfs}/tmp"
+
+##Tests
+# Scan the local ssh server for a key.
+chroot "${rootfs}"/ ssh-keyscan 127.0.0.1
+
+# Generate a client key
+mkdir -p "${rootfs}/root/.ssh"
+chroot "${rootfs}"/ ssh-keygen -f /root/.ssh/id -N ''
+
+# Start an agent in the chroot and bring its auth socket and pid to the environment
+eval "$(chroot "${rootfs}"/ ssh-agent)"
+
+chroot "${rootfs}"/ ssh-add -L | MATCH 'The agent has no identities.'
+chroot "${rootfs}"/ ssh-add /root/.ssh/id
+diff "${rootfs}/root/.ssh/id.pub" <(chroot "${rootfs}/" ssh-add -L)
+
+# Copy their identity over to the outer machine so they can ssh back out
+# shellcheck disable=SC2174  # permission only applies to the innermost directory
+mkdir -m 700 -p ~openssh-slice-test-user/.ssh
+chown openssh-slice-test-user ~openssh-slice-test-user/.ssh
+cp "${rootfs}"/root/.ssh/id.pub ~openssh-slice-test-user/.ssh/authorized_keys
+chown openssh-slice-test-user ~openssh-slice-test-user/.ssh/authorized_keys
+
+# Does the ssh binary actually work?
+chroot "${rootfs}"/ ssh -oStrictHostKeyChecking=no -i /root/.ssh/id openssh-slice-test-user@127.0.0.1 true
+
+# Now try scp and sftp
+echo "I am going to scp this" > "${rootfs}/scp-file"
+chroot "${rootfs}"/ scp -i /root/.ssh/id /scp-file openssh-slice-test-user@127.0.0.1:~/scp-done
+test -f ~openssh-slice-test-user/scp-done
+diff -q "${rootfs}/scp-file" ~openssh-slice-test-user/scp-done
+
+echo "I am going to sftp this" > "${rootfs}/sftp-file"
+echo "put sftp-file" > "${rootfs}/sftp-commands"
+chroot "${rootfs}"/ sftp -i /root/.ssh/id -b /sftp-commands openssh-slice-test-user@127.0.0.1
+test -f ~openssh-slice-test-user/sftp-file
+diff -q "${rootfs}/sftp-file" ~openssh-slice-test-user/sftp-file

--- a/tests/spread/integration/openssh-client/test_ssh-argv0.sh
+++ b/tests/spread/integration/openssh-client/test_ssh-argv0.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Tests for openssh-client's ssh-argv0 slice.
+
+## Setup
+rootfs="$(install-slices openssh-client_ssh-argv0)"
+
+mkdir -p "${rootfs}/dev"
+touch "${rootfs}/dev/null"
+mkdir "${rootfs}/tmp"
+
+# Generate a client key and add it to the agent
+mkdir -p "${rootfs}/root/.ssh"
+chroot "${rootfs}"/ ssh-keygen -f /root/.ssh/id -N ''
+eval "$(chroot "${rootfs}"/ ssh-agent)"
+chroot "${rootfs}"/ ssh-add /root/.ssh/id
+
+# Copy their identity over to the outer machine so they can ssh back out
+# shellcheck disable=SC2174  # permission only applies to the innermost directory
+mkdir -m 700 -p ~openssh-slice-test-user/.ssh
+chown openssh-slice-test-user ~openssh-slice-test-user/.ssh
+cp "${rootfs}"/root/.ssh/id.pub ~openssh-slice-test-user/.ssh/authorized_keys
+chown openssh-slice-test-user ~openssh-slice-test-user/.ssh/authorized_keys
+
+## Tests
+
+ln -s usr/bin/ssh-argv0 "${rootfs}/openssh-slice-test-user@127.0.0.1"
+chroot "${rootfs}"/ dash /usr/bin/ssh-argv0 |& MATCH 'This script should not be run like this'
+chroot "${rootfs}"/ dash /openssh-slice-test-user@127.0.0.1 -oStrictHostKeyChecking=no -i /root/.ssh/id2 true

--- a/tests/spread/integration/openssh-client/test_ssh-copy-id.sh
+++ b/tests/spread/integration/openssh-client/test_ssh-copy-id.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Tests for openssh-client's ssh-copy-id slice.
+
+## Setup
+rootfs="$(install-slices openssh-client_ssh-copy-id)"
+
+mkdir -p "${rootfs}/dev"
+touch "${rootfs}/dev/null"
+mkdir "${rootfs}/tmp"
+
+# Generate a client key and add it to the agent
+mkdir -p "${rootfs}/root/.ssh"
+chroot "${rootfs}"/ ssh-keygen -f /root/.ssh/id -N ''
+eval "$(chroot "${rootfs}"/ ssh-agent)"
+chroot "${rootfs}"/ ssh-add /root/.ssh/id
+
+# Copy their identity over to the outer machine so they can ssh back out
+# shellcheck disable=SC2174  # permission only applies to the innermost directory
+mkdir -m 700 -p ~openssh-slice-test-user/.ssh
+chown openssh-slice-test-user ~openssh-slice-test-user/.ssh
+cp "${rootfs}"/root/.ssh/id.pub ~openssh-slice-test-user/.ssh/authorized_keys
+chown openssh-slice-test-user ~openssh-slice-test-user/.ssh/authorized_keys
+
+## Tests
+
+# Generate another key and use ssh-copy-id to copy it over.
+chroot "${rootfs}"/ ssh-keygen -f /root/.ssh/id2 -N ''
+chroot "${rootfs}"/ ssh-add /root/.ssh/id2
+chroot "${rootfs}"/ dash /usr/bin/ssh-copy-id -oStrictHostKeyChecking=no openssh-slice-test-user@127.0.0.1
+chroot "${rootfs}"/ ssh -oStrictHostKeyChecking=no -i /root/.ssh/id2 openssh-slice-test-user@127.0.0.1 true
+
+# Try with scp
+chroot "${rootfs}"/ ssh-keygen -f /root/.ssh/id3 -N ''
+chroot "${rootfs}"/ ssh-add /root/.ssh/id3
+chroot "${rootfs}"/ dash /usr/bin/ssh-copy-id -oStrictHostKeyChecking=no -s openssh-slice-test-user@127.0.0.1
+chroot "${rootfs}"/ ssh -oStrictHostKeyChecking=no -i /root/.ssh/id3 openssh-slice-test-user@127.0.0.1 true


### PR DESCRIPTION
# Proposed changes
This updates the openssh slices for the removal of:

- /usr/bin/slogin
- /usr/lib/openssh/agent-launch

It also adds integration tests.

While writing the integration tests, I noticed that ssh-copy-id and ssh-argv0 are actually shell scripts, so I separated them into their own slices and made a scripts slice for them and added their appropriate dependencies. These dependencies are notably absent from the actual openssh-client package, which may be a packaging bug. The individual slices are useful for distinguishing which slices are necessary for which script.

## Related issues/PRs
Fixes #653 

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
n/a

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
We may want to backport the scripts slice to earlier releases, but I'm unsure how best to do that without breaking compatibility for them.