### PR TITLE
fix(26.04): use the host env vars to set the manifest export dir

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -6,7 +6,7 @@ environment:
   PROJECT_PATH: /chisel-releases
   SHARED_LIBRARIES: $PROJECT_PATH/tests/spread/lib
   PATH: /snap/bin:$PATH:$SHARED_LIBRARIES
-  MANIFESTS_EXPORT_DIR: /usr/share/manifests
+  MANIFESTS_EXPORT_DIR: $(HOST:echo "${MANIFESTS_EXPORT_DIR:-/usr/share/manifests}")
 
 exclude:
   - .github


### PR DESCRIPTION
# Proposed changes
Use the `$HOST` in spread to set the `MANIFESTS_EXPORT_DIR` environment variable to avoid duplication, as mentioned in [this comment](https://github.com/canonical/chisel-releases/pull/720#discussion_r2697345760). 

Source from spread docs [here](https://github.com/canonical/spread?tab=readme-ov-file#environments)

### Related Issues
* #851
* #852 
* #853 
* #854 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)