### PR TITLE
ci: add debug check for the releases' archives

### DIFF
--- a/.github/workflows/check-releases-archives.yaml
+++ b/.github/workflows/check-releases-archives.yaml
@@ -21,6 +21,7 @@ jobs:
         name: Infer maintained releases
         run: |
           set -x
+          set -o pipefail
 
           all_branches="$(git branch --all | grep -E "remotes.*ubuntu-[0-9]{2}\.[0-9]{2}$" | cut -d '/' -f 3)"
 
@@ -28,9 +29,8 @@ jobs:
 
           for branch in $all_branches; do
             echo "Checking maintenance status for '${branch}'"
-            git switch $branch
             
-            eol="$(yq .maintenance."end-of-life" chisel.yaml || echo null)"
+            eol="$(git show origin/${branch}:chisel.yaml | yq .maintenance."end-of-life" || true)"
             if [[ "$eol" != "null" && "$(date +"%Y-%m-%d")" < "$eol" ]];
             then
               echo "'$branch' is still maintained (EOL: $eol)"


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

Add a scheduled CI workflow to check each release's archives, to check that there are no issues which are not handled in the slice definition files (SDFs).

Multiple types of issues can be reported by this check (e.g. `path-conflict` - see `chisel help debug check-release-archives`).

## Related issues/PRs
<!-- If any -->

https://github.com/canonical/chisel/pull/236


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

See an example of a successful run at: https://github.com/cjdcordeiro/chisel-releases/actions/runs/18524160330
See an example of a detected issue at: https://github.com/cjdcordeiro/chisel-releases/actions/runs/18525100516/job/52793975353