### PR TITLE
feat(24.04): add libc-bin getent slice

### DIFF
--- a/slices/libc-bin.yaml
+++ b/slices/libc-bin.yaml
@@ -36,6 +36,12 @@ slices:
     contents:
       /usr/bin/getconf:
 
+  getent:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/getent:
+
   copyright:
     contents:
       /usr/share/doc/libc-bin/copyright:

--- a/tests/spread/integration/libc-bin/task.yaml
+++ b/tests/spread/integration/libc-bin/task.yaml
@@ -1,6 +1,17 @@
 summary: Integration tests for libc-bin
 
-execute: |
-  rootfs="$(install-slices libc-bin_getconf)"
+environment:
+  SLICE/getconf: "getconf"
+  SLICE/getent: "getent"
 
-  chroot "$rootfs" getconf -a
+execute: |
+  rootfs="$(install-slices libc-bin_${SLICE} )"
+
+  case SLICE in
+    getconf)
+      chroot "$rootfs" getconf -a
+    ;;
+    getent)
+      chroot "$rootfs" getent --version | grep -q getent
+    ;;
+  esac


### PR DESCRIPTION
# Proposed changes

Add libc-bin getent slice. 

When building development rock I have tried to run `apt-get install maven`. Since development rock does not have proper apt database, it pulled full dependency tree, including passwd. Passwd failed postinst script due to missing `getent` utility.

## Related issues/PRs
<!-- If any -->

### Forward porting
 
Pending initial review.

## Checklist

* [ ] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [ ] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [ ] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->