### PR TITLE
feat(25.10): add golang-1.24

### DIFF
--- a/slices/golang-1.24-go.yaml
+++ b/slices/golang-1.24-go.yaml
@@ -1,0 +1,128 @@
+package: golang-1.24-go
+
+essential:
+  - golang-1.24-go_copyright
+
+slices:
+  # Note: The minimal slice provides a working Go installation
+  #       that can be used to build and run simple Go programs,
+  #       such as a "Hello World" program.
+  #       See tests/spread/integration/golang-1.24-go/test_minimal.sh
+  #       for more details.
+  minimal:
+    essential:
+      - base-files_tmp
+      - golang-1.24-go_build-tools
+      - golang-1.24-go_headers
+      - golang-1.24-go_symlinks
+      - golang-1.24-src_src-with-tests
+    contents:
+      /usr/lib/go-1.24/bin/go:
+      /usr/lib/go-1.24/bin/gofmt:
+
+  # Note: The core slices provides the source code within the golang-1.24-go
+  #       package in additional to the minimal slice.
+  core:
+    essential:
+      - golang-1.24-go_cmd-src
+      - golang-1.24-go_go-build-src
+      - golang-1.24-go_go-env
+      - golang-1.24-go_internal-src
+      - golang-1.24-go_minimal
+      - golang-1.24-go_runtime-src
+      - golang-1.24-go_time-src
+
+  # Note: The build-tools provides the essential Go tools for building
+  #       a minimal Go program, i.e., a single Hello World program.
+  build-tools:
+    contents:
+      /usr/lib/go-1.24/pkg/tool/linux_*/asm:
+      /usr/lib/go-1.24/pkg/tool/linux_*/buildid:
+      /usr/lib/go-1.24/pkg/tool/linux_*/compile:
+      /usr/lib/go-1.24/pkg/tool/linux_*/link:
+      /usr/lib/go-1.24/pkg/tool/linux_*/pack:
+      # vet is used for go test
+      /usr/lib/go-1.24/pkg/tool/linux_*/vet:
+
+  cgo-tools:
+    essential:
+      - gcc_gcc
+      - libc6-dev_core
+      - libc6-dev_libresolv
+      - libc6-dev_runtime
+    contents:
+      /usr/lib/go-1.24/pkg/tool/linux_*/cgo:
+
+  cmd-src:
+    contents:
+      /usr/share/go-1.24/src/cmd/cgo/zdefaultcc.go:
+      /usr/share/go-1.24/src/cmd/go/internal/cfg/zdefaultcc.go:
+      /usr/share/go-1.24/src/cmd/internal/objabi/zbootstrap.go:
+
+  debug-tools:
+    contents:
+      /usr/lib/go-1.24/pkg/tool/linux_*/fix:
+      /usr/lib/go-1.24/pkg/tool/linux_*/nm:
+      /usr/lib/go-1.24/pkg/tool/linux_*/objdump:
+      /usr/lib/go-1.24/pkg/tool/linux_*/trace:
+
+  dist-tools:
+    essential:
+      - base-files_tmp
+      - golang-1.24-src_bash-scripts
+    contents:
+      /usr/lib/go-1.24/VERSION:
+      /usr/lib/go-1.24/pkg/tool/linux_*/dist:
+      /usr/lib/go-1.24/pkg/tool/linux_*/distpack:
+
+  doc-tools:
+    contents:
+      /usr/lib/go-1.24/pkg/tool/linux_*/doc:
+
+  go-build-src:
+    contents:
+      /usr/share/go-1.24/src/go/build/zcgo.go:
+
+  go-env:
+    contents:
+      /usr/lib/go-1.24/go.env:
+
+  headers:
+    contents:
+      /usr/share/go-1.24/pkg/include/*.h:
+
+  internal-src:
+    contents:
+      /usr/share/go-1.24/src/internal/buildcfg/zbootstrap.go:
+
+  profiling-tools:
+    contents:
+      /usr/lib/go-1.24/pkg/tool/linux_*/addr2line:
+      /usr/lib/go-1.24/pkg/tool/linux_*/pprof:
+
+  runtime-src:
+    contents:
+      /usr/share/go-1.24/src/internal/runtime/sys/zversion.go:
+
+  symlinks:
+    contents:
+      /usr/lib/go-1.24/api:  # Symlink to ../share/go-1.24/api
+      /usr/lib/go-1.24/lib:  # Symlink to ../share/go-1.24/lib
+      /usr/lib/go-1.24/misc:  # Symlink to ../share/go-1.24/misc
+      /usr/lib/go-1.24/pkg/include:  # Symlink to ../share/go-1.24/pkg/include
+      /usr/lib/go-1.24/src:  # Symlink to ../share/go-1.24/src
+      /usr/lib/go-1.24/test:  # Symlink to ../share/go-1.24/test
+
+  testing-tools:
+    contents:
+      /usr/lib/go-1.24/pkg/tool/linux_*/covdata:
+      /usr/lib/go-1.24/pkg/tool/linux_*/cover:
+      /usr/lib/go-1.24/pkg/tool/linux_*/test2json:
+
+  time-src:
+    contents:
+      /usr/share/go-1.24/src/time/tzdata/zzipdata.go:
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-1.24-go/copyright:

