### PR TITLE
feat(26.04): remove gconv-modules-extra fom libc6

### DIFF
--- a/slices/libc6.yaml
+++ b/slices/libc6.yaml
@@ -50,7 +50,6 @@ slices:
     contents:
       /usr/lib/*-linux-*/gconv/gconv-modules:
       /usr/lib/*-linux-*/gconv/gconv-modules.cache:
-      /usr/lib/*-linux-*/gconv/gconv-modules.d/gconv-modules-extra.conf:
 
   gconv-core:
     essential:


### PR DESCRIPTION
# Proposed changes

remove the nonexistent file from libc6

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/889

### Forward porting
n/a


## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)