### PR TITLE
fix(25.10): update gearman dependencies

### DIFF
--- a/slices/gearman-job-server.yaml
+++ b/slices/gearman-job-server.yaml
@@ -9,7 +9,7 @@ slices:
     # remove a user during package install/removal - however we don't
     # support this currently so adduser is not added here.
     essential:
-      - libboost-program-options1.83.0_libs
+      - libboost-program-options1.88.0_libs
       - libc6_libs
       - libevent-2.1-7t64_libs
       - libevent-pthreads-2.1-7t64_libs

--- a/slices/gearman-tools.yaml
+++ b/slices/gearman-tools.yaml
@@ -6,7 +6,7 @@ essential:
 slices:
   bins:
     essential:
-      - libboost-program-options1.83.0_libs
+      - libboost-program-options1.88.0_libs
       - libc6_libs
       - libgcc-s1_libs
       - libgearman8t64_libs

--- a/slices/libboost-program-options1.88.0.yaml
+++ b/slices/libboost-program-options1.88.0.yaml
@@ -1,0 +1,17 @@
+package: libboost-program-options1.88.0
+
+essential:
+  - libboost-program-options1.88.0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/*-linux-*/libboost_program_options.so.1.88.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libboost-program-options1.88.0/copyright:


### PR DESCRIPTION
# Proposed changes
The gearman packages on questing got updated to a newer version of libboost-program-options. The older one still exists and is used by many apps, so I added a copy of those slices (checking that they're still correct) for the newer version and updated the gearman slices.

## Related issues/PRs
<!-- If any -->
n/a

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
n/a

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->