### PR TITLE
feat(24.04): add libc6-dev

### DIFF
--- a/slices/libc6-dev.yaml
+++ b/slices/libc6-dev.yaml
@@ -1,0 +1,658 @@
+package: libc6-dev
+
+essential:
+  - libc6-dev_copyright
+
+slices:
+  # The main library slice, including the core runtime and most-common
+  # optional libraries.
+  libs:
+    essential:
+      - libc6-dev_core
+      - libc6-dev_libm
+      - libc6-dev_symlink-libc6-libs
+
+  # C runtime libraries, needed to start a C program
+  # - https://stackoverflow.com/a/16436294/2531987
+  # - https://web.archive.org/web/20241229232634/https://dev.gentoo.org/~vapier/crt.txt
+  # - https://gcc.gnu.org/onlinedocs/gccint/Initialization.html
+  runtime:
+    contents:
+      # Used in place of crt1.o when generating code with profiling information,
+      # for programs that use the `prof` tool. Compile with -p
+      /usr/lib/*-linux-*/Mcrt1.o:
+      # For dynamically linked position-independent executables (PIE, with -fPIE -pie)
+      /usr/lib/*-linux-*/Scrt1.o:
+      # initial runtime setup. this contains the entry point _start
+      /usr/lib/*-linux-*/crt1.o:
+      # prolog
+      /usr/lib/*-linux-*/crti.o:
+      # epilog
+      /usr/lib/*-linux-*/crtn.o:
+      # Used in place of crt1.o when generating code with profiling information.
+      # Compile with -pg.  Produces output suitable for the gprof util.
+      /usr/lib/*-linux-*/gcrt1.o:
+      # Just like gcrt1.o but for profiling position-independent executables.
+      /usr/lib/*-linux-*/grcrt1.o:
+        arch: [amd64, arm64, i386, s390x]
+      # For statically linked PIEs (with -static)
+      /usr/lib/*-linux-*/rcrt1.o:
+        arch: [amd64, arm64, i386, s390x]
+
+  core:
+    essential:
+      - libc6-dev_runtime
+      - libc6_libs
+    contents:
+      # dummy file to allow linking with -lanl. this functionality in integrated into libc
+      /usr/lib/*-linux-*/libanl.a:
+      # symlink to libanl.so from libc6
+      /usr/lib/*-linux-*/libanl.so:
+      # Static libc version
+      /usr/lib/*-linux-*/libc.a:
+      # linker script to look up symbols in libc_nonshared.a and libc.so.6 from libc6
+      /usr/lib/*-linux-*/libc.so:
+      /usr/lib/*-linux-*/libc_nonshared.a:
+      # dummy file to allow linking with -ldl. this functionality in integrated into libc
+      /usr/lib/*-linux-*/libdl.a:
+      # dummy file to allow linking with -lbg. this functionality in integrated into libc
+      /usr/lib/*-linux-*/libg.a:
+      # dummy file to allow linking with -lpthread. this functionality in integrated into libc
+      /usr/lib/*-linux-*/libpthread.a:
+      # dummy file. part of libpthread, but separate file.
+      /usr/lib/*-linux-*/libpthread_nonshared.a:
+      # dummy file to allow linking with -lrt. this functionality in integrated into libc
+      /usr/lib/*-linux-*/librt.a:
+      # dummy file to allow linking with -lutil. this functionality in integrated into libc
+      /usr/lib/*-linux-*/libutil.a:
+
+  # only needed if linking with -lm
+  libm:
+    essential:
+      - libc6-dev_core
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libm-2.*.a:
+        arch: [amd64, arm64]
+      # on amd64/arm64 this is a linker script which redirects to libm-2.41.a and libmvec.so
+      # on non-amd64/arm64 archs libm.a is not a linker script, but a real static library
+      /usr/lib/*-linux-*/libm.a:
+      # on amd64/arm64 this is a linker script which redirects to libm.so and libmvec.so from libc6
+      # on non-amd64/arm64 this is a symlink to libm.so.6 from libc6
+      /usr/lib/*-linux-*/libm.so:
+      /usr/lib/*-linux-*/libmvec.a:
+        arch: [amd64, arm64]
+      /usr/lib/*-linux-*/libmvec.so:
+        arch: [amd64, arm64]
+
+  # only needed if linking with -lmcheck
+  libmcheck:
+    essential:
+      - libc6-dev_core
+    contents:
+      /usr/lib/*-linux-*/libmcheck.a:
+
+  # only needed if linking with -lresolv
+  libresolv:
+    essential:
+      - libc6-dev_core
+    contents:
+      # static libresolv version
+      /usr/lib/*-linux-*/libresolv.a:
+      # symlink to libresolv.so from libc6
+      /usr/lib/*-linux-*/libresolv.so:
+
+  # dynamic linter auditing library
+  # needs to be manually enabled with e.g. LD_AUDIT=<path to sotruss-lib.so>
+  audit:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/audit/sotruss-lib.so:
+
+  # legacy locale support library, usually not needed
+  libbrokenlocale:
+    essential:
+      - libc6-dev_core
+    contents:
+      /usr/lib/*-linux-*/libBrokenLocale.a:
+      /usr/lib/*-linux-*/libBrokenLocale.so:
+
+  symlink-libc6-libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libc_malloc_debug.so:
+      /usr/lib/*-linux-*/libnss_compat.so:
+      /usr/lib/*-linux-*/libnss_hesiod.so:
+      /usr/lib/*-linux-*/libthread_db.so:
+
+  # All the standard C library headers
+  headers:
+    # We need `libcrypt-dev_headers` for the crypt.h header which is referenced from unistd.h
+    essential:
+      - libcrypt-dev_headers
+      - linux-libc-dev_linux-headers
+    contents:
+      /usr/include/*-linux-*/a.out.h:
+      /usr/include/*-linux-*/bits/a.out.h:
+      /usr/include/*-linux-*/bits/argp-ldbl.h:
+      /usr/include/*-linux-*/bits/atomic_wide_counter.h:
+      /usr/include/*-linux-*/bits/byteswap.h:
+      /usr/include/*-linux-*/bits/cmathcalls.h:
+      /usr/include/*-linux-*/bits/confname.h:
+      /usr/include/*-linux-*/bits/cpu-set.h:
+      /usr/include/*-linux-*/bits/dirent.h:
+      /usr/include/*-linux-*/bits/dirent_ext.h:
+      /usr/include/*-linux-*/bits/dl_find_object.h:
+      /usr/include/*-linux-*/bits/dlfcn.h:
+      /usr/include/*-linux-*/bits/elfclass.h:
+      /usr/include/*-linux-*/bits/endian.h:
+      /usr/include/*-linux-*/bits/endianness.h:
+      /usr/include/*-linux-*/bits/environments.h:
+      /usr/include/*-linux-*/bits/epoll.h:
+      /usr/include/*-linux-*/bits/err-ldbl.h:
+      /usr/include/*-linux-*/bits/errno.h:
+      /usr/include/*-linux-*/bits/error-ldbl.h:
+      /usr/include/*-linux-*/bits/error.h:
+      /usr/include/*-linux-*/bits/eventfd.h:
+      /usr/include/*-linux-*/bits/fcntl-linux.h:
+      /usr/include/*-linux-*/bits/fcntl.h:
+      /usr/include/*-linux-*/bits/fcntl2.h:
+      /usr/include/*-linux-*/bits/fenv.h:
+      /usr/include/*-linux-*/bits/floatn-common.h:
+      /usr/include/*-linux-*/bits/floatn.h:
+      /usr/include/*-linux-*/bits/flt-eval-method.h:
+      /usr/include/*-linux-*/bits/fp-fast.h:
+      /usr/include/*-linux-*/bits/fp-logb.h:
+      /usr/include/*-linux-*/bits/getopt_core.h:
+      /usr/include/*-linux-*/bits/getopt_ext.h:
+      /usr/include/*-linux-*/bits/getopt_posix.h:
+      /usr/include/*-linux-*/bits/hwcap.h:
+      /usr/include/*-linux-*/bits/in.h:
+      /usr/include/*-linux-*/bits/indirect-return.h:
+      /usr/include/*-linux-*/bits/initspin.h:
+      /usr/include/*-linux-*/bits/inotify.h:
+      /usr/include/*-linux-*/bits/ioctl-types.h:
+      /usr/include/*-linux-*/bits/ioctls.h:
+      /usr/include/*-linux-*/bits/ipc-perm.h:
+      /usr/include/*-linux-*/bits/ipc.h:
+      /usr/include/*-linux-*/bits/ipctypes.h:
+      /usr/include/*-linux-*/bits/iscanonical.h:
+      /usr/include/*-linux-*/bits/libc-header-start.h:
+      /usr/include/*-linux-*/bits/libm-simd-decl-stubs.h:
+      /usr/include/*-linux-*/bits/link.h:
+      /usr/include/*-linux-*/bits/link_lavcurrent.h:
+      /usr/include/*-linux-*/bits/local_lim.h:
+      /usr/include/*-linux-*/bits/locale.h:
+      /usr/include/*-linux-*/bits/long-double.h:
+      /usr/include/*-linux-*/bits/math-vector.h:
+      /usr/include/*-linux-*/bits/mathcalls-helper-functions.h:
+      /usr/include/*-linux-*/bits/mathcalls-narrow.h:
+      /usr/include/*-linux-*/bits/mathcalls.h:
+      /usr/include/*-linux-*/bits/mathdef.h:
+      /usr/include/*-linux-*/bits/mman-linux.h:
+      /usr/include/*-linux-*/bits/mman-map-flags-generic.h:
+      /usr/include/*-linux-*/bits/mman-shared.h:
+      /usr/include/*-linux-*/bits/mman.h:
+      /usr/include/*-linux-*/bits/mman_ext.h:
+      /usr/include/*-linux-*/bits/monetary-ldbl.h:
+      /usr/include/*-linux-*/bits/mqueue.h:
+      /usr/include/*-linux-*/bits/mqueue2.h:
+      /usr/include/*-linux-*/bits/msq.h:
+      /usr/include/*-linux-*/bits/netdb.h:
+      /usr/include/*-linux-*/bits/param.h:
+      /usr/include/*-linux-*/bits/platform/features.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/bits/platform/x86.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/bits/poll.h:
+      /usr/include/*-linux-*/bits/poll2.h:
+      /usr/include/*-linux-*/bits/posix1_lim.h:
+      /usr/include/*-linux-*/bits/posix2_lim.h:
+      /usr/include/*-linux-*/bits/posix_opt.h:
+      /usr/include/*-linux-*/bits/ppc.h:
+        arch: [ppc64el]
+      /usr/include/*-linux-*/bits/printf-ldbl.h:
+      /usr/include/*-linux-*/bits/procfs-extra.h:
+      /usr/include/*-linux-*/bits/procfs-id.h:
+      /usr/include/*-linux-*/bits/procfs-prregset.h:
+      /usr/include/*-linux-*/bits/procfs.h:
+      /usr/include/*-linux-*/bits/pthread_stack_min-dynamic.h:
+      /usr/include/*-linux-*/bits/pthread_stack_min.h:
+      /usr/include/*-linux-*/bits/pthreadtypes-arch.h:
+      /usr/include/*-linux-*/bits/pthreadtypes.h:
+      /usr/include/*-linux-*/bits/ptrace-shared.h:
+      /usr/include/*-linux-*/bits/resource.h:
+      /usr/include/*-linux-*/bits/rseq.h:
+      /usr/include/*-linux-*/bits/sched.h:
+      /usr/include/*-linux-*/bits/select-decl.h:
+      /usr/include/*-linux-*/bits/select.h:
+      /usr/include/*-linux-*/bits/select2.h:
+      /usr/include/*-linux-*/bits/sem.h:
+      /usr/include/*-linux-*/bits/semaphore.h:
+      /usr/include/*-linux-*/bits/setjmp.h:
+      /usr/include/*-linux-*/bits/setjmp2.h:
+      /usr/include/*-linux-*/bits/shm.h:
+      /usr/include/*-linux-*/bits/shmlba.h:
+      /usr/include/*-linux-*/bits/sigaction.h:
+      /usr/include/*-linux-*/bits/sigcontext.h:
+      /usr/include/*-linux-*/bits/sigevent-consts.h:
+      /usr/include/*-linux-*/bits/siginfo-arch.h:
+      /usr/include/*-linux-*/bits/siginfo-consts-arch.h:
+      /usr/include/*-linux-*/bits/siginfo-consts.h:
+      /usr/include/*-linux-*/bits/signal_ext.h:
+      /usr/include/*-linux-*/bits/signalfd.h:
+      /usr/include/*-linux-*/bits/signum-arch.h:
+      /usr/include/*-linux-*/bits/signum-generic.h:
+      /usr/include/*-linux-*/bits/sigstack.h:
+      /usr/include/*-linux-*/bits/sigstksz.h:
+      /usr/include/*-linux-*/bits/sigthread.h:
+      /usr/include/*-linux-*/bits/sockaddr.h:
+      /usr/include/*-linux-*/bits/socket-constants.h:
+      /usr/include/*-linux-*/bits/socket.h:
+      /usr/include/*-linux-*/bits/socket2.h:
+      /usr/include/*-linux-*/bits/socket_type.h:
+      /usr/include/*-linux-*/bits/spawn_ext.h:
+      /usr/include/*-linux-*/bits/ss_flags.h:
+      /usr/include/*-linux-*/bits/stab.def:  # debug symbol definitions
+      /usr/include/*-linux-*/bits/stat.h:
+      /usr/include/*-linux-*/bits/statfs.h:
+      /usr/include/*-linux-*/bits/statvfs.h:
+      /usr/include/*-linux-*/bits/statx-generic.h:
+      /usr/include/*-linux-*/bits/statx.h:
+      /usr/include/*-linux-*/bits/stdint-intn.h:
+      /usr/include/*-linux-*/bits/stdint-least.h:
+      /usr/include/*-linux-*/bits/stdint-uintn.h:
+      /usr/include/*-linux-*/bits/stdio-ldbl.h:
+      /usr/include/*-linux-*/bits/stdio.h:
+      /usr/include/*-linux-*/bits/stdio2-decl.h:
+      /usr/include/*-linux-*/bits/stdio2.h:
+      /usr/include/*-linux-*/bits/stdio_lim.h:
+      /usr/include/*-linux-*/bits/stdlib-bsearch.h:
+      /usr/include/*-linux-*/bits/stdlib-float.h:
+      /usr/include/*-linux-*/bits/stdlib-ldbl.h:
+      /usr/include/*-linux-*/bits/stdlib.h:
+      /usr/include/*-linux-*/bits/string_fortified.h:
+      /usr/include/*-linux-*/bits/strings_fortified.h:
+      /usr/include/*-linux-*/bits/struct_mutex.h:
+      /usr/include/*-linux-*/bits/struct_rwlock.h:
+      /usr/include/*-linux-*/bits/struct_stat.h:
+      /usr/include/*-linux-*/bits/struct_stat_time64_helper.h:
+      /usr/include/*-linux-*/bits/syscall.h:
+      /usr/include/*-linux-*/bits/syslog-decl.h:
+      /usr/include/*-linux-*/bits/syslog-ldbl.h:
+      /usr/include/*-linux-*/bits/syslog-path.h:
+      /usr/include/*-linux-*/bits/syslog.h:
+      /usr/include/*-linux-*/bits/sysmacros.h:
+      /usr/include/*-linux-*/bits/termios-baud.h:
+      /usr/include/*-linux-*/bits/termios-c_cc.h:
+      /usr/include/*-linux-*/bits/termios-c_cflag.h:
+      /usr/include/*-linux-*/bits/termios-c_iflag.h:
+      /usr/include/*-linux-*/bits/termios-c_lflag.h:
+      /usr/include/*-linux-*/bits/termios-c_oflag.h:
+      /usr/include/*-linux-*/bits/termios-misc.h:
+      /usr/include/*-linux-*/bits/termios-struct.h:
+      /usr/include/*-linux-*/bits/termios-tcflow.h:
+      /usr/include/*-linux-*/bits/termios.h:
+      /usr/include/*-linux-*/bits/thread-shared-types.h:
+      /usr/include/*-linux-*/bits/time.h:
+      /usr/include/*-linux-*/bits/time64.h:
+      /usr/include/*-linux-*/bits/timerfd.h:
+      /usr/include/*-linux-*/bits/timesize.h:
+      /usr/include/*-linux-*/bits/timex.h:
+      /usr/include/*-linux-*/bits/types.h:
+      /usr/include/*-linux-*/bits/types/FILE.h:
+      /usr/include/*-linux-*/bits/types/__FILE.h:
+      /usr/include/*-linux-*/bits/types/__fpos64_t.h:
+      /usr/include/*-linux-*/bits/types/__fpos_t.h:
+      /usr/include/*-linux-*/bits/types/__locale_t.h:
+      /usr/include/*-linux-*/bits/types/__mbstate_t.h:
+      /usr/include/*-linux-*/bits/types/__sigset_t.h:
+      /usr/include/*-linux-*/bits/types/__sigval_t.h:
+      /usr/include/*-linux-*/bits/types/clock_t.h:
+      /usr/include/*-linux-*/bits/types/clockid_t.h:
+      /usr/include/*-linux-*/bits/types/cookie_io_functions_t.h:
+      /usr/include/*-linux-*/bits/types/error_t.h:
+      /usr/include/*-linux-*/bits/types/idtype_t.h:
+      /usr/include/*-linux-*/bits/types/locale_t.h:
+      /usr/include/*-linux-*/bits/types/mbstate_t.h:
+      /usr/include/*-linux-*/bits/types/res_state.h:
+      /usr/include/*-linux-*/bits/types/sig_atomic_t.h:
+      /usr/include/*-linux-*/bits/types/sigevent_t.h:
+      /usr/include/*-linux-*/bits/types/siginfo_t.h:
+      /usr/include/*-linux-*/bits/types/sigset_t.h:
+      /usr/include/*-linux-*/bits/types/sigval_t.h:
+      /usr/include/*-linux-*/bits/types/stack_t.h:
+      /usr/include/*-linux-*/bits/types/struct_FILE.h:
+      /usr/include/*-linux-*/bits/types/struct___jmp_buf_tag.h:
+      /usr/include/*-linux-*/bits/types/struct_iovec.h:
+      /usr/include/*-linux-*/bits/types/struct_itimerspec.h:
+      /usr/include/*-linux-*/bits/types/struct_msqid64_ds.h:
+      /usr/include/*-linux-*/bits/types/struct_msqid64_ds_helper.h:
+      /usr/include/*-linux-*/bits/types/struct_msqid_ds.h:
+      /usr/include/*-linux-*/bits/types/struct_osockaddr.h:
+      /usr/include/*-linux-*/bits/types/struct_rusage.h:
+      /usr/include/*-linux-*/bits/types/struct_sched_param.h:
+      /usr/include/*-linux-*/bits/types/struct_semid64_ds.h:
+      /usr/include/*-linux-*/bits/types/struct_semid64_ds_helper.h:
+      /usr/include/*-linux-*/bits/types/struct_semid_ds.h:
+      /usr/include/*-linux-*/bits/types/struct_shmid64_ds.h:
+      /usr/include/*-linux-*/bits/types/struct_shmid64_ds_helper.h:
+      /usr/include/*-linux-*/bits/types/struct_shmid_ds.h:
+      /usr/include/*-linux-*/bits/types/struct_sigstack.h:
+      /usr/include/*-linux-*/bits/types/struct_statx.h:
+      /usr/include/*-linux-*/bits/types/struct_statx_timestamp.h:
+      /usr/include/*-linux-*/bits/types/struct_timeb.h:
+      /usr/include/*-linux-*/bits/types/struct_timespec.h:
+      /usr/include/*-linux-*/bits/types/struct_timeval.h:
+      /usr/include/*-linux-*/bits/types/struct_tm.h:
+      /usr/include/*-linux-*/bits/types/time_t.h:
+      /usr/include/*-linux-*/bits/types/timer_t.h:
+      /usr/include/*-linux-*/bits/types/wint_t.h:
+      /usr/include/*-linux-*/bits/typesizes.h:
+      /usr/include/*-linux-*/bits/uintn-identity.h:
+      /usr/include/*-linux-*/bits/uio-ext.h:
+      /usr/include/*-linux-*/bits/uio_lim.h:
+      /usr/include/*-linux-*/bits/unistd-decl.h:
+      /usr/include/*-linux-*/bits/unistd.h:
+      /usr/include/*-linux-*/bits/unistd_ext.h:
+      /usr/include/*-linux-*/bits/utmp.h:
+      /usr/include/*-linux-*/bits/utmpx.h:
+      /usr/include/*-linux-*/bits/utsname.h:
+      /usr/include/*-linux-*/bits/waitflags.h:
+      /usr/include/*-linux-*/bits/waitstatus.h:
+      /usr/include/*-linux-*/bits/wchar-ldbl.h:
+      /usr/include/*-linux-*/bits/wchar.h:
+      /usr/include/*-linux-*/bits/wchar2-decl.h:
+      /usr/include/*-linux-*/bits/wchar2.h:
+      /usr/include/*-linux-*/bits/wctype-wchar.h:
+      /usr/include/*-linux-*/bits/wordsize.h:
+      /usr/include/*-linux-*/bits/xopen_lim.h:
+      /usr/include/*-linux-*/fpu_control.h:
+      /usr/include/*-linux-*/gnu/lib-names-32.h:
+        arch: [i386]
+      /usr/include/*-linux-*/gnu/lib-names-64-v2.h:
+        arch: [ppc64el]
+      /usr/include/*-linux-*/gnu/lib-names-64.h:
+        arch: [amd64, s390x]
+      /usr/include/*-linux-*/gnu/lib-names-hard.h:
+        arch: [armhf]
+      /usr/include/*-linux-*/gnu/lib-names-lp64.h:
+        arch: [arm64]
+      /usr/include/*-linux-*/gnu/lib-names-lp64d.h:
+        arch: [riscv64]
+      /usr/include/*-linux-*/gnu/lib-names.h:
+      /usr/include/*-linux-*/gnu/libc-version.h:
+      /usr/include/*-linux-*/gnu/stubs-32.h:
+        arch: [i386]
+      /usr/include/*-linux-*/gnu/stubs-64-v2.h:
+        arch: [ppc64el]
+      /usr/include/*-linux-*/gnu/stubs-64.h:
+        arch: [amd64, s390x]
+      /usr/include/*-linux-*/gnu/stubs-hard.h:
+        arch: [armhf]
+      /usr/include/*-linux-*/gnu/stubs-lp64.h:
+        arch: [arm64]
+      /usr/include/*-linux-*/gnu/stubs-lp64d.h:
+        arch: [riscv64]
+      /usr/include/*-linux-*/gnu/stubs.h:
+      /usr/include/*-linux-*/ieee754.h:
+      /usr/include/*-linux-*/sys/acct.h:
+      /usr/include/*-linux-*/sys/asm.h:
+        arch: [riscv64]
+      /usr/include/*-linux-*/sys/auxv.h:
+      /usr/include/*-linux-*/sys/bitypes.h:
+      /usr/include/*-linux-*/sys/cachectl.h:
+        arch: [riscv64]
+      /usr/include/*-linux-*/sys/cdefs.h:
+      /usr/include/*-linux-*/sys/debugreg.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/sys/dir.h:
+      /usr/include/*-linux-*/sys/elf.h:
+        arch: [amd64, arm64, armhf, i386, s390x]
+      /usr/include/*-linux-*/sys/epoll.h:
+      /usr/include/*-linux-*/sys/errno.h:
+      /usr/include/*-linux-*/sys/eventfd.h:
+      /usr/include/*-linux-*/sys/fanotify.h:
+      /usr/include/*-linux-*/sys/fcntl.h:
+      /usr/include/*-linux-*/sys/file.h:
+      /usr/include/*-linux-*/sys/fsuid.h:
+      /usr/include/*-linux-*/sys/gmon.h:
+      /usr/include/*-linux-*/sys/gmon_out.h:
+      /usr/include/*-linux-*/sys/ifunc.h:
+        arch: [arm64]
+      /usr/include/*-linux-*/sys/inotify.h:
+      /usr/include/*-linux-*/sys/io.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/sys/ioctl.h:
+      /usr/include/*-linux-*/sys/ipc.h:
+      /usr/include/*-linux-*/sys/kd.h:
+      /usr/include/*-linux-*/sys/klog.h:
+      /usr/include/*-linux-*/sys/mman.h:
+      /usr/include/*-linux-*/sys/mount.h:
+      /usr/include/*-linux-*/sys/msg.h:
+      /usr/include/*-linux-*/sys/mtio.h:
+      /usr/include/*-linux-*/sys/param.h:
+      /usr/include/*-linux-*/sys/pci.h:
+      /usr/include/*-linux-*/sys/perm.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/sys/personality.h:
+      /usr/include/*-linux-*/sys/pidfd.h:
+      /usr/include/*-linux-*/sys/platform/ppc.h:
+        arch: [ppc64el]
+      /usr/include/*-linux-*/sys/platform/x86.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/sys/poll.h:
+      /usr/include/*-linux-*/sys/prctl.h:
+      /usr/include/*-linux-*/sys/procfs.h:
+      /usr/include/*-linux-*/sys/profil.h:
+      /usr/include/*-linux-*/sys/ptrace.h:
+      /usr/include/*-linux-*/sys/queue.h:
+      /usr/include/*-linux-*/sys/quota.h:
+      /usr/include/*-linux-*/sys/random.h:
+      /usr/include/*-linux-*/sys/raw.h:
+      /usr/include/*-linux-*/sys/reboot.h:
+      /usr/include/*-linux-*/sys/reg.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/sys/resource.h:
+      /usr/include/*-linux-*/sys/rseq.h:
+      /usr/include/*-linux-*/sys/select.h:
+      /usr/include/*-linux-*/sys/sem.h:
+      /usr/include/*-linux-*/sys/sendfile.h:
+      /usr/include/*-linux-*/sys/shm.h:
+      /usr/include/*-linux-*/sys/signal.h:
+      /usr/include/*-linux-*/sys/signalfd.h:
+      /usr/include/*-linux-*/sys/single_threaded.h:
+      /usr/include/*-linux-*/sys/socket.h:
+      /usr/include/*-linux-*/sys/socketvar.h:
+      /usr/include/*-linux-*/sys/soundcard.h:
+      /usr/include/*-linux-*/sys/stat.h:
+      /usr/include/*-linux-*/sys/statfs.h:
+      /usr/include/*-linux-*/sys/statvfs.h:
+      /usr/include/*-linux-*/sys/swap.h:
+      /usr/include/*-linux-*/sys/syscall.h:
+      /usr/include/*-linux-*/sys/sysinfo.h:
+      /usr/include/*-linux-*/sys/syslog.h:
+      /usr/include/*-linux-*/sys/sysmacros.h:
+      /usr/include/*-linux-*/sys/termios.h:
+      /usr/include/*-linux-*/sys/time.h:
+      /usr/include/*-linux-*/sys/timeb.h:
+      /usr/include/*-linux-*/sys/timerfd.h:
+      /usr/include/*-linux-*/sys/times.h:
+      /usr/include/*-linux-*/sys/timex.h:
+      /usr/include/*-linux-*/sys/ttychars.h:
+      /usr/include/*-linux-*/sys/ttydefaults.h:
+      /usr/include/*-linux-*/sys/types.h:
+      /usr/include/*-linux-*/sys/ucontext.h:
+      /usr/include/*-linux-*/sys/uio.h:
+      /usr/include/*-linux-*/sys/un.h:
+      /usr/include/*-linux-*/sys/unistd.h:
+      /usr/include/*-linux-*/sys/user.h:
+      /usr/include/*-linux-*/sys/utsname.h:
+      /usr/include/*-linux-*/sys/vfs.h:
+      /usr/include/*-linux-*/sys/vlimit.h:
+      /usr/include/*-linux-*/sys/vm86.h:
+        arch: [amd64, i386]
+      /usr/include/*-linux-*/sys/vt.h:
+      /usr/include/*-linux-*/sys/wait.h:
+      /usr/include/*-linux-*/sys/xattr.h:
+      /usr/include/aio.h:
+      /usr/include/aliases.h:
+      /usr/include/alloca.h:
+      /usr/include/ar.h:
+      /usr/include/argp.h:
+      /usr/include/argz.h:
+      /usr/include/arpa/ftp.h:
+      /usr/include/arpa/inet.h:
+      /usr/include/arpa/nameser.h:
+      /usr/include/arpa/nameser_compat.h:
+      /usr/include/arpa/telnet.h:
+      /usr/include/arpa/tftp.h:
+      /usr/include/assert.h:
+      /usr/include/byteswap.h:
+      /usr/include/complex.h:
+      /usr/include/cpio.h:
+      /usr/include/ctype.h:
+      /usr/include/dirent.h:
+      /usr/include/dlfcn.h:
+      /usr/include/elf.h:
+      /usr/include/endian.h:
+      /usr/include/envz.h:
+      /usr/include/err.h:
+      /usr/include/errno.h:
+      /usr/include/error.h:
+      /usr/include/execinfo.h:
+      /usr/include/fcntl.h:
+      /usr/include/features-time64.h:
+      /usr/include/features.h:
+      /usr/include/fenv.h:
+      /usr/include/finclude/*-linux-*/math-vector-fortran.h:
+      /usr/include/fmtmsg.h:
+      /usr/include/fnmatch.h:
+      /usr/include/fstab.h:
+      /usr/include/fts.h:
+      /usr/include/ftw.h:
+      /usr/include/gconv.h:
+      /usr/include/getopt.h:
+      /usr/include/glob.h:
+      /usr/include/gnu-versions.h:
+      /usr/include/grp.h:
+      /usr/include/gshadow.h:
+      /usr/include/iconv.h:
+      /usr/include/ifaddrs.h:
+      /usr/include/inttypes.h:
+      /usr/include/langinfo.h:
+      /usr/include/lastlog.h:
+      /usr/include/libgen.h:
+      /usr/include/libintl.h:
+      /usr/include/limits.h:
+      /usr/include/link.h:
+      /usr/include/locale.h:
+      /usr/include/malloc.h:
+      /usr/include/math.h:
+      /usr/include/mcheck.h:
+      /usr/include/memory.h:
+      /usr/include/mntent.h:
+      /usr/include/monetary.h:
+      /usr/include/mqueue.h:
+      /usr/include/net/ethernet.h:
+      /usr/include/net/if.h:
+      /usr/include/net/if_arp.h:
+      /usr/include/net/if_packet.h:
+      /usr/include/net/if_ppp.h:
+      /usr/include/net/if_shaper.h:
+      /usr/include/net/if_slip.h:
+      /usr/include/net/ppp-comp.h:
+      /usr/include/net/ppp_defs.h:
+      /usr/include/net/route.h:
+      /usr/include/netash/ash.h:
+      /usr/include/netatalk/at.h:
+      /usr/include/netax25/ax25.h:
+      /usr/include/netdb.h:
+      /usr/include/neteconet/ec.h:
+      /usr/include/netinet/ether.h:
+      /usr/include/netinet/icmp6.h:
+      /usr/include/netinet/if_ether.h:
+      /usr/include/netinet/if_fddi.h:
+      /usr/include/netinet/if_tr.h:
+      /usr/include/netinet/igmp.h:
+      /usr/include/netinet/in.h:
+      /usr/include/netinet/in_systm.h:
+      /usr/include/netinet/ip.h:
+      /usr/include/netinet/ip6.h:
+      /usr/include/netinet/ip_icmp.h:
+      /usr/include/netinet/tcp.h:
+      /usr/include/netinet/udp.h:
+      /usr/include/netipx/ipx.h:
+      /usr/include/netiucv/iucv.h:
+      /usr/include/netpacket/packet.h:
+      /usr/include/netrom/netrom.h:
+      /usr/include/netrose/rose.h:
+      /usr/include/nfs/nfs.h:
+      /usr/include/nl_types.h:
+      /usr/include/nss.h:
+      /usr/include/obstack.h:
+      /usr/include/paths.h:
+      /usr/include/poll.h:
+      /usr/include/printf.h:
+      /usr/include/proc_service.h:
+      /usr/include/protocols/routed.h:
+      /usr/include/protocols/rwhod.h:
+      /usr/include/protocols/talkd.h:
+      /usr/include/protocols/timed.h:
+      /usr/include/pthread.h:
+      /usr/include/pty.h:
+      /usr/include/pwd.h:
+      /usr/include/re_comp.h:
+      /usr/include/regex.h:
+      /usr/include/regexp.h:
+      /usr/include/resolv.h:
+      /usr/include/rpc/netdb.h:
+      /usr/include/sched.h:
+      /usr/include/scsi/scsi.h:
+      /usr/include/scsi/scsi_ioctl.h:
+      /usr/include/scsi/sg.h:
+      /usr/include/search.h:
+      /usr/include/semaphore.h:
+      /usr/include/setjmp.h:
+      /usr/include/sgtty.h:
+      /usr/include/shadow.h:
+      /usr/include/signal.h:
+      /usr/include/spawn.h:
+      /usr/include/stab.h:
+      /usr/include/stdbit.h:
+      /usr/include/stdc-predef.h:
+      /usr/include/stdint.h:
+      /usr/include/stdio.h:
+      /usr/include/stdio_ext.h:
+      /usr/include/stdlib.h:
+      /usr/include/string.h:
+      /usr/include/strings.h:
+      /usr/include/syscall.h:
+      /usr/include/sysexits.h:
+      /usr/include/syslog.h:
+      /usr/include/tar.h:
+      /usr/include/termio.h:
+      /usr/include/termios.h:
+      /usr/include/tgmath.h:
+      /usr/include/thread_db.h:
+      /usr/include/threads.h:
+      /usr/include/time.h:
+      /usr/include/ttyent.h:
+      /usr/include/uchar.h:
+      /usr/include/ucontext.h:
+      /usr/include/ulimit.h:
+      /usr/include/unistd.h:
+      /usr/include/utime.h:
+      /usr/include/utmp.h:
+      /usr/include/utmpx.h:
+      /usr/include/values.h:
+      /usr/include/wait.h:
+      /usr/include/wchar.h:
+      /usr/include/wctype.h:
+      /usr/include/wordexp.h:
+
+  copyright:
+    contents:
+      /usr/share/doc/libc6-dev/copyright:

--- a/slices/libcrypt-dev.yaml
+++ b/slices/libcrypt-dev.yaml
@@ -1,0 +1,25 @@
+package: libcrypt-dev
+
+essential:
+  - libcrypt-dev_copyright
+
+slices:
+  libs:
+    essential:
+      - libcrypt1_libs
+    contents:
+      /usr/lib/*-linux-*/libcrypt.a:
+      # Symlink to .so in libcrypt1
+      /usr/lib/*-linux-*/libcrypt.so:
+
+  headers:
+    contents:
+      /usr/include/crypt.h:
+
+  pkgconfig:
+    contents:
+      /usr/lib/*-linux-*/pkgconfig/*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libcrypt-dev/copyright:

--- a/slices/linux-libc-dev.yaml
+++ b/slices/linux-libc-dev.yaml
@@ -1,0 +1,20 @@
+package: linux-libc-dev
+
+essential:
+  - linux-libc-dev_copyright
+
+slices:
+  asm-headers:
+    contents:
+      /usr/include/*-linux-*/asm/**.h:
+      /usr/include/asm-generic/**.h:
+
+  linux-headers:
+    essential:
+      - linux-libc-dev_asm-headers
+    contents:
+      /usr/include/linux/**.h:
+
+  copyright:
+    contents:
+      /usr/share/doc/linux-libc-dev/copyright:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR ports the `libc6-dev` and its dependencies back from 25.04 (#633).

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

Already exist as #633 , #664 .

FP for 26.04 is already included in the opening of 26.04

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->

Diff from branch `ubuntu25.04` to this PR:
```
diff --git a/slices/libc6-dev.yaml b/slices/libc6-dev.yaml
index 000aa17..a21d025 100644
--- a/slices/libc6-dev.yaml
+++ b/slices/libc6-dev.yaml
@@ -34,10 +34,10 @@ slices:
       /usr/lib/*-linux-*/gcrt1.o:
       # Just like gcrt1.o but for profiling position-independent executables.
       /usr/lib/*-linux-*/grcrt1.o:
