### PR TITLE
feat(26.04): slice busybox-static

### DIFF
--- a/slices/busybox-static.yaml
+++ b/slices/busybox-static.yaml
@@ -1,0 +1,14 @@
+package: busybox-static
+
+essential:
+  - busybox-static_copyright
+
+slices:
+  bins:
+    contents:
+      /bin/static-sh: { symlink: /usr/bin/busybox }
+      /usr/bin/busybox: { prefer: busybox }
+
+  copyright:
+    contents:
+      /usr/share/doc/busybox-static/copyright:

--- a/tests/spread/integration/busybox-static/task.yaml
+++ b/tests/spread/integration/busybox-static/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for busybox-static
+
+execute: |
+  rootfs="$(install-slices busybox-static_bins)"
+
+  chroot "${rootfs}" busybox echo "Success" > ./test
+
+  test $(chroot "${rootfs}" busybox echo "Success") = "Success"
+  test $(chroot "${rootfs}" static-sh -c 'echo ahoy') = "ahoy"


### PR DESCRIPTION
FP of https://github.com/canonical/chisel-releases/pull/581

Closes https://github.com/canonical/chisel-releases/pull/581
Closes https://github.com/canonical/chisel-releases/pull/597

See the rationale for closing the previous PRs in favor of adding this slice **only** for 26.04, in https://github.com/canonical/chisel-releases/pull/581#pullrequestreview-3563758939

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

---
FYI @endersonmaia 
