### PR TITLE
chore(25.04): use v3-essential for rabbitmq-server

### DIFF
--- a/slices/rabbitmq-server.yaml
+++ b/slices/rabbitmq-server.yaml
@@ -20,13 +20,6 @@ slices:
       - base-passwd_data
       - bash_bins
       - coreutils_bins
-      # TODO: The slices bellow are necessary to run RabbitMQ server for amd64 and arm64,
-      #       but are not included by default to avoid dependency issues with other
-      #       architectures such as i386.
-      # - erlang-base_bins
-      # - erlang-inets_scripts
-      # - erlang-inets_modules
-      # - erlang-os-mon_bins
       - grep_bins
       - libc-bin_locale
       - libc-bin_nsswitch
@@ -40,6 +33,11 @@ slices:
       - rabbitmq-server_modules
       - sed_bins
       - util-linux_su-support
+    v3-essential:
+      erlang-base_bins: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-inets_scripts: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-inets_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-os-mon_bins: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
     contents:
       /usr/bin/rabbitmqadmin:
       /usr/lib/ocf/resource.d/rabbitmq/rabbitmq-server:
@@ -79,19 +77,17 @@ slices:
         mode: 0644
 
   modules:
-    # TODO: Uncomment the following lines when chisel support arch-specific
-    # slices/dependencies
-    # essential:
-    #   - erlang-crypto_modules
-    #   - erlang-eldap_modules
-    #   - erlang-mnesia_modules
-    #   - erlang-parsetools_modules
-    #   - erlang-public-key_modules
-    #   - erlang-runtime-tools_modules
-    #   - erlang-ssl_modules
-    #   - erlang-syntax-tools_modules
-    #   - erlang-tools_modules
-    #   - erlang-xmerl_modules
+    v3-essential:
+      erlang-crypto_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-eldap_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-mnesia_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-parsetools_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-public-key_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-runtime-tools_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-ssl_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-syntax-tools_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-tools_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
+      erlang-xmerl_modules: {arch: [amd64, arm64, armhf, ppc64el, riscv64, s390x]}
     contents:
       /usr/lib/rabbitmq/lib/rabbitmq_server-*/plugins/**:
 


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR uses the `v3-essential` to include the `erlang` dependencies of `rabbitmq-server`, since `erlang` is not available to `i386`, while `rabbitmq-server` is available to all the architectures.

## Related issues/PRs
<!-- If any -->

#732 
#733

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

#735 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->

PR in Chisel: https://github.com/canonical/chisel/pull/246