-        arch: [amd64, arm64, i386, riscv64, s390x]
+        arch: [amd64, arm64, i386, s390x]
       # For statically linked PIEs (with -static)
       /usr/lib/*-linux-*/rcrt1.o:
-        arch: [amd64, arm64, i386, riscv64, s390x]
+        arch: [amd64, arm64, i386, s390x]
 
   core:
     essential:
@@ -115,6 +115,7 @@ slices:
     essential:
       - libc6-dev_core
     contents:
+      /usr/lib/*-linux-*/libBrokenLocale.a:
       /usr/lib/*-linux-*/libBrokenLocale.so:
 
   symlink-libc6-libs:
@@ -187,7 +188,6 @@ slices:
       /usr/include/*-linux-*/bits/long-double.h:
       /usr/include/*-linux-*/bits/math-vector.h:
       /usr/include/*-linux-*/bits/mathcalls-helper-functions.h:
-      /usr/include/*-linux-*/bits/mathcalls-macros.h:
       /usr/include/*-linux-*/bits/mathcalls-narrow.h:
       /usr/include/*-linux-*/bits/mathcalls.h:
       /usr/include/*-linux-*/bits/mathdef.h:
@@ -420,8 +421,6 @@ slices:
       /usr/include/*-linux-*/sys/fsuid.h:
       /usr/include/*-linux-*/sys/gmon.h:
       /usr/include/*-linux-*/sys/gmon_out.h:
-      /usr/include/*-linux-*/sys/hwprobe.h:
-        arch: [riscv64]
       /usr/include/*-linux-*/sys/ifunc.h:
         arch: [arm64]
       /usr/include/*-linux-*/sys/inotify.h:
(END)
```

