### PR TITLE
Add .NET 8 chisel slice definitions for Ubuntu 22.04

### DIFF
--- a/slices/aspnetcore-runtime-6.0.yaml
+++ b/slices/aspnetcore-runtime-6.0.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       - dotnet-runtime-6.0_libs
     contents:
-      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/6.0.*/**:
 
   copyright:
     contents:

--- a/slices/aspnetcore-runtime-8.0.yaml
+++ b/slices/aspnetcore-runtime-8.0.yaml
@@ -1,0 +1,26 @@
+package: aspnetcore-runtime-8.0
+
+essential:
+  - aspnetcore-runtime-8.0_copyright
+
+slices:
+  # libicu is not needed if the environment is set to invariant by using
+  # the environment variable DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+  # If globalization is needed, libicu must be included as well.
+  # For more information, see:
+  # https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization
+  # https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md
+  core:
+    essential:
+      - dotnet-runtime-8.0_core
+    contents:
+      /usr/lib/dotnet/shared/Microsoft.AspNetCore.App/8.0.*/**:
+
+  standard:
+    essential:
+      - aspnetcore-runtime-8.0_core
+      - libicu70_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/aspnetcore-runtime-8.0/copyright:

--- a/slices/aspnetcore-targeting-pack-8.0.yaml
+++ b/slices/aspnetcore-targeting-pack-8.0.yaml
@@ -1,0 +1,13 @@
+package: aspnetcore-targeting-pack-8.0
+
+essential:
+  - aspnetcore-targeting-pack-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Ref/8.0.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/aspnetcore-targeting-pack-8.0/copyright:

--- a/slices/dotnet-apphost-pack-8.0.yaml
+++ b/slices/dotnet-apphost-pack-8.0.yaml
@@ -1,0 +1,21 @@
+package: dotnet-apphost-pack-8.0
+
+essential:
+  - dotnet-apphost-pack-8.0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libssl3_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+    contents:
+      # This package is not meant for general use. Therefore we are not
+      # splitting it further into _bins and _headers slices.
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Host.*/8.0.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-apphost-pack-8.0/copyright:

--- a/slices/dotnet-host-8.0.yaml
+++ b/slices/dotnet-host-8.0.yaml
@@ -1,0 +1,18 @@
+package: dotnet-host-8.0
+
+essential:
+  - dotnet-host-8.0_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/bin/dotnet:
+      /usr/lib/dotnet/dotnet:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-host-8.0/copyright:

--- a/slices/dotnet-host.yaml
+++ b/slices/dotnet-host.yaml
@@ -10,7 +10,7 @@ slices:
       - libgcc-s1_libs
       - libstdc++6_libs
     contents:
-      /usr/lib/dotnet/dotnet:
+      /usr/lib/dotnet/dotnet: { prefer: dotnet-host-8.0 }
 
   copyright:
     contents:

--- a/slices/dotnet-hostfxr-6.0.yaml
+++ b/slices/dotnet-hostfxr-6.0.yaml
@@ -11,7 +11,7 @@ slices:
       - libgcc-s1_libs
       - libstdc++6_libs
     contents:
-      /usr/lib/dotnet/host/fxr/*/libhostfxr.so:
+      /usr/lib/dotnet/host/fxr/6.0.*/libhostfxr.so:
 
   copyright:
     contents:

--- a/slices/dotnet-hostfxr-8.0.yaml
+++ b/slices/dotnet-hostfxr-8.0.yaml
@@ -1,0 +1,18 @@
+package: dotnet-hostfxr-8.0
+
+essential:
+  - dotnet-hostfxr-8.0_copyright
+
+slices:
+  libs:
+    essential:
+      - dotnet-host-8.0_bins
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+    contents:
+      /usr/lib/dotnet/host/fxr/8.0.*/libhostfxr.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-hostfxr-8.0/copyright:

--- a/slices/dotnet-runtime-6.0.yaml
+++ b/slices/dotnet-runtime-6.0.yaml
@@ -17,7 +17,7 @@ slices:
       - libunwind8_libs
       - zlib1g_libs
     contents:
-      /usr/lib/dotnet/shared/Microsoft.NETCore.App/**:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/6.0.*/**:
 
   copyright:
     contents:

