### PR TITLE
feat(26.04): change `binutils` paths to devel pattern

### DIFF
--- a/slices/binutils-aarch64-linux-gnu.yaml
+++ b/slices/binutils-aarch64-linux-gnu.yaml
@@ -57,7 +57,9 @@ slices:
       - libzstd1_libs
       - zlib1g_libs
     contents:
-      /usr/lib/*-linux-*/libbfd-*-arm64.so:
+      # TODO: The devel branches use a different file-naming pattern. We need
+      #       to go back to this after feature freeze.
+      /usr/lib/*-linux-*/libbfd-2.45.50-arm64.*.so:
         arch: [amd64, i386, ppc64el, s390x]
 
   cross-libctf:
@@ -82,7 +84,9 @@ slices:
       - binutils-aarch64-linux-gnu_cross-libbfd
       - libc6_libs
     contents:
-      /usr/lib/*-linux-*/libopcodes-*-arm64.so:
+      # TODO: The devel branches use a different file-naming pattern. We need
+      #       to go back to this after feature freeze.
+      /usr/lib/*-linux-*/libopcodes-2.45.50-arm64.*.so:
         arch: [amd64, i386, ppc64el, s390x]
 
   ldscripts:

--- a/slices/binutils-x86-64-linux-gnu.yaml
+++ b/slices/binutils-x86-64-linux-gnu.yaml
@@ -57,7 +57,9 @@ slices:
       - libzstd1_libs
       - zlib1g_libs
     contents:
-      /usr/lib/*-linux-*/libbfd-*-amd64.so:
+      # TODO: The devel branches use a different file-naming pattern. We need
+      #       to go back to this after feature freeze.
+      /usr/lib/*-linux-*/libbfd-2.45.50-amd64.*.so:
         arch: [arm64, i386, ppc64el, s390x]
 
   cross-libctf:
@@ -82,7 +84,9 @@ slices:
       - binutils-x86-64-linux-gnu_cross-libbfd
       - libc6_libs
     contents:
-      /usr/lib/*-linux-*/libopcodes-*-amd64.so:
+      # TODO: The devel branches use a different file-naming pattern. We need
+      #       to go back to this after feature freeze.
+      /usr/lib/*-linux-*/libopcodes-2.45.50-amd64.*.so:
         arch: [arm64, i386, ppc64el, s390x]
 
   ldscripts:

--- a/slices/libbinutils.yaml
+++ b/slices/libbinutils.yaml
@@ -11,8 +11,15 @@ slices:
       - libzstd1_libs
       - zlib1g_libs
     contents:
-      /usr/lib/*-linux-*/libbfd-*-system.*.so:
-      /usr/lib/*-linux-*/libopcodes-*-system.*.so:
+      # NOTE: we cannot use two single globs here, since they would
+      #       https://github.com/canonical/chisel/issues/258
+      # TODO: The devel branches use a different file-naming pattern. We need
+      #       to go back to this after feature freeze.
+      #       https://git.launchpad.net/ubuntu/+source/binutils/log/?h=ubuntu/noble
+      /usr/lib/*-linux-*/libbfd-2.45.50-system.*.so:
+      /usr/lib/*-linux-*/libopcodes-2.45.50-system.*.so:
+      # /usr/lib/*-linux-*/libbfd-*-system.so:
+      # /usr/lib/*-linux-*/libopcodes-*-system.so:
 
   copyright:
     essential:


### PR DESCRIPTION
# Proposed changes
The devel branches use a different file-naming pattern, e.g. `/usr/lib/*-linux-*/libbfd-2.45.50-system.20251125.so:`. This PR changes the `binutils` sdfs to account for this.
We will need to go back to this after feature freeze (February 16th, 2026)

**NOTE**: the `2.45.50` part is constant within a single ubuntu release, and changes only between releases

- feature freeze: https://discourse.ubuntu.com/t/ubuntu-26-04-lts-the-roadmap/72740
- devel naming pattern: https://git.launchpad.net/ubuntu/+source/binutils/log/?h=ubuntu/noble
- closes https://github.com/canonical/chisel-releases/issues/775#issuecomment-3606286256

this PR is part of the following stacks:

- https://github.com/canonical/chisel-releases/pull/776 **(this PR)**
  - https://github.com/canonical/chisel-releases/pull/771
    - https://github.com/canonical/chisel-releases/pull/788

and
 
- https://github.com/canonical/chisel-releases/pull/776 **(this PR)**
  - https://github.com/canonical/chisel-releases/pull/782

## Related issues/PRs

- closes https://github.com/canonical/chisel-releases/issues/775
- related to https://github.com/canonical/chisel/issues/258

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
