### PR TITLE
feat(25.10): use 25.10 as apt source and testing environment for 25.10 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ubuntu-25.04
+# ubuntu-25.10
 
-This is the `ubuntu-25.04` Chisel release.
+This is the `ubuntu-25.10` Chisel release.
 
 To learn more about Chisel, Chisel releases and how to contribute to this
 branch, please read

--- a/slices/apt.yaml
+++ b/slices/apt.yaml
@@ -61,13 +61,13 @@ slices:
         text: |
           Types: deb
           URIs: http://archive.ubuntu.com/ubuntu/
-          Suites: plucky plucky-updates plucky-backports
+          Suites: questing questing-updates questing-backports
           Components: main universe restricted multiverse
           Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
           Types: deb
           URIs: http://security.ubuntu.com/ubuntu/
-          Suites: plucky-security
+          Suites: questing-security
           Components: main universe restricted multiverse
           Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
       /etc/apt/sources.list.d/ubuntu-ports-default.sources:
@@ -76,13 +76,13 @@ slices:
         text: |
           Types: deb
           URIs: http://ports.ubuntu.com/ubuntu-ports/
-          Suites: plucky plucky-updates plucky-backports
+          Suites: questing questing-updates questing-backports
           Components: main universe restricted multiverse
           Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
           Types: deb
           URIs: http://ports.ubuntu.com/ubuntu-ports/
-          Suites: plucky-security
+          Suites: questing-security
           Components: main universe restricted multiverse
           Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
       /etc/apt/sources.list.d/ubuntu.sources: {text: "", mutable: true}

--- a/spread.yaml
+++ b/spread.yaml
@@ -39,7 +39,7 @@ backends:
       ADDRESS `lxc list --format=json $SPREAD_SYSTEM | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address'`
     discard: lxc stop $SPREAD_SYSTEM || true
     systems:
-      - ubuntu-plucky:
+      - ubuntu-questing:
           password: ubuntu
 
   docker:
@@ -69,17 +69,17 @@ backends:
       ADDRESS `docker inspect $SPREAD_SYSTEM --format '{{.NetworkSettings.Networks.bridge.IPAddress}}'`
     discard: docker rm -f $SPREAD_SYSTEM
     systems:
-      - ubuntu-25.04-amd64:
+      - ubuntu-25.10-amd64:
           password: ubuntu
-      - ubuntu-25.04-arm64v8:
+      - ubuntu-25.10-arm64v8:
           password: ubuntu
-      - ubuntu-25.04-arm32v7:
+      - ubuntu-25.10-arm32v7:
           password: ubuntu
-      - ubuntu-25.04-ppc64le:
+      - ubuntu-25.10-ppc64le:
           password: ubuntu
-      - ubuntu-25.04-s390x:
+      - ubuntu-25.10-s390x:
           password: ubuntu
-      - ubuntu-25.04-riscv64:
+      - ubuntu-25.10-riscv64:
           password: ubuntu
 
 prepare: |


### PR DESCRIPTION
The apt.yaml and spread.yaml configuration files of the ubuntu-25.10 branch still uses plucky as the source for the packages and as the testing environment for testing the slices.

This PR updates these configs to use Ubuntu 25.10 (Questing Quokka).