--- a/slices/dotnet-runtime-8.0.yaml
+++ b/slices/dotnet-runtime-8.0.yaml
@@ -1,0 +1,32 @@
+package: dotnet-runtime-8.0
+
+essential:
+  - dotnet-runtime-8.0_copyright
+
+slices:
+  # libicu is not needed if the environment is set to invariant by using
+  # the environment variable DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+  # If globalization is needed, libicu must be included as well.
+  # For more information, see:
+  # https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization
+  # https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md
+  core:
+    essential:
+      - dotnet-hostfxr-8.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - liblttng-ust1_libs
+      - libssl3_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/dotnet/shared/Microsoft.NETCore.App/8.0.*/**:
+
+  standard:
+    essential:
+      - dotnet-runtime-8.0_core
+      - libicu70_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-runtime-8.0/copyright:

--- a/slices/dotnet-sdk-8.0.yaml
+++ b/slices/dotnet-sdk-8.0.yaml
@@ -1,0 +1,41 @@
+package: dotnet-sdk-8.0
+
+essential:
+  - dotnet-sdk-8.0_copyright
+
+slices:
+  # libicu is not needed if the environment is set to invariant by using
+  # the environment variable DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+  # If globalization is needed, libicu must be included as well.
+  # For more information, see:
+  # https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization
+  # https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md
+  core:
+    essential:
+      - aspnetcore-runtime-8.0_core
+      - aspnetcore-targeting-pack-8.0_libs
+      - ca-certificates_data
+      - dotnet-apphost-pack-8.0_libs
+      - dotnet-runtime-8.0_core
+      - dotnet-targeting-pack-8.0_libs
+      - dotnet-templates-8.0_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - netstandard-targeting-pack-2.1-8.0_libs
+    contents:
+      /usr/lib/dotnet/metadata/workloads/8.0.100/userlocal:
+      /usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Runtime.*/8.0.*/**:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Runtime.*/8.0.*/**:
+      /usr/lib/dotnet/sdk-manifests/8.0.100/microsoft.net.sdk.aspire/8.0.0-preview.*/**:
+      /usr/lib/dotnet/sdk-manifests/8.0.100/microsoft.net.workload.*/**:
+      /usr/lib/dotnet/sdk/8.0.*/**:
+
+  standard:
+    essential:
+      - dotnet-sdk-8.0_core
+      - libicu70_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-sdk-8.0/copyright:

--- a/slices/dotnet-targeting-pack-8.0.yaml
+++ b/slices/dotnet-targeting-pack-8.0.yaml
@@ -1,0 +1,13 @@
+package: dotnet-targeting-pack-8.0
+
+essential:
+  - dotnet-targeting-pack-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/8.0.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-targeting-pack-8.0/copyright:

--- a/slices/dotnet-templates-8.0.yaml
+++ b/slices/dotnet-templates-8.0.yaml
@@ -1,0 +1,15 @@
+package: dotnet-templates-8.0
+
+essential:
+  - dotnet-templates-8.0_copyright
+
+slices:
+  libs:
+    essential:
+      - dotnet-host-8.0_bins
+    contents:
+      /usr/lib/dotnet/templates/8.0.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/dotnet-templates-8.0/copyright:

--- a/slices/netstandard-targeting-pack-2.1-8.0.yaml
+++ b/slices/netstandard-targeting-pack-2.1-8.0.yaml
@@ -1,0 +1,13 @@
+package: netstandard-targeting-pack-2.1-8.0
+
+essential:
+  - netstandard-targeting-pack-2.1-8.0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/dotnet/packs/NETStandard.Library.Ref/2.1.*/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/netstandard-targeting-pack-2.1-8.0/copyright:

