### PR TITLE
feat: retry `chisel cut` on failure to talk to the archive

### DIFF
--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -318,6 +318,8 @@ _patterns_to_retry: list[str] = [
     "cannot fetch from archive",
     # https://github.com/canonical/chisel-releases/issues/766
     "cannot talk to archive",
+    # https://github.com/canonical/chisel-releases/issues/768
+    "cannot find archive data",
 ]
 
 def chisel_cut(


### PR DESCRIPTION
# Proposed changes

We've already implemented a retry mechanism for `chisel cut` on digest failure already: https://github.com/canonical/chisel-releases/issues/765, but there are still some failures in the `install_slices` workflow due to a different pattern, which we can also retry:

https://github.com/canonical/chisel-releases/actions/runs/19820639814/job/56782010480?pr=763

```
2025/12/01 14:31:44 Processing ./ release...
2025/12/01 14:31:59 Selecting slices...
2025/12/01 14:31:59 Fetching ubuntu 25.10 questing suite details...
error: cannot talk to archive: Get "http://archive.ubuntu.com/ubuntu/dists/questing/InRelease": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Error: Process completed with exit code 1.
```

EDIT: also adds retry for this case:

https://github.com/canonical/chisel-releases/actions/runs/19820639814/job/56804232406?pr=763

```
2025/12/01 16:54:51 Processing ./ release...
2025/12/01 16:55:13 Selecting slices...
2025/12/01 16:55:13 Fetching ubuntu 25.04 plucky suite details...
2025/12/01 16:55:14 Release date: Thu, 17 Apr 2025 15:43:00 UTC
2025/12/01 16:55:14 Fetching index for ubuntu 25.04 plucky main component...
2025/12/01 16:55:14 Fetching index for ubuntu 25.04 plucky universe component...
2025/12/01 16:55:16 Fetching ubuntu 25.04 plucky-security suite details...
2025/12/01 16:55:16 Release date: Mon, 01 Dec 2025 15:37:28 UTC
2025/12/01 16:55:16 Fetching index for ubuntu 25.04 plucky-security main component...
2025/12/01 16:55:17 Fetching index for ubuntu 25.04 plucky-security universe component...
2025/12/01 16:55:17 Fetching ubuntu 25.04 plucky-updates suite details...
2025/12/01 16:55:17 Release date: Mon, 01 Dec 2025 10:49:56 UTC
2025/12/01 16:55:17 Fetching index for ubuntu 25.04 plucky-updates main component...
2025/12/01 16:55:17 Fetching index for ubuntu 25.04 plucky-updates universe component...
2025/12/01 16:55:17 Fetching pool/main/b/base-files/base-files_13.6ubuntu2_amd64.deb...
2025/12/01 16:55:18 Fetching pool/main/g/glibc/libc6_2.41-6ubuntu1.2_amd64.deb...
2025/12/01 16:55:18 Fetching pool/main/b/binutils/libsframe1_2.44-3ubuntu1.2_amd64.deb...
error: cannot find archive data
```

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/721
- closes https://github.com/canonical/chisel-releases/issues/766
- closes https://github.com/canonical/chisel-releases/issues/768

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)