### PR TITLE
fix: coverage issues

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -15,6 +15,8 @@ jobs:
             runs-on: ${{ github.repository_owner == 'canonical' && fromJSON('["noble", "ARM64", "large"]') || 'ubuntu-24.04-arm' }}
     name: Run Spread tests | ${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.runs-on }}
+    outputs:
+      tests-conclusion: ${{ steps.run-spread.conclusion }}
     env:
       main-branch-path: files-from-main
       MANIFESTS_EXPORT_DIR: /usr/share/manifests
@@ -115,6 +117,7 @@ jobs:
     name: Generate PR Comment
     runs-on: ubuntu-latest
     needs: [ spread-tests ]
+    if: ${{ needs.spread-tests.outputs.tests-conclusion == 'success' }}
     env:
       main-branch-path: files-from-main
     permissions:


### PR DESCRIPTION
# Proposed changes
* Create the manifest export directory and give ownership to prevent permission errors
* Skip the entire `generate PR Comment` job if the spread tests don't succeed.
  * Prevents an ugly empty coverage report being posted

## Related issues/PRs
* permission issues: [workflow run](https://github.com/canonical/chisel-releases/actions/runs/21483349295/job/61885512240?pr=871#step:10:38)
* empty comment: https://github.com/canonical/chisel-releases/pull/868#issuecomment-3818484461

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
