### PR TITLE
feat(24.04): archiver slice

### DIFF
--- a/slices/binutils.yaml
+++ b/slices/binutils.yaml
@@ -4,6 +4,14 @@ essential:
   - binutils_copyright
 
 slices:
+  archiver:
+    # Note: `v3-essential` only works for chisel>=1.3.0
+    v3-essential:
+      binutils-aarch64-linux-gnu_archiver: {arch: [arm64]}
+      binutils-x86-64-linux-gnu_archiver: {arch: [amd64]}
+    contents:
+      /usr/bin/ar:  # Symlink to ${ARCH_TRIPLET}-ar
+
   assembler:
     # Note: `v3-essential` only works for chisel>=1.3.0
     v3-essential:

--- a/tests/spread/integration/binutils/task.yaml
+++ b/tests/spread/integration/binutils/task.yaml
@@ -1,6 +1,7 @@
 summary: Integration tests for binutils
 
 variants:
-    - as_ld
+    - help_and_version
+    - archiver
 
 execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/binutils/test_archiver.sh
+++ b/tests/spread/integration/binutils/test_archiver.sh
@@ -1,0 +1,20 @@
+# TODO: remove the --arch and the ${arch} logic once
+# canonical/chisel #256 is merged.
+arch=$(uname -m)
+arch="${arch//_/-}"
+
+if [ "${arch}" = "aarch64" ]; then
+chisel_arch="arm64"
+elif [ "${arch}" = "x86-64" ]; then
+chisel_arch="amd64"
+else
+echo "Unsupported architecture: ${arch}"
+exit 1
+fi
+
+rootfs="$(install-slices --arch "${chisel_arch}" binutils_archiver)"
+
+touch "$rootfs/file1" "$rootfs/file2"
+chroot "$rootfs" ar rcs archive file1 file2
+chroot "$rootfs" ar t archive | grep -q "file1"
+chroot "$rootfs" ar t archive | grep -q "file2"

--- a/tests/spread/integration/binutils/test_help_and_version.sh
+++ b/tests/spread/integration/binutils/test_help_and_version.sh
@@ -12,8 +12,9 @@ echo "Unsupported architecture: ${arch}"
 exit 1
 fi
 
-rootfs="$(install-slices --arch "${chisel_arch}" binutils_assembler binutils_linker)"
+rootfs="$(install-slices --arch "${chisel_arch}" binutils_assembler binutils_linker binutils_archiver)"
 
 chroot "${rootfs}/" as --version | grep "GNU assembler"
 chroot "${rootfs}/" ld --version | grep "GNU ld"
 chroot "${rootfs}/" ld.bfd --version | grep "GNU ld"
+chroot "${rootfs}/" ar --version | grep "GNU ar"


### PR DESCRIPTION
# Proposed changes

arch-independent slice for the `binutils` archiver

required for ~~`rustc`~~ `cargo` to be able to create static libraries, so not a blocker for rust but will be for `cargo`

## Related issues/PRs

- addendum to https://github.com/canonical/chisel-releases/pull/802
- ~~unblocks https://github.com/canonical/chisel-releases/pull/806~~

### Forward porting

~~FPs could be included in https://github.com/canonical/chisel-releases/pull/805 +, or i can do them afterwards :)~~

EDIT: we've decided that i will do them afterwards. see below.

- https://github.com/canonical/chisel-releases/pull/807 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/820
- https://github.com/canonical/chisel-releases/pull/822
- https://github.com/canonical/chisel-releases/pull/823
- 
## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)