--- a/slices/golang-1.24-src.yaml
+++ b/slices/golang-1.24-src.yaml
@@ -205,13 +205,16 @@ slices:
     contents:
       /usr/share/go-1.24/api/*.txt:
 
+  # Note: The bash-scripts slice provides bash scripts used to build Go from source.
+  #       This is not tested in the integration tests, since it requires an
+  #       existing Go installation (in a different GOROOT) to run the scripts.
   bash-scripts:
     essential:
       - bash_bins
       - binutils_linker
-      # TODO: Include binutils-${ARCH_TRIPLET}_loader as well.
       - coreutils_bins
       - grep_bins
+      - sed_bins
     contents:
       /usr/share/go-1.24/src/all.bash:
       /usr/share/go-1.24/src/bootstrap.bash:

--- a/slices/golang-1.24-src.yaml
+++ b/slices/golang-1.24-src.yaml
@@ -13,7 +13,9 @@ slices:
   #      \( -path '*test*' \
   #         ! -path '*src/testing*' \
   #         ! -path '*src/internal/test*' \
-  #         ! -path '*src/runtime/synctest*' \) -o \
+  #         ! -path '*src/runtime/synctest*' \
+  #         ! -path '*synctest.go' \
+  #         ! -path '*synctest_o*' \) -o \
   #      \( -path '*/testing/*' -name '*_test.go' \) \
   #      \) -exec rm -rf {} +
   src-with-tests:

--- a/slices/golang-1.24-src.yaml
+++ b/slices/golang-1.24-src.yaml
@@ -230,6 +230,7 @@ slices:
     contents:
       /usr/share/go-1.24/lib/fips140/Makefile:
       /usr/share/go-1.24/lib/fips140/fips140.sum:
+      /usr/share/go-1.24/lib/fips140/inprocess.txt:
       /usr/share/go-1.24/lib/fips140/v1.0.0.zip:
       /usr/share/go-1.24/lib/time/mkzip.go:
       /usr/share/go-1.24/lib/time/update.bash:

--- a/slices/golang-1.24-src.yaml
+++ b/slices/golang-1.24-src.yaml
@@ -1,0 +1,241 @@
+package: golang-1.24-src
+
+essential:
+  - golang-1.24-src_copyright
+
+slices:
+  # Note: This slice contains the source code of Go 1.24 as well as the tests.
+  # Due to Go's project layout convention, we cannot split the source code
+  # easily without Chisel's support for negative wildcards.
+  # To exclude the tests and test data, a command should be run after cutting
+  # this slice:
+  #   find . -depth \( \
+  #      \( -path '*test*' \
+  #         ! -path '*src/testing*' \
+  #         ! -path '*src/internal/test*' \
+  #         ! -path '*src/runtime/synctest*' \) -o \
+  #      \( -path '*/testing/*' -name '*_test.go' \) \
+  #      \) -exec rm -rf {} +
+  src-with-tests:
+    essential:
+      - golang-1.24-src_api
+      - golang-1.24-src_libs
+    contents:
+      # Note: Some paths are explicitly listed to avoid conflicts with
+      # the paths defined in golang-1.24-go.
+      # src/cmd/** conflicts with
+      #   src/cmd/cgo/zdefaultcc.go
+      #   src/cmd/go/internal/cfg/zdefaultcc.go
+      #   src/cmd/internal/objabi/zbootstrap.go
+      # src/go/** conflicts with
+      #   src/go/build/zcgo.go
+      # src/internal/** conflicts with
+      #   src/internal/buildcfg/zbootstrap.go
+      #   src/internal/runtime/sys/zversion.go
+      # src/time/** conflicts with
+      #   src/time/tzdata/zzipdata.go
+      /usr/share/go-1.24/misc/**:
+      /usr/share/go-1.24/src/Make.dist:
+      /usr/share/go-1.24/src/a*/**:
+      /usr/share/go-1.24/src/b*/**:
+      /usr/share/go-1.24/src/cmd/a*/**:
+      /usr/share/go-1.24/src/cmd/b*/**:
+      /usr/share/go-1.24/src/cmd/cgo/a*.go:
+      /usr/share/go-1.24/src/cmd/cgo/doc.go:
+      /usr/share/go-1.24/src/cmd/cgo/g*.go:
+      /usr/share/go-1.24/src/cmd/cgo/internal/**:
+      /usr/share/go-1.24/src/cmd/cgo/main.go:
+      /usr/share/go-1.24/src/cmd/cgo/out.go:
+      /usr/share/go-1.24/src/cmd/cgo/util.go:
+      /usr/share/go-1.24/src/cmd/co*/**:
+      /usr/share/go-1.24/src/cmd/d*/**:
+      /usr/share/go-1.24/src/cmd/f*/**:
+      /usr/share/go-1.24/src/cmd/go.mod:
+      /usr/share/go-1.24/src/cmd/go.sum:
+      /usr/share/go-1.24/src/cmd/go/*.go:
+      /usr/share/go-1.24/src/cmd/go/internal/a*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/b*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/ca*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/cfg/bench_test.go:
+      /usr/share/go-1.24/src/cmd/go/internal/cfg/cfg.go:
+      /usr/share/go-1.24/src/cmd/go/internal/cl*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/cm*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/d*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/e*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/f*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/g*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/h*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/i*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/l*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/m*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/r*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/s*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/t*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/v*/**:
+      /usr/share/go-1.24/src/cmd/go/internal/w*/**:
+      /usr/share/go-1.24/src/cmd/go/t*/**:
+      /usr/share/go-1.24/src/cmd/gof*/**:
+      /usr/share/go-1.24/src/cmd/internal/a*/**:
+      /usr/share/go-1.24/src/cmd/internal/b*/**:
+      /usr/share/go-1.24/src/cmd/internal/c*/**:
+      /usr/share/go-1.24/src/cmd/internal/d*/**:
+      /usr/share/go-1.24/src/cmd/internal/e*/**:
+      /usr/share/go-1.24/src/cmd/internal/g*/**:
+      /usr/share/go-1.24/src/cmd/internal/h*/**:
+      /usr/share/go-1.24/src/cmd/internal/m*/**:
+      /usr/share/go-1.24/src/cmd/internal/obj/**:
+      /usr/share/go-1.24/src/cmd/internal/objabi/a*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/f*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/h*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/l*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/p*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/r*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/s*:
+      /usr/share/go-1.24/src/cmd/internal/objabi/u*:
+      /usr/share/go-1.24/src/cmd/internal/objfile/*.go:
+      /usr/share/go-1.24/src/cmd/internal/os*/**:
+      /usr/share/go-1.24/src/cmd/internal/p*/**:
+      /usr/share/go-1.24/src/cmd/internal/q*/**:
+      /usr/share/go-1.24/src/cmd/internal/r*/**:
+      /usr/share/go-1.24/src/cmd/internal/s*/**:
+      /usr/share/go-1.24/src/cmd/internal/t*/**:
+      /usr/share/go-1.24/src/cmd/l*/**:
+      /usr/share/go-1.24/src/cmd/n*/**:
+      /usr/share/go-1.24/src/cmd/o*/**:
+      /usr/share/go-1.24/src/cmd/p*/**:
+      /usr/share/go-1.24/src/cmd/r*/**:
+      /usr/share/go-1.24/src/cmd/t*/**:
+      /usr/share/go-1.24/src/cmd/v*/**:
+      /usr/share/go-1.24/src/cmp/**:
+      /usr/share/go-1.24/src/co*/**:
+      /usr/share/go-1.24/src/crypto/**:
+      /usr/share/go-1.24/src/d*/**:
+      /usr/share/go-1.24/src/e*/**:
+      /usr/share/go-1.24/src/f*/**:
+      /usr/share/go-1.24/src/go.mod:
+      /usr/share/go-1.24/src/go.sum:
+      /usr/share/go-1.24/src/go/a*/**:
+      /usr/share/go-1.24/src/go/build/b*:
+      /usr/share/go-1.24/src/go/build/c*/**:
+      /usr/share/go-1.24/src/go/build/d*:
+      /usr/share/go-1.24/src/go/build/g*:
+      /usr/share/go-1.24/src/go/build/r*:
+      /usr/share/go-1.24/src/go/build/s*:
+      /usr/share/go-1.24/src/go/build/t*/**:
+      /usr/share/go-1.24/src/go/build/v*:
+      /usr/share/go-1.24/src/go/c*/**:
+      /usr/share/go-1.24/src/go/d*/**:
+      /usr/share/go-1.24/src/go/f*/**:
+      /usr/share/go-1.24/src/go/i*/**:
+      /usr/share/go-1.24/src/go/p*/**:
+      /usr/share/go-1.24/src/go/s*/**:
+      /usr/share/go-1.24/src/go/t*/**:
+      /usr/share/go-1.24/src/go/v*/**:
+      /usr/share/go-1.24/src/h*/**:
+      /usr/share/go-1.24/src/im*/**:
+      /usr/share/go-1.24/src/ind*/**:
+      /usr/share/go-1.24/src/internal/a*/**:
+      /usr/share/go-1.24/src/internal/bi*/**:
+      /usr/share/go-1.24/src/internal/buildcfg/c*:
+      /usr/share/go-1.24/src/internal/buildcfg/e*:
+      /usr/share/go-1.24/src/internal/by*/**:
+      /usr/share/go-1.24/src/internal/c*/**:
+      /usr/share/go-1.24/src/internal/d*/**:
+      /usr/share/go-1.24/src/internal/e*/**:
+      /usr/share/go-1.24/src/internal/f*/**:
+      /usr/share/go-1.24/src/internal/g*/**:
+      /usr/share/go-1.24/src/internal/i*/**:
+      /usr/share/go-1.24/src/internal/l*/**:
+      /usr/share/go-1.24/src/internal/m*/**:
+      /usr/share/go-1.24/src/internal/n*/**:
+      /usr/share/go-1.24/src/internal/o*/**:
+      /usr/share/go-1.24/src/internal/p*/**:
+      /usr/share/go-1.24/src/internal/ra*/**:
+      /usr/share/go-1.24/src/internal/re*/**:
+      /usr/share/go-1.24/src/internal/runtime/a*/**:
+      /usr/share/go-1.24/src/internal/runtime/e*/**:
+      /usr/share/go-1.24/src/internal/runtime/m*/**:
+      /usr/share/go-1.24/src/internal/runtime/sys/c*:
+      /usr/share/go-1.24/src/internal/runtime/sys/d*:
+      /usr/share/go-1.24/src/internal/runtime/sys/e*:
+      /usr/share/go-1.24/src/internal/runtime/sys/i*:
+      /usr/share/go-1.24/src/internal/runtime/sys/n*:
+      /usr/share/go-1.24/src/internal/runtime/sys/s*:
+      /usr/share/go-1.24/src/internal/runtime/sysc*/**:
+      /usr/share/go-1.24/src/internal/s*/**:
+      /usr/share/go-1.24/src/internal/t*/**:
+      /usr/share/go-1.24/src/internal/u*/**:
+      /usr/share/go-1.24/src/internal/x*/**:
+      /usr/share/go-1.24/src/internal/z*/**:
+      /usr/share/go-1.24/src/io*/**:
+      /usr/share/go-1.24/src/it*/**:
+      /usr/share/go-1.24/src/l*/**:
+      /usr/share/go-1.24/src/m*/**:
+      /usr/share/go-1.24/src/n*/**:
+      /usr/share/go-1.24/src/o*/**:
+      /usr/share/go-1.24/src/p*/**:
+      /usr/share/go-1.24/src/re*/**:
+      /usr/share/go-1.24/src/runtime/**.S:
+      /usr/share/go-1.24/src/runtime/**.c:
+      /usr/share/go-1.24/src/runtime/**.h:
+      /usr/share/go-1.24/src/runtime/**.s:
+      /usr/share/go-1.24/src/runtime/*.go:
+      /usr/share/go-1.24/src/runtime/*.py:
+      /usr/share/go-1.24/src/runtime/Makefile:
+      /usr/share/go-1.24/src/runtime/a*/**:
+      /usr/share/go-1.24/src/runtime/c*/**:
+      /usr/share/go-1.24/src/runtime/d*/**:
+      /usr/share/go-1.24/src/runtime/internal/st*/**:
+      /usr/share/go-1.24/src/runtime/internal/w*/**:
+      /usr/share/go-1.24/src/runtime/m*/**:
+      /usr/share/go-1.24/src/runtime/p*/**:
+      /usr/share/go-1.24/src/runtime/r*/**:
+      /usr/share/go-1.24/src/runtime/t*/**:
+      /usr/share/go-1.24/src/s*/**:
+      /usr/share/go-1.24/src/te*/**:
+      /usr/share/go-1.24/src/time/*.go:
+      /usr/share/go-1.24/src/time/te*/**:
+      /usr/share/go-1.24/src/time/tzdata/tzdata.go:
+      /usr/share/go-1.24/src/u*/**:
+      /usr/share/go-1.24/src/v*/**:
+      /usr/share/go-1.24/src/w*/**:
+      /usr/share/go-1.24/test/**:
+
+  api:
+    contents:
+      /usr/share/go-1.24/api/*.txt:
+
+  bash-scripts:
+    essential:
+      - bash_bins
+      - binutils_linker
+      # TODO: Include binutils-${ARCH_TRIPLET}_loader as well.
+      - coreutils_bins
+      - grep_bins
+    contents:
+      /usr/share/go-1.24/src/all.bash:
+      /usr/share/go-1.24/src/bootstrap.bash:
+      /usr/share/go-1.24/src/buildall.bash:
+      /usr/share/go-1.24/src/clean.bash:
+      /usr/share/go-1.24/src/cmp.bash:
+      /usr/share/go-1.24/src/make.bash:
+      /usr/share/go-1.24/src/race.bash:
+      /usr/share/go-1.24/src/run.bash:
+
+  libs:
+    essential:
+      - bash_bins
+      - coreutils_bins
+      - make_bins
+    contents:
+      /usr/share/go-1.24/lib/fips140/Makefile:
+      /usr/share/go-1.24/lib/fips140/fips140.sum:
+      /usr/share/go-1.24/lib/fips140/v1.0.0.zip:
+      /usr/share/go-1.24/lib/time/mkzip.go:
+      /usr/share/go-1.24/lib/time/update.bash:
+      /usr/share/go-1.24/lib/time/zoneinfo.zip:
+      /usr/share/go-1.24/lib/wasm/*:
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-1.24-src/copyright:

--- a/slices/golang-1.24.yaml
+++ b/slices/golang-1.24.yaml
@@ -1,0 +1,15 @@
+package: golang-1.24
+
+essential:
+  - golang-1.24_copyright
+
+slices:
+  core:
+    essential:
+      # Note: Package golang-1.24-go is not available on i386.
+      - golang-1.24-go_core
+      - golang-1.24-src_src-with-tests
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-1.24/copyright:

--- a/slices/golang-1.24.yaml
+++ b/slices/golang-1.24.yaml
@@ -10,6 +10,11 @@ slices:
       - golang-1.24-go_core
       - golang-1.24-src_src-with-tests
 
+  cgo-support:
+    essential:
+      - golang-1.24-go_cgo-tools
+      - golang-1.24_core
+
   copyright:
     contents:
       /usr/share/doc/golang-1.24/copyright:

--- a/slices/golang-go.yaml
+++ b/slices/golang-go.yaml
@@ -1,0 +1,21 @@
+package: golang-go
+
+essential:
+  - golang-go_copyright
+
+slices:
+  core:
+    essential:
+      - golang-1.24-go_core
+    contents:
+      /usr/bin/go:  # Symlink to ../lib/go-1.24/bin/go
+      /usr/bin/gofmt:  # Symlink to ../lib/go-1.24/bin/gofmt
+      /usr/lib/go:  # Symlink to ../share/go-1.24
+
+  cgo-tools:
+    essential:
+      - golang-1.24-go_cgo-tools
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-go/copyright:

--- a/slices/golang-src.yaml
+++ b/slices/golang-src.yaml
@@ -1,0 +1,15 @@
+package: golang-src
+
+essential:
+  - golang-src_copyright
+
+slices:
+  src-with-tests:
+    essential:
+      - golang-1.24-src_src-with-tests
+    contents:
+      /usr/share/go:  # Symlink to go-1.24
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-src/copyright:

--- a/slices/golang.yaml
+++ b/slices/golang.yaml
@@ -1,0 +1,19 @@
+package: golang
+
+essential:
+  - golang_copyright
+
+slices:
+  core:
+    essential:
+      - golang-go_core
+      - golang-src_src-with-tests
+
+  cgo-support:
+    essential:
+      - golang-1.24-go_cgo-tools
+      - golang_core
+
+  copyright:
+    contents:
+      /usr/share/doc/golang/copyright:

--- a/slices/make.yaml
+++ b/slices/make.yaml
@@ -1,0 +1,12 @@
+package: make
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/bin/make:
+
+  copyright:
+    contents:
+      /usr/share/doc/make/copyright:

--- a/tests/spread/integration/golang-1.24-go/shared/epilogue.sh
+++ b/tests/spread/integration/golang-1.24-go/shared/epilogue.sh
@@ -1,0 +1,3 @@
+# cleanup
+umount -l "${rootfs}"/dev
+umount -l "${rootfs}"/proc

--- a/tests/spread/integration/golang-1.24-go/shared/prologue.sh
+++ b/tests/spread/integration/golang-1.24-go/shared/prologue.sh
@@ -1,0 +1,26 @@
+# TODO: remove the --arch and the ${arch} logic once
+# canonical/chisel #256 is merged.
+arch=$(uname -m)
+arch="${arch//_/-}"
+
+if [ "${arch}" = "aarch64" ]; then
+chisel_arch="arm64"
+elif [ "${arch}" = "x86-64" ]; then
+chisel_arch="amd64"
+else
+echo "Unsupported architecture: ${arch}"
+exit 1
+fi
+
+rootfs="$(install-slices --arch "${chisel_arch}" golang-1.24-go_${SLICE} golang-1.24-go_minimal)"
+
+# we need dev/sys mounted for some of them
+mkdir "${rootfs}"/dev
+mkdir "${rootfs}/proc"
+
+mount --bind /dev "${rootfs}"/dev
+mount --bind /proc "${rootfs}/proc"
+
+mkdir -p "${rootfs}/tmp"
+
+echo -n "${rootfs}"

--- a/tests/spread/integration/golang-1.24-go/task.yaml
+++ b/tests/spread/integration/golang-1.24-go/task.yaml
@@ -10,6 +10,9 @@ variants:
   - profiling-tools
   - testing-tools
 
+environment:
+  GOTOOLCHAIN: local
+
 execute: |
   export "SLICE=${SPREAD_VARIANT}"
   export "rootfs=$(bash -ex ./shared/prologue.sh)"

--- a/tests/spread/integration/golang-1.24-go/task.yaml
+++ b/tests/spread/integration/golang-1.24-go/task.yaml
@@ -1,0 +1,17 @@
+summary: Integration tests for golang-1.24-go 
+
+variants:
+  - build-tools
+  - cgo-tools
+  - debug-tools
+  - dist-tools
+  - doc-tools
+  - minimal
+  - profiling-tools
+  - testing-tools
+
+execute: |
+  export "SLICE=${SPREAD_VARIANT}"
+  export "rootfs=$(bash -ex ./shared/prologue.sh)"
+  bash -ex ./test_${SPREAD_VARIANT}.sh
+  bash -ex ./shared/epilogue.sh

--- a/tests/spread/integration/golang-1.24-go/test_build-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_build-tools.sh
@@ -1,0 +1,7 @@
+[ -n "${rootfs}" ] || { echo "rootfs not set"; exit 1; }
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool asm -V
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool buildid 2>&1 || true) | grep "usage"
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool compile -V
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool link -V
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool pack --help 2>&1 || true) | grep "Usage"
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool vet -V

--- a/tests/spread/integration/golang-1.24-go/test_cgo-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_cgo-tools.sh
@@ -1,0 +1,4 @@
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool cgo -V
+cp ../golang/hello/cmd/hello_cgo/main_cgo.go "${rootfs}/main_cgo.go"
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool cgo main_cgo.go
+grep -q "hello_from_c" "${rootfs}/_obj/_cgo_.o"

--- a/tests/spread/integration/golang-1.24-go/test_debug-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_debug-tools.sh
@@ -1,0 +1,4 @@
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool fix --help 2>&1 || true) | grep "usage"
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool nm --help 2>&1 || true) | grep "usage"
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool objdump --help 2>&1 || true) | grep "usage"
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool trace --help 2>&1 || true) | grep "Usage"

--- a/tests/spread/integration/golang-1.24-go/test_dist-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_dist-tools.sh
@@ -1,0 +1,2 @@
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool dist version
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool distpack --help 2>&1 || true) | grep "usage"

--- a/tests/spread/integration/golang-1.24-go/test_doc-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_doc-tools.sh
@@ -1,0 +1,1 @@
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool doc help

--- a/tests/spread/integration/golang-1.24-go/test_minimal.sh
+++ b/tests/spread/integration/golang-1.24-go/test_minimal.sh
@@ -1,0 +1,2 @@
+cp ../golang/hello/cmd/hello/main.go "${rootfs}/hello.go"
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go run /hello.go | grep "Hello, World!"

--- a/tests/spread/integration/golang-1.24-go/test_profiling-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_profiling-tools.sh
@@ -1,0 +1,2 @@
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool addr2line --help
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool pprof --help

--- a/tests/spread/integration/golang-1.24-go/test_testing-tools.sh
+++ b/tests/spread/integration/golang-1.24-go/test_testing-tools.sh
@@ -1,0 +1,3 @@
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool covdata --help 2>&1 || true) | grep "usage"
+chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool cover -V
+(chroot "${rootfs}" /usr/lib/go-1.24/bin/go tool test2json --help 2>&1 || true) | grep "usage"

--- a/tests/spread/integration/golang/hello/cmd/hello/main.go
+++ b/tests/spread/integration/golang/hello/cmd/hello/main.go
@@ -1,0 +1,9 @@
+// Source: https://gobyexample.com/hello-world
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/tests/spread/integration/golang/hello/cmd/hello_cgo/main_cgo.go
+++ b/tests/spread/integration/golang/hello/cmd/hello_cgo/main_cgo.go
@@ -1,0 +1,15 @@
+package main
+
+/*
+#include <stdio.h>
+
+void hello_from_c() {
+    printf("Hello from C!\n");
+}
+*/
+import "C"
+
+func main() {
+	C.hello_from_c()
+	C.fflush(C.stdout)
+}

