### PR TITLE
feat(25.04): add maintenance to chisel.yaml

### DIFF
--- a/chisel.yaml
+++ b/chisel.yaml
@@ -1,5 +1,9 @@
 format: v1
 
+maintenance:
+  standard: 2025-04-17
+  end-of-life: 2026-01-15
+
 archives:
   ubuntu:
     default: true


### PR DESCRIPTION
# Proposed changes

add `maintenance` field to chisel.yaml

dates obtained with:

```
date -d "today + $(distro-info --days=release --series <series>) days" --iso-8601 
```

[distro-info data](https://git.launchpad.net/ubuntu/+source/distro-info-data/plain/ubuntu.csv)

## Related issues/PRs

implements #631, resolves #675

### Forward porting

25.10: #681
25.04: #680 **(this pr)**
24.04: #679 
22.04: #678
20:04: #677

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)