### PR TITLE
fix: avoid awk failing when merging slice files into one for coverage

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ steps.run-spread.conclusion == 'success' }}
         id: json-coverage-report
         run: |
-          printf '%s\n' "${{ steps.changed-slices.outputs.slices_files }}" | xargs awk 'FNR==1{print "---"}{print}' > committed-slices.yaml
+          echo "${{ steps.changed-slices.outputs.slices_files }}" | xargs --no-run-if-empty awk 'FNR==1{print "---"}{print}' > committed-slices.yaml
           find "$MANIFESTS_EXPORT_DIR" -type f -name "*.wall" -exec zstdcat {} \; > installed-slices.wall
 
           ln -s "${{ env.main-branch-path }}/.github/scripts/test-coverage/coverage-report" coverage-report


### PR DESCRIPTION
# Proposed changes
${{ steps.changed-slices.outputs.slices_files }} returns a string like "slice/foo.yaml slice/bar.yaml" which is considered as one single argument by `awk`. We need to format it properly so it can be read correctly.

## Related issues/PRs
* https://github.com/canonical/chisel-releases/actions/runs/21515615927/job/61993130420?pr=839

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)