### PR TITLE
feat: retry `chisel cut` on digest failure

### DIFF
--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -321,7 +321,7 @@ def chisel_cut(
     root: str,
     slice_name: str,
     chisel_version: str,
-    env: dict[str, str],
+    cache_dir: str,
     n_retries: int = 3,
 ) -> str | None:
     """
@@ -329,6 +329,8 @@ def chisel_cut(
     Retry up to n_retries times if a fetch error occurs.
     Return an error message if something went wrong, or None on success.
     """
+    env = dict(os.environ)
+    env["XDG_CACHE_HOME"] = str(cache_dir)
 
     _fetch_error_substr = "error: cannot fetch from archive"
 
@@ -378,15 +380,13 @@ def install_slices(
         if dry_run:
             continue
         with tempfile.TemporaryDirectory() as tmpfs, tempfile.TemporaryDirectory() as cache_dir:
-            env = dict(os.environ)
-            env["XDG_CACHE_HOME"] = str(cache_dir)
             err = chisel_cut(
                 arch=arch,
                 release=release,
                 root=tmpfs,
+                cache_dir=cache_dir,
                 slice_name=slice_name,
                 chisel_version=chisel_version,
-                env=env,
             )
             if err:
                 logging.error("==============================================\n%s", err)


### PR DESCRIPTION
# Proposed changes

The 'install_slices' run often fails due to a race condition between chisel and archive update.

```
error: cannot fetch from archive: expected digest b6077fffd1713e5bb0a2ab630a749f4cb830cbe0dc263ce056dcc5ea9f0f5d91, got d77dd776f0e271f2dfb833d7cb34a1ff7db51cccceaf2191ee49539e86683239
```

this PR adds a simple retry mechanism to alleviate this.

the old chisel cut code has been refactored into `_chisel_cut`, and a simple retry wrapper has been added around it with no delay/backoff mechanism.

example of a failure: https://github.com/canonical/chisel-releases/actions/runs/18392830847

example of a successful save: https://github.com/canonical/chisel-releases/actions/runs/18418001690/job/52486125490#step:8:1165

## Related issues/PRs

- closes https://github.com/canonical/chisel-releases/issues/765

### Forward porting
n/a

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)