### PR TITLE
ci(22.04): accept 'degraded' status when preparing lxd machine for tests

### DIFF
--- a/slices/coreutils.yaml
+++ b/slices/coreutils.yaml
@@ -3,8 +3,6 @@ package: coreutils
 essential:
   - coreutils_copyright
 
-# hello coreutils
-
 slices:
   libs:
     essential:


### PR DESCRIPTION
# Proposed changes

accept `degraded` status when preparing lxd machine for tests

on one hand side it allows us to proceed in cases like the one described in #828, one the other hand we are risking running tests on a degraded machine. its more likely thought that this would cause false negatives (tests failing while they should not) rather than false positives (tests passing while they shouldn't)

## Related issues/PRs

- closes https://github.com/canonical/chisel-releases/issues/828 (although will need forward + backports too ofc)

### Forward porting

- https://github.com/canonical/chisel-releases/pull/888
- https://github.com/canonical/chisel-releases/pull/829 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/887
- https://github.com/canonical/chisel-releases/pull/886
- https://github.com/canonical/chisel-releases/pull/885


## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)