### PR TITLE
fix(24.04): base-files_etc - add /etc/profile.d

### DIFF
--- a/slices/base-files.yaml
+++ b/slices/base-files.yaml
@@ -16,6 +16,7 @@ slices:
   etc:
     contents:
       /etc/:
+      /etc/profile.d/:
 
   bin:
     contents:


### PR DESCRIPTION
# Proposed changes

Installing gdb in the dev rock does not work because /etc/profile.d is missing:

```
2025-10-01 14:11:25.811 :: #5 175.5 Use of uninitialized value $Debconf::Encoding::charmap in scalar chomp at /usr/share/perl5/Debconf/Encoding.pm line 17.
2025-10-01 14:11:25.811 :: #5 175.6 ln: failed to create symbolic link '/etc/profile.d/debuginfod.sh': No such file or directory
2025-10-01 14:11:25.811 :: #5 175.6 dpkg: error processing package libdebuginfod-common (--configure):
2025-10-01 14:11:25.811 :: #5 175.6  installed libdebuginfod-common package post-installation script subprocess returned error exit status 1
```

## Related issues/PRs
<!-- If any -->

### Forward porting

https://github.com/canonical/chisel-releases/pull/686
https://github.com/canonical/chisel-releases/pull/687

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->