### PR TITLE
fix(ci): succeed pr triaging if nothing to do

### DIFF
--- a/.github/workflows/triage-prs.yaml
+++ b/.github/workflows/triage-prs.yaml
@@ -19,15 +19,8 @@ jobs:
           set -euxo pipefail
           
           for pr_number in `gh pr list -R ${{ github.repository }} \
-            --search "-team-review-requested:canonical/${{ env.REVIEWERS }}" --json number | jq -e '.[].number' \
-            || echo fail`
+            --search "-team-review-requested:canonical/${{ env.REVIEWERS }}" --json number | jq -e '.[].number'`
             do
-              if [[ "$pr_number" == "fail" ]]
-              then
-                echo "ERR: couldn't search for PRs"
-                exit 1
-              fi
-
               echo "Requesting review from ${{ env.REVIEWERS }} on PR ${pr_number}"
 
               gh api \


### PR DESCRIPTION
This workflow was failing whenever all PRs already had the team for review. It should pass in this case.