### PR TITLE
feat(25.10): add base-files_chisel to install_slices

### DIFF
--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -1,10 +1,19 @@
 #!/bin/bash -ex
+# spellchecker: ignore rootfs
 
 # Installs one or more slices into a dynamically created temporary path.
 # Usage: install-slices [<slice>...]
 # Returns the path of the chiselled rootfs
 
-tmpdir="$(mktemp -d)"
+function main() {
+    local slices="$*"
+    # add base-files_chisel slice to ensure we generate the manifest
+    slices="${slices} base-files_chisel"
 
-echo "${tmpdir}"
-chisel cut --release "$PROJECT_PATH" --root "$tmpdir" $@
+    local rootfs="$(mktemp -d)"
+    #shellcheck disable=SC2086
+    chisel cut --release "$PROJECT_PATH" --root "$rootfs" $slices
+    echo "${rootfs}"
+}
+
+main "$@"


### PR DESCRIPTION
# Proposed changes

Ensure every `install_slices` always installs `base-files_chisel` slice and therefore every rootfs in tests has a generated manifest.wall file.

Example of a correct behavior can be seen [here](https://github.com/canonical/chisel-releases/actions/runs/18308147392/job/52130186706?pr=706#step:10:91) ( testing PR with the same `install_slices` and the test for ca-certificates modified to ensure the manifest is generated, and then fail on purpose with `exit 99` so that we see the spread output )

This PR includes a gentle refactor if `install_slices` to prepare it for future work.

## Related issues/PRs
n/a

### Forward porting

![work in progress](https://img.shields.io/badge/Work%20In%20Progress-yellow)

will add all the forward porting links once all the PRs are up

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)