### PR TITLE
ci: add option to ignore unstable and unmaintained chisel releases

### DIFF
--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -297,10 +297,11 @@ def ignore_missing_packages(
 
 def install_slices(
     chunk: list[tuple[str, str]],
-    dry_run: bool,
+    worker: int,
+    *,
     arch: str,
     release: str,
-    worker: int,
+    dry_run: bool = False,
     ignore_unstable: bool = False,
 ) -> None:
     """

--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -5,9 +5,9 @@ Verify chisel slice definition files by installing the slices.
 
 Usage
 -----
-install_slices.py [-h] --arch ARCH --release RELEASE [--dry-run] [--ensure-existence]
-                  [--ignore-missing] [--ignore-unstable] [--ignore-unmaintained]
-                  [--workers WORKERS] [file ...]
+install_slices [-h] --arch ARCH --release RELEASE [--dry-run]
+               [--ensure-existence] [--ignore-missing] [--ignore-unstable]
+               [--ignore-unmaintained] [--workers WORKERS] [file ...]
 
 Verify slice definition files by installing the slices
 

--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -21,8 +21,8 @@ options:
   --dry-run             Perform dry run: do not actually install the slices
   --ensure-existence    Each package must exist in the archive for at least one architecture
   --ignore-missing      Ignore arch-specific package not found in archive errors
-  --ignore-unstable     Ignore packages from unstable components
-  --ignore-unmaintained Ignore packages from unmaintained components
+  --ignore-unstable     Ignore packages from unstable releases
+  --ignore-unmaintained Ignore packages from unmaintained releases
   --workers WORKERS     Number of workers to use for parallel installation (default: 5)
 """
 
@@ -113,13 +113,13 @@ def parse_args() -> argparse.Namespace:
         "--ignore-unstable",
         required=False,
         action="store_true",
-        help="Ignore packages from unstable components",
+        help="Ignore packages from unstable releases",
     )
     parser.add_argument(
         "--ignore-unmaintained",
         required=False,
         action="store_true",
-        help="Ignore packages from unmaintained components",
+        help="Ignore packages from unmaintained releases",
     )
     parser.add_argument(
         "files",

--- a/.github/scripts/install-slices/version-matrix.py
+++ b/.github/scripts/install-slices/version-matrix.py
@@ -3,19 +3,6 @@
 import os
 import json
 
-# NOTE: This is a temporary function to determine the ignore flag which we then
-#       pass to install-slices.py. We will likely refactor this in the future
-#       to be a neater and the logic will be moved away from here.
-#       See: https://github.com/canonical/chisel-releases/issues/675
-def determine_ignore_flag(ignore: str, chisel_version: str) -> str:
-    ignore_flag = ""
-    if chisel_version == "main":
-        if ignore == "unstable":
-            ignore_flag = "--ignore-unstable"
-        elif ignore == "unmaintained":
-            ignore_flag = "--ignore-unmaintained"
-    return ignore_flag
-
 arches, releases = json.loads(os.environ["ARCHES"]), json.loads(os.environ["RELEASES"])
 matrix = []
 for arch in arches:
@@ -25,7 +12,6 @@ for arch in arches:
                 "arch": arch,
                 "ref": release["ref"],
                 "chisel-version": chisel_version,
-                "ignore-flag": determine_ignore_flag(release.get("ignore", ""), chisel_version)
             })
 
 print(json.dumps(matrix))

--- a/.github/scripts/install-slices/version-matrix.py
+++ b/.github/scripts/install-slices/version-matrix.py
@@ -3,6 +3,15 @@
 import os
 import json
 
+def determine_ignore_flag(ignore: str, chisel_version: str) -> str:
+    ignore_flag = ""
+    if chisel_version == "main":
+        if ignore == "unstable":
+            ignore_flag = "--ignore-unstable"
+        elif ignore == "unmaintained":
+            ignore_flag = "--ignore-unmaintained"
+    return ignore_flag
+
 arches, releases = json.loads(os.environ["ARCHES"]), json.loads(os.environ["RELEASES"])
 matrix = []
 for arch in arches:
@@ -12,6 +21,7 @@ for arch in arches:
                 "arch": arch,
                 "ref": release["ref"],
                 "chisel-version": chisel_version,
+                "ignore-flag": determine_ignore_flag(release.get("ignore", ""), chisel_version)
             })
 
 print(json.dumps(matrix))

--- a/.github/scripts/install-slices/version-matrix.py
+++ b/.github/scripts/install-slices/version-matrix.py
@@ -3,6 +3,10 @@
 import os
 import json
 
+# NOTE: This is a temporary function to determine the ignore flag which we then
+#       pass to install-slices.py. We will likely refactor this in the future
+#       to be a neater and the logic will be moved away from here.
+#       See: https://github.com/canonical/chisel-releases/issues/675
 def determine_ignore_flag(ignore: str, chisel_version: str) -> str:
     ignore_flag = ""
     if chisel_version == "main":

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -31,13 +31,6 @@ env:
       {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","main"], "ignore": "unstable"}
     ]
 
-  # when ignore flag is set to "unstable", we want to pass --ignore-unstable to
-  # install-slices.py to ignore errors about unstable slices.
-  # when ignore flag is set to "unmaintained", we want to pass --ignore-unmaintained to
-  # install-slices.py to ignore errors about unmaintained slices.
-  # when ignore flag is empty, we don't want to pass any ignore flag to
-  # install-slices.py.
-
 jobs:
   prepare-install:
     runs-on: ubuntu-latest

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -214,6 +214,7 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
+              --ignore-unstable \
               --workers "${WORKERS}" \
               slices/**/*.yaml
           elif [[ "${{ steps.changed-paths.outputs.slices }}" == "true" ]]; then
