### PR TITLE
fix(24.04): default to /usr/share/manifests if env var is not set

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -6,7 +6,6 @@ environment:
   PROJECT_PATH: /chisel-releases
   SHARED_LIBRARIES: $PROJECT_PATH/tests/spread/lib
   PATH: /snap/bin:$PATH:$SHARED_LIBRARIES
-  MANIFESTS_EXPORT_DIR: /usr/share/manifests
 
 exclude:
   - .github
@@ -39,6 +38,7 @@ backends:
       lxc exec $SPREAD_SYSTEM -- killall -HUP sshd
       ADDRESS `lxc list --format=json $SPREAD_SYSTEM | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address'`
     discard: |
+      MANIFESTS_EXPORT_DIR=${MANIFESTS_EXPORT_DIR:-/usr/share/manifests}
       lxc file pull -pr $SPREAD_SYSTEM/$MANIFESTS_EXPORT_DIR $MANIFESTS_EXPORT_DIR || true
       lxc stop $SPREAD_SYSTEM || true
     systems:


### PR DESCRIPTION
# Proposed changes
Default to `/usr/share/manifests` if `MANIFESTS_EXPORT_DIR` is not set to avoid duplication, as mentioned in [this comment](https://github.com/canonical/chisel-releases/pull/720#discussion_r2697345760)

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