--- a/tests/spread/integration/aspnetcore-runtime-8.0/task.yaml
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/task.yaml
@@ -1,0 +1,59 @@
+summary: Integration tests for ASP.NET 8 Runtime
+
+variants:
+    - +WithoutLibicu
+    - +WithLibicu
+
+environment:
+  # needed, because libicu is not installed
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT/WithoutLibicu: "true"
+  # disable noisy help text for users who run .NET for the first time
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+
+prepare: |
+  required_slices=()
+  if [[ -v DOTNET_SYSTEM_GLOBALIZATION_INVARIANT ]]; then
+    required_slices+=(aspnetcore-runtime-8.0_core)
+  else
+    required_slices+=(aspnetcore-runtime-8.0_standard)
+  fi
+  
+  # install slices
+  rootfs="$(install-slices ${required_slices[@]})"
+  echo "$rootfs" > ROOTFS
+
+  # preparing the test data
+  apt-get update && apt-get install -y dotnet-sdk-8.0
+  cp -r web_helloworld "${rootfs}"/web_helloworld
+  dotnet publish "${rootfs}"/web_helloworld/Hello.csproj --no-self-contained
+
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+  mkdir -p "${rootfs}"/dev
+  head -c 500 /dev/urandom > "${rootfs}"/dev/random
+  head -c 500 /dev/urandom > "${rootfs}"/dev/urandom
+
+execute: |
+  rootfs="$(cat ROOTFS)"
+
+  # test the helloworld web app
+  chroot "${rootfs}" /usr/bin/dotnet /web_helloworld/bin/Release/net8.0/Hello.dll --urls="http://0.0.0.0:5108" &
+  app_pid=$!
+
+  # Wait for the web app to start
+  while ! fuser 5108/tcp > /dev/null 2>&1; do
+    if ! test -d /proc/$app_pid; then
+      echo "dotnet exited quickly"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  # Send a request to the web app and verify the result
+  ret=0
+  curl http://localhost:5108/ | grep "Hello World!" || ret=1
+
+  # Cleanup
+  kill $app_pid
+  exit $ret

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Hello.csproj
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Hello.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Program.cs
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Properties/launchSettings.json
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+    "iisSettings": {
+        "windowsAuthentication": false,
+        "anonymousAuthentication": true,
+        "iisExpress": {
+            "applicationUrl": "http://localhost:65090",
+            "sslPort": 44311
+        }
+    },
+    "profiles": {
+        "Hello": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "https://localhost:7158;http://localhost:5108",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        "IIS Express": {
+            "commandName": "IISExpress",
+            "launchBrowser": true,
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
+    }
+}

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.Development.json
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    }
+}

--- a/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.json
+++ b/tests/spread/integration/aspnetcore-runtime-8.0/web_helloworld/appsettings.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*"
+}

--- a/tests/spread/integration/dotnet-host-8.0/task.yaml
+++ b/tests/spread/integration/dotnet-host-8.0/task.yaml
@@ -1,0 +1,28 @@
+summary: Integration tests for .NET 8 Host 
+
+variants:
+    - +WithoutLibicu
+    - +WithLibicu
+
+environment:
+  # needed, because libicu is not installed
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT/WithoutLibicu: "true"
+  # disable noisy help text for users who run .NET for the first time
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+
+prepare: |
+  required_slices=(dotnet-runtime-8.0_core)
+  if [[ ! -v DOTNET_SYSTEM_GLOBALIZATION_INVARIANT ]]; then
+    required_slices+=(libicu70_libs)
+  fi
+  
+  # install slices
+  rootfs="$(install-slices ${required_slices[@]})"
+  echo "$rootfs" > ROOTFS
+
+execute: |
+  rootfs="$(cat ROOTFS)"
+  
+  # smoking test the .NET host
+  chroot "${rootfs}" /usr/bin/dotnet --info

--- a/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Hello.csproj
+++ b/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Hello.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Program.cs
+++ b/tests/spread/integration/dotnet-runtime-8.0/app_helloworld/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Hello, World!");

--- a/tests/spread/integration/dotnet-runtime-8.0/task.yaml
+++ b/tests/spread/integration/dotnet-runtime-8.0/task.yaml
@@ -1,0 +1,38 @@
+summary: Integration tests for .NET 8 Runtime 
+
+variants:
+    - +WithoutLibicu
+    - +WithLibicu
+
+environment:
+  # needed, because libicu is not installed
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT/WithoutLibicu: "true"
+  # disable noisy help text for users who run .NET for the first time
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+
+prepare: |
+  required_slices=()
+  if [[ -v DOTNET_SYSTEM_GLOBALIZATION_INVARIANT ]]; then
+    required_slices+=(dotnet-runtime-8.0_core)
+  else
+    required_slices+=(dotnet-runtime-8.0_standard)
+  fi
+  
+  # install slices
+  rootfs="$(install-slices ${required_slices[@]})"
+  echo "$rootfs" > ROOTFS
+
+  # preparing the test data
+  apt-get update && apt-get install -y dotnet-sdk-8.0
+  cp -r app_helloworld "${rootfs}"/app_helloworld
+  dotnet publish "${rootfs}"/app_helloworld/Hello.csproj --no-self-contained
+
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+
+execute: |
+  rootfs="$(cat ROOTFS)"
+
+  # test the helloworld app
+  chroot "${rootfs}" /usr/bin/dotnet /app_helloworld/bin/Release/net8.0/Hello.dll | grep -q "Hello, World!"