@@ -221,6 +222,7 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
+              --ignore-unstable \
               --workers "${WORKERS}" \
               ${{ steps.changed-paths.outputs.slices_files }}
           fi

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -82,6 +82,7 @@ jobs:
             RELEASES="[]"
             for branch in $all_branches; do
               # Only add to RELEASES when ref is equal to $branch from RELEASES_COMPATIBILITY
+              # and the entry in RELEASES_COMPATIBILITY contains "main" in "chisel-versions"
               jq_program='[.[] | select(.ref == $ref) | select(.["chisel-versions"] | index("main")) | ."chisel-versions" = ["main"]]'
               ref="$(echo "$RELEASES_COMPATIBILITY" | jq --arg ref "$branch" "$jq_program")"
               RELEASES="$(echo "$RELEASES" | jq --argjson ref "$ref" '. + $ref')"

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -24,12 +24,19 @@ env:
   ARCHES: '["amd64","arm64","armhf","ppc64el","riscv64","s390x"]'
   RELEASES_COMPATIBILITY: |
     [
-      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"], "ignore": "unmaintained"},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-25.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
-      {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","main"]}
+      {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","main"], "ignore": "unstable"}
     ]
+
+  # when ignore flag is set to "unstable", we want to pass --ignore-unstable to
+  # install-slices.py to ignore errors about unstable slices.
+  # when ignore flag is set to "unmaintained", we want to pass --ignore-unmaintained to
+  # install-slices.py to ignore errors about unmaintained slices.
+  # when ignore flag is empty, we don't want to pass any ignore flag to
+  # install-slices.py.
 
 jobs:
   prepare-install:
@@ -214,7 +221,7 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
-              --ignore-unstable \
+              ${{ matrix.ignore-flag }} \
               --workers "${WORKERS}" \
               slices/**/*.yaml
           elif [[ "${{ steps.changed-paths.outputs.slices }}" == "true" ]]; then
@@ -222,7 +229,7 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
-              --ignore-unstable \
+              ${{ matrix.ignore-flag }} \
               --workers "${WORKERS}" \
               ${{ steps.changed-paths.outputs.slices_files }}
           fi

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -24,11 +24,11 @@ env:
   ARCHES: '["amd64","arm64","armhf","ppc64el","riscv64","s390x"]'
   RELEASES_COMPATIBILITY: |
     [
-      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"], "ignore": "unmaintained"},
+      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-25.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
-      {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","main"], "ignore": "unstable"}
+      {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","main"]}
     ]
 
 jobs:
@@ -214,7 +214,7 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
-              ${{ matrix.ignore-flag }} \
+              --ignore-unstable \
               --workers "${WORKERS}" \
               slices/**/*.yaml
           elif [[ "${{ steps.changed-paths.outputs.slices }}" == "true" ]]; then
@@ -222,7 +222,7 @@ jobs:
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
-              ${{ matrix.ignore-flag }} \
+              --ignore-unstable \
               --workers "${WORKERS}" \
               ${{ steps.changed-paths.outputs.slices_files }}
           fi

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -24,7 +24,7 @@ env:
   ARCHES: '["amd64","arm64","armhf","ppc64el","riscv64","s390x"]'
   RELEASES_COMPATIBILITY: |
     [
-      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
+      {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-25.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -82,7 +82,7 @@ jobs:
             RELEASES="[]"
             for branch in $all_branches; do
               # Only add to RELEASES when ref is equal to $branch from RELEASES_COMPATIBILITY
-              jq_program='[.[] | select(.ref == $ref) | ."chisel-versions" = ["main"]]'
+              jq_program='[.[] | select(.ref == $ref) | select(.["chisel-versions"] | index("main")) | ."chisel-versions" = ["main"]]'
               ref="$(echo "$RELEASES_COMPATIBILITY" | jq --arg ref "$branch" "$jq_program")"
               RELEASES="$(echo "$RELEASES" | jq --argjson ref "$ref" '. + $ref')"
             done

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -82,7 +82,8 @@ jobs:
             RELEASES="[]"
             for branch in $all_branches; do
               # Only add to RELEASES when ref is equal to $branch from RELEASES_COMPATIBILITY
-              ref="$(echo "$RELEASES_COMPATIBILITY" | jq --arg ref "$branch" '[.[] | select(.ref == $ref) | ."chisel-versions" = ["main"]]')"
+              jq_program='[.[] | select(.ref == $ref) | ."chisel-versions" = ["main"]]'
+              ref="$(echo "$RELEASES_COMPATIBILITY" | jq --arg ref "$branch" "$jq_program")"
               RELEASES="$(echo "$RELEASES" | jq --argjson ref "$ref" '. + $ref')"
             done
 


### PR DESCRIPTION
# Proposed changes

adds `--ignore=unstable` and `--ignore=unmaintained` flag to the `install-slices` ci job. 

the unstable flag is required allow #681 to not fail (at the time of writing it is unstable)

the unmaintained flag allows #677 not to fail (at the time of writing it is past its maintenance period) 

note: the CI checks are going to be red across the board due to the underlying issue, until we add the `maintenance` field.

## Related issues/PRs

#677 and #681 are part of a series of (independent) commits which implement #631, and resolves #675

### Forward porting
n/a

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)