### PR TITLE
fix(25.10): fix lxc discard when MANIFESTS_EXPORT_DIR is unset

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -43,7 +43,7 @@ backends:
     # This allows us to collect the generated manifests after the test run. If the variable is not set,
     # the pull step is skipped and the instance is stopped.
     discard: |
-      [ -v MANIFESTS_EXPORT_DIR ] && lxc file pull -pr $SPREAD_SYSTEM/$MANIFESTS_EXPORT_DIR $MANIFESTS_EXPORT_DIR
+      [ -n "${MANIFESTS_EXPORT_DIR-}" ] && lxc file pull -pr $SPREAD_SYSTEM/$MANIFESTS_EXPORT_DIR $MANIFESTS_EXPORT_DIR
       lxc stop $SPREAD_SYSTEM || true
     systems:
       - ubuntu-questing:


### PR DESCRIPTION
# Proposed changes
fix lxc discard when MANIFESTS_EXPORT_DIR is unset

### Related PRs
* #859
* #860 
* #861 

### Forward porting
* #863 

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)