--- a/tests/spread/integration/dotnet-sdk-8.0/NuGet.Config
+++ b/tests/spread/integration/dotnet-sdk-8.0/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+    </packageSources>
+</configuration>

--- a/tests/spread/integration/dotnet-sdk-8.0/helloworld.fsx
+++ b/tests/spread/integration/dotnet-sdk-8.0/helloworld.fsx
@@ -1,0 +1,1 @@
+printfn "Hello from F#"

--- a/tests/spread/integration/dotnet-sdk-8.0/task.yaml
+++ b/tests/spread/integration/dotnet-sdk-8.0/task.yaml
@@ -1,0 +1,70 @@
+summary: Integration tests for .NET 8 SDK 
+
+kill-timeout: 1m30s
+
+variants:
+    - +WithoutLibicu
+    - +WithLibicu
+
+environment:
+  # needed, because libicu is not installed
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT/WithoutLibicu: "true"
+  # disable noisy help text for users who run .NET for the first time
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+  HOME: /root
+
+prepare: |
+  required_slices=(base-passwd_data base-files_lib)
+  if [[ -v DOTNET_SYSTEM_GLOBALIZATION_INVARIANT ]]; then
+    required_slices+=(dotnet-sdk-8.0_core)
+  else
+    required_slices+=(dotnet-sdk-8.0_standard)
+  fi
+  
+  # install slices
+  rootfs="$(install-slices ${required_slices[@]})"
+  echo "$rootfs" > ROOTFS
+  
+  # needed by the SDK to determine system information
+  mkdir -p "${rootfs}"/proc
+  mount --bind /proc "${rootfs}"/proc
+ 
+  # needed by various utilities of the SDK
+  mkdir -p "${rootfs}/tmp"
+  
+  # needed by crypto libraries e.g. to generate a GUID's
+  mkdir -p "${rootfs}"/dev
+  head -c 500 /dev/urandom > "${rootfs}"/dev/random
+  head -c 500 /dev/urandom > "${rootfs}"/dev/urandom
+  
+  # The .NET SDK creates config files in the users home directory.
+  mkdir -p "${rootfs}${HOME}"
+
+  # Set the user config to not use nuget.org, because sometimes dotnet restore is
+  # flaky and hangs indefinitely. Also, we do not need depenencies from the internet.
+  mkdir -p "${rootfs}${HOME}/.nuget/NuGet"
+  cp NuGet.Config "${rootfs}${HOME}/.nuget/NuGet/NuGet.Config"
+  
+  cp helloworld.fsx "${rootfs}"/helloworld.fsx
+
+execute: |
+  rootfs="$(cat ROOTFS)"
+
+  # smoke test the .NET host:
+  chroot "${rootfs}" /usr/bin/dotnet --info
+
+  # smoke test the F# interpreter:
+  chroot "${rootfs}" /usr/bin/dotnet fsi /helloworld.fsx | grep -q "Hello from F#"
+
+  # Create a C# Hello World .NET app from templates
+  # Using --no-restore flag, because dotnet new hangs indefinitely at restoring (related to: https://github.com/dotnet/core/issues/8057)
+  chroot "${rootfs}" /usr/bin/dotnet new console --output /app_helloworld --no-restore
+
+  # Build the C# Hello World .NET app
+  chroot "${rootfs}" /usr/bin/dotnet restore /app_helloworld/app_helloworld.csproj
+  chroot "${rootfs}" /usr/bin/dotnet build /app_helloworld/app_helloworld.csproj --configuration Release --no-restore
+  chroot "${rootfs}" /usr/bin/dotnet publish /app_helloworld/app_helloworld.csproj --no-restore --no-build
+  
+  # Run the C# Hello World .NET app
+  chroot "${rootfs}" /usr/bin/dotnet /app_helloworld/bin/Release/net8.0/publish/app_helloworld.dll | grep -q "Hello, World!"


### PR DESCRIPTION
# Proposed changes
Add .NET 8 SDK chisel slice definitions for Ubuntu 24.04.

This is a backport from the recently merged Ubuntu 24.04 .NET 8 runtimes/SDK slice definitions (commit: 3c2d428960fe7f45183d0cabf56dee1b11757b5e).

## Related issues/PRs
N/A

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->
- https://github.com/canonical/chisel-releases/pull/692
- https://github.com/canonical/chisel-releases/pull/561
- https://github.com/canonical/chisel-releases/pull/562
- https://github.com/canonical/chisel-releases/pull/563


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [ ] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
Needed to create .NET SDK chiseled container images.