### PR TITLE
Gconv split

### DIFF
--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -36,6 +36,14 @@ slices:
     contents:
       /usr/bin/getconf:
 
+  iconv:
+    essential:
+      - libc6_gconv-core
+      - libc6_iconv-config
+      - libc6_libs
+    contents:
+      /usr/bin/iconv:
+
   copyright:
     contents:
       /usr/share/doc/libc-bin/copyright:

--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -40,8 +40,26 @@ slices:
       /usr/lib/*-linux-*/libutil.so.*:
 
   gconv:
+    essential:
+      - libc6_gconv-core
+      - libc6_iconv-config
     contents:
       /usr/lib/*-linux-*/gconv/**:
+
+  iconv-config:
+    contents:
+      /usr/lib/x86_64-linux-gnu/gconv/gconv-modules:
+      /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache:
+      /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.d/gconv-modules-extra.conf:
+
+  gconv-core:
+    contents:
+      /usr/lib/*-linux-*/gconv/ANSI_X3.110.so:
+      /usr/lib/*-linux-*/gconv/CP1252.so:
+      /usr/lib/*-linux-*/gconv/ISO8859-1.so:
+      /usr/lib/*-linux-*/gconv/ISO8859-15.so:
+      /usr/lib/*-linux-*/gconv/UNICODE.so:
+      /usr/lib/*-linux-*/gconv/UTF-*.so:
 
   copyright:
     contents:

--- a/tests/spread/integration/libc-bin/task.yaml
+++ b/tests/spread/integration/libc-bin/task.yaml
@@ -4,3 +4,9 @@ execute: |
   rootfs="$(install-slices libc-bin_getconf)"
 
   chroot "$rootfs" getconf -a
+
+  rootfs=$(install-slices libc-bin_iconv base-files_base)
+  in=Foo
+  echo $in | (chroot "$rootfs" /usr/bin/iconv -f cp1252 -t UNICODE) > test.txt
+  out=$(cat test.txt | chroot "$rootfs" /usr/bin/iconv -t cp1252 -f UNICODE)
+  test "$out" = "$in"


### PR DESCRIPTION
# Proposed changes

This PR splits libc6_gconv slice to provide smaller slices with common converters and iconv cache. 

## Related issues/PRs

https://github.com/canonical/chisel-releases/issues/368

### Forward porting

Waiting for the initial review.

## Checklist

* [ ] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [ ] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [ ] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

This implement gconv split in line with Fedora