--- a/tests/spread/integration/golang/hello/go.mod
+++ b/tests/spread/integration/golang/hello/go.mod
@@ -1,0 +1,3 @@
+module hello
+
+go 1.22.2

--- a/tests/spread/integration/golang/hello/hello.go
+++ b/tests/spread/integration/golang/hello/hello.go
@@ -1,0 +1,5 @@
+package hello
+
+func Hello() string {
+	return "Hello, World!"
+}

--- a/tests/spread/integration/golang/hello/hello_test.go
+++ b/tests/spread/integration/golang/hello/hello_test.go
@@ -1,0 +1,14 @@
+package hello_test
+
+import (
+	"hello"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	expected := "Hello, World!"
+	t.Logf("expected: %s", expected)
+	if got := hello.Hello(); got != expected {
+		t.Errorf("expect %v, got %v", expected, got)
+	}
+}

--- a/tests/spread/integration/golang/task.yaml
+++ b/tests/spread/integration/golang/task.yaml
@@ -1,0 +1,6 @@
+summary: Integration tests for golang
+
+variants:
+  - all
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/golang/task.yaml
+++ b/tests/spread/integration/golang/task.yaml
@@ -3,4 +3,7 @@ summary: Integration tests for golang
 variants:
   - all
 
+environment:
+  GOTOOLCHAIN: local
+
 execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/golang/test_all.sh
+++ b/tests/spread/integration/golang/test_all.sh
@@ -1,0 +1,58 @@
+arch=$(uname -m)
+arch="${arch//_/-}"
+
+if [ "${arch}" = "aarch64" ]; then
+chisel_arch="arm64"
+elif [ "${arch}" = "x86-64" ]; then
+chisel_arch="amd64"
+else
+echo "Unsupported architecture: ${arch}"
+exit 1
+fi
+
+rootfs="$(install-slices --arch "${chisel_arch}" \
+  golang_cgo-support \
+  ca-certificates_data \  # for `go get` to work properly
+)"
+
+find ${rootfs}/usr/share/go-1.24 -depth \( \
+        \( -path '*test*' \
+          ! -path '*src/testing*' \
+          ! -path '*src/internal/test*' \
+          ! -path '*src/runtime/synctest*' \) -o \
+  \( -path '*/testing/*' -name '*_test.go' \) \
+  \) -exec rm -rf {} +
+
+mkdir "${rootfs}/proc"
+mount --bind /proc "${rootfs}/proc"
+
+mkdir "${rootfs}/dev"
+mount --bind /dev "${rootfs}/dev"
+
+mkdir -p "${rootfs}/tmp"
+
+mkdir "${rootfs}/app"
+cp -r hello "${rootfs}/"
+
+chroot "${rootfs}/" go version
+chroot "${rootfs}/" go run /hello/cmd/hello/main.go | grep "Hello, World!"
+
+chroot "${rootfs}/" gofmt /hello/cmd/hello/main.go > /dev/null
+
+chroot "${rootfs}/" go -C /hello test
+
+git clone https://github.com/canonical/chisel.git "${rootfs}/chisel"
+git -C "$rootfs/chisel" checkout v1.2.0
+cp /etc/resolv.conf "${rootfs}/etc/resolv.conf"
+
+chroot "${rootfs}/" go -C chisel build ./cmd/chisel
+chroot "${rootfs}/" ./chisel/chisel 2>&1 > /dev/null
+
+
+export CGO_ENABLED=1
+chroot "${rootfs}/" go run /hello/cmd/hello_cgo/main_cgo.go | grep "Hello from C!"
+
+umount "${rootfs}/proc"
+umount "${rootfs}/dev"
+rm -rf "${rootfs}/proc"
+rm -rf "${rootfs}/dev"

--- a/tests/spread/integration/golang/test_all.sh
+++ b/tests/spread/integration/golang/test_all.sh
@@ -19,7 +19,9 @@ find ${rootfs}/usr/share/go-1.24 -depth \( \
         \( -path '*test*' \
           ! -path '*src/testing*' \
           ! -path '*src/internal/test*' \
-          ! -path '*src/runtime/synctest*' \) -o \
+          ! -path '*src/runtime/synctest*' \
+          ! -path '*synctest.go' \
+          ! -path '*synctest_o*' \) -o \
   \( -path '*/testing/*' -name '*_test.go' \) \
   \) -exec rm -rf {} +
 

--- a/tests/spread/integration/make/Makefile
+++ b/tests/spread/integration/make/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	$(info Hello from Makefile!)

--- a/tests/spread/integration/make/task.yaml
+++ b/tests/spread/integration/make/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for make
+
+execute: |
+  rootfs=$(install-slices make_bins)
+
+  chroot "${rootfs}" make --version | grep "GNU Make"
+
+  cp Makefile "${rootfs}/Makefile"
+  chroot "${rootfs}" make | grep -q "Hello from Makefile!"


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This is a straight forward port from #818 . The first commit is cherry-picked, and the delta is overlayed as the second commit.

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

The FP #825  of this PR is a quasi-FP, which actually provides `golang-1.25` on 26.04.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->