### PR TITLE
test(26.04): use latest stable release as test backend for devel

### DIFF
--- a/tests/spread/integration/dash/task.yaml
+++ b/tests/spread/integration/dash/task.yaml
@@ -3,6 +3,6 @@ summary: Integration tests for dash
 execute: |
   rootfs="$(install-slices dash_bins)"
 
-  chroot "${rootfs}" dash -c "echo Hello > /test"
+  chroot "${rootfs}" dash -c "echo Success > /test"
 
-  test $(cat "${rootfs}/test") == "Hello"
+  test $(cat "${rootfs}/test") == "Success"


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR changes the spread to use the latest stable release as the LXD test backend to avoid the currently ongoing systemctl degraded issue (#828)

## Related issues/PRs
<!-- If any -->

#828 

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

N/A

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->