### PR TITLE
feat(24.10): Add kill-timeout to integration test suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -101,3 +101,5 @@ prepare-each: chisel version
 suites:
   tests/spread/integration/:
     summary: Tests common scenarios
+
+kill-timeout: 1.5h


### PR DESCRIPTION
Part of a series of PRs to mitigate integration test timeout.
See description in https://github.com/canonical/chisel-releases/pull/736