### PR TITLE
feat(24.04): add maintenance to chisel.yaml

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -4,7 +4,7 @@ maintenance:
   standard: 2024-04-25
   expanded: 2029-05-31
   legacy: 2034-04-25
-  end-of-life: 2036-04-25
+  end-of-life: 2036-04-29
 
 archives:
   # archive.ubuntu.com/ubuntu/      (amd64, i386)

--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,5 +1,11 @@
 format: v1
 
+maintenance:
+  standard: 2024-04-25
+  expanded: 2029-05-31
+  legacy: 2034-04-25
+  end-of-life: 2036-04-25
+
 archives:
   # archive.ubuntu.com/ubuntu/      (amd64, i386)
   # ports.ubuntu.com/ubuntu-ports/  (other arch)


### PR DESCRIPTION
# Proposed changes

add `maintenance` field to chisel.yaml

dates obtained with:

```
date -d "today + $(distro-info --days=release --series <series>) days" --iso-8601 
```

[distro-info data](https://git.launchpad.net/ubuntu/+source/distro-info-data/plain/ubuntu.csv)

## Related issues/PRs

implements #631, resolves #675

### Forward porting

25.10: #681
25.04: #680
24.04: #679 **(this pr)** 
22.04: #678
20:04: #677

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)