### PR TITLE
ci: add experimental s390x architecture

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -9,10 +9,11 @@ jobs:
     strategy:
       matrix:
         runner:
-          - name: X64
-            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "X64", "large"]') || 'ubuntu-24.04' }}
-          - name: ARM64
-            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
+        # DO NOT MERGE until you uncomment these again
+          # - name: X64
+          #   runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "X64", "large"]') || 'ubuntu-24.04' }}
+          # - name: ARM64
+          #   runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
           # ppc64el fails because of https://github.com/actions/setup-go/issues/648
           # - name: PPC64EL
           #   runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "edge"]') }}

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -13,6 +13,8 @@ jobs:
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "X64", "large"]') || 'ubuntu-24.04' }}
           - name: ARM64
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
+          - name: PPC64EL
+            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "large"]') }}
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
     steps:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -14,7 +14,9 @@ jobs:
           - name: ARM64
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
           - name: PPC64EL
-            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "large"]') }}
+            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "edge"]') }}
+          - name: S390x
+            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "s390x", "edge"]') }}
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
     steps:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -18,7 +18,7 @@ jobs:
           # - name: PPC64EL
           #   runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "edge"]') }}
           - name: S390x
-            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "s390x", "edge"]') }}
+            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "s390x"]') }}
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
     steps:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -13,8 +13,9 @@ jobs:
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "X64", "large"]') || 'ubuntu-24.04' }}
           - name: ARM64
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
-          - name: PPC64EL
-            runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "edge"]') }}
+          # ppc64el fails because of https://github.com/actions/setup-go/issues/648
+          # - name: PPC64EL
+          #   runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ppc64el", "edge"]') }}
           - name: S390x
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "s390x", "edge"]') }}
     name: Run Spread tests | ${{ matrix.runner.name }}

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -45,7 +45,7 @@ jobs:
           repository: snapcore/spread
           path: _spread
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: '>=1.17.0'
 


### PR DESCRIPTION
# Proposed changes
Run the LXD spread tests on s390x.

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
n/a

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
We have experimental self-hosted s390x and ppc64el runners. The PowerPC ones currently don't work because the `setup-go` action fails on little-endian PowerPC (see: https://github.com/actions/setup-go/issues/648), but there is at least one s390x runner. Adding these platforms has two nice benefits:

1. We get to run the spread tests on those architectures, getting us a more thorough testing of the slices.
2. We get to test out the experimental s390x and (once that actions bug is fixed) ppc64el runners for the kind platform-engineering folks who make this possible.

A demo PR is available at https://github.com/canonical/chisel-releases/pull/656 ([Test run](https://github.com/canonical/chisel-releases/actions/runs/17846112512/job/50745611544?pr=656))