### PR TITLE
feat(25.04): publish chisel manifests as test artefacts

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -6,7 +6,7 @@ environment:
   PROJECT_PATH: /chisel-releases
   SHARED_LIBRARIES: $PROJECT_PATH/tests/spread/lib
   PATH: /snap/bin:$PATH:$SHARED_LIBRARIES
-  MANIFESTS_EXPORT_DIR: manifests
+  MANIFESTS_EXPORT_DIR: /usr/share/manifests
 
 exclude:
   - .github
@@ -39,7 +39,7 @@ backends:
       lxc exec $SPREAD_SYSTEM -- killall -HUP sshd
       ADDRESS `lxc list --format=json $SPREAD_SYSTEM | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address'`
     discard: |
-      lxc file pull -pr $SPREAD_SYSTEM/$MANIFESTS_EXPORT_DIR ~/$MANIFESTS_EXPORT_DIR || true
+      lxc file pull -pr $SPREAD_SYSTEM/$MANIFESTS_EXPORT_DIR $MANIFESTS_EXPORT_DIR || true
       lxc stop $SPREAD_SYSTEM || true
     systems:
       - ubuntu-plucky:

--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -13,26 +13,25 @@ function main() {
     local rootfs="$(mktemp -d)"
     #shellcheck disable=SC2086
     chisel cut --release "$PROJECT_PATH" --root "$rootfs" $slices
-    export_manifests "$rootfs"
+    [ -n "$MANIFESTS_EXPORT_DIR" ] && export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"
 
     echo "${rootfs}"
 }
 
 function export_manifests() {
-    # if MANIFESTS_EXPORT_DIR is set, copy the manifests there
+    # copy the manifests to a common export directory
     # manifest is at $rootfs/var/lib/chisel/manifest.wall
-    # it will be copied to $MANIFESTS_EXPORT_DIR/$test_name/manifestXXXXX.wall where
+    # it will be copied to $manifests_export_dir/$test_name/manifestXXXXX.wall where
     # XXXXX is sequence number (starting from 00000)
     # note that install_slices can be called multiple times from the same test
     local rootfs="$1"
-    if [ -n "$MANIFESTS_EXPORT_DIR" ]; then
-        local test_name=$(basename "$PWD")
-        test_name=${test_name:-default}
-        local export_dir="/$MANIFESTS_EXPORT_DIR/$test_name"
-        mkdir -p "$export_dir"
-        local seq=$(find "$export_dir" -type f -name 'manifest_*.wall' | wc -l)
-        cp "$rootfs/var/lib/chisel/manifest.wall" "$export_dir/manifest_$(printf "%05d" "$seq").wall"
-    fi
+    local manifests_export_dir="$2"
+    local test_name=$(basename "$PWD")
+    test_name=${test_name:-default}
+    local export_dir="$manifests_export_dir/$test_name"
+    mkdir -p "$export_dir"
+    local seq=$(find "$export_dir" -type f -name 'manifest_*.wall' | wc -l)
+    cp "$rootfs/var/lib/chisel/manifest.wall" "$export_dir/manifest_$(printf "%05d" "$seq").wall"
 }
 
 main "$@"


### PR DESCRIPTION
# Proposed changes

Ensure every `install_slices` always installs `base-files_chisel` slice and therefore every rootfs in tests has a generated manifest.wall file.

All the `.wall` files for every test are then exported to host to be used in other parts of the pipeline.

Example of a correct behavior can be seen [here](https://github.com/alesancor1/chisel-releases/pull/10).

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/720
- unblocks https://github.com/canonical/chisel-releases/issues/743
- unblocks https://github.com/canonical/chisel-releases/issues/770

### Forward porting

_(all identical)_

- https://github.com/canonical/chisel-releases/pull/708
- https://github.com/canonical/chisel-releases/pull/709
- https://github.com/canonical/chisel-releases/pull/710
- https://github.com/canonical/chisel-releases/pull/711 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/712
- https://github.com/canonical/chisel-releases/pull/772

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)