### PR TITLE
feat(25.10): arch-dependent gcc slices

### DIFF
--- a/slices/cpp-aarch64-linux-gnu.yaml
+++ b/slices/cpp-aarch64-linux-gnu.yaml
@@ -1,0 +1,9 @@
+package: cpp-aarch64-linux-gnu
+
+essential:
+  - cpp-aarch64-linux-gnu_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/cpp-aarch64-linux-gnu/copyright:

--- a/slices/cpp-x86-64-linux-gnu.yaml
+++ b/slices/cpp-x86-64-linux-gnu.yaml
@@ -1,0 +1,9 @@
+package: cpp-x86-64-linux-gnu
+
+essential:
+  - cpp-x86-64-linux-gnu_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/cpp-x86-64-linux-gnu/copyright:

--- a/slices/gcc-aarch64-linux-gnu.yaml
+++ b/slices/gcc-aarch64-linux-gnu.yaml
@@ -1,0 +1,17 @@
+package: gcc-aarch64-linux-gnu
+
+essential:
+  - gcc-aarch64-linux-gnu_copyright
+
+slices:
+  gcc:
+    essential:
+      - gcc-15-aarch64-linux-gnu_gcc-15
+    contents:
+      /usr/bin/aarch64-linux-gnu-gcc:  # Symlink to aarch64-linux-gnu-gcc-15
+
+  copyright:
+    essential:
+      - cpp-aarch64-linux-gnu_copyright
+    contents:
+      /usr/share/doc/gcc-aarch64-linux-gnu:  # Symlink to cpp-aarch64-linux-gnu

--- a/slices/gcc-x86-64-linux-gnu.yaml
+++ b/slices/gcc-x86-64-linux-gnu.yaml
@@ -1,0 +1,17 @@
+package: gcc-x86-64-linux-gnu
+
+essential:
+  - gcc-x86-64-linux-gnu_copyright
+
+slices:
+  gcc:
+    essential:
+      - gcc-15-x86-64-linux-gnu_gcc-15
+    contents:
+      /usr/bin/x86_64-linux-gnu-gcc:  # Symlink to x86_64-linux-gnu-gcc-15
+
+  copyright:
+    essential:
+      - cpp-x86-64-linux-gnu_copyright
+    contents:
+      /usr/share/doc/gcc-x86-64-linux-gnu:  # Symlink to cpp-x86-64-linux-gnu

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/task.yaml
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for gcc-aarch64-linux-gnu
+
+variants:
+    - dump
+    - hello
+    - help_and_version
+    - print
+    - std
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/test_dump.sh
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/test_dump.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs dumpmachine dumpversion dumpspecs
+
+rootfs="$(install-slices gcc-aarch64-linux-gnu_gcc)"
+ln -s "aarch64-linux-gnu-gcc" "${rootfs}/usr/bin/gcc"
+
+dumpmachine=$(chroot "${rootfs}" gcc -dumpmachine)
+test "$dumpmachine" = "aarch64-linux-gnu"
+dumpversion=$(chroot "${rootfs}" gcc -dumpversion)
+test "$dumpversion" = "15"
+
+# shellcheck disable=SC2063
+dumpspecs=$(chroot "${rootfs}" gcc -dumpspecs | grep '^*' | tr '\n' ' ')
+expected_keys=("asm" "cc1" "cpp" "link" "lib")
+for key in "${expected_keys[@]}"; do
+    # shellcheck disable=SC2063
+    echo "$dumpspecs" | grep -q "*${key}:"
+done

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/test_hello.sh
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/test_hello.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "aarch64" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-15-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-aarch64-linux-gnu_gcc
+        cpp-15-aarch64-linux-gnu_cc1
+        binutils-aarch64-linux-gnu_assembler
+        binutils-aarch64-linux-gnu_linker
+        libgcc-15-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s aarch64-linux-gnu-gcc "${rootfs}/usr/bin/gcc"
+    ln -s aarch64-linux-gnu-as "${rootfs}/usr/bin/as"
+    ln -s aarch64-linux-gnu-ld "${rootfs}/usr/bin/ld"
+
+    cp testfiles/hello.c "${rootfs}/hello.c"
+
+    chroot "${rootfs}" gcc /hello.c -o /hello
+    chroot "${rootfs}" /hello | grep -q "Hello from C!"
+fi

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/test_help_and_version.sh
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/test_help_and_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs
+
+rootfs="$(install-slices gcc-aarch64-linux-gnu_gcc)"
+ln -s "aarch64-linux-gnu-gcc" "${rootfs}/usr/bin/gcc"
+
+# something like: Usage: gcc [options] file...
+help=$(chroot "${rootfs}" gcc --help | head -n1)
+echo "$help" | grep -q "Usage: gcc"
+
+# something like: gcc (Ubuntu 15.2.0-19ubuntu2) 15.2.0
+version=$(chroot "${rootfs}" gcc --version | head -n1)
+echo "$version" | grep -q "gcc"
+echo "$version" | grep -q "15."

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/test_print.sh
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/test_print.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libgcc libexec libc multiarch
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "aarch64" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    gcc_dir="gcc-cross"
+    sysroot="/"
+else
+    gcc_dir="gcc"
+    sysroot=""
+fi
+
+rootfs="$(install-slices gcc-aarch64-linux-gnu_gcc)"
+    ln -s "aarch64-linux-gnu-gcc" "${rootfs}/usr/bin/gcc"
+
+test "$(chroot "${rootfs}" gcc -print-search-dirs | head -n 1)" = "install: /usr/lib/$gcc_dir/aarch64-linux-gnu/15/"
+chroot "${rootfs}" gcc -print-search-dirs | head -n 2 | tail -n 1 | grep -q "/usr/libexec/$gcc_dir/aarch64-linux-gnu/15/"
+
+test "$(chroot "${rootfs}" gcc -print-libgcc-file-name)" = "libgcc.a"
+chroot "${rootfs}" gcc -print-file-name=libc.so.6 | grep -q "libc.so.6"
+
+# create a fake program called 'foo' in libexec dir to test -print-prog-name
+touch "${rootfs}/usr/libexec/$gcc_dir/aarch64-linux-gnu/15/foo"
+chmod +x "${rootfs}/usr/libexec/$gcc_dir/aarch64-linux-gnu/15/foo"
+
+chroot "${rootfs}" gcc -print-prog-name=foo
+test "$(chroot "${rootfs}" gcc -print-prog-name=foo)" = "/usr/libexec/$gcc_dir/aarch64-linux-gnu/15/foo"
+
+# we're not configured for multiple architectures
+test "$(chroot "${rootfs}" gcc -print-multiarch)" = "aarch64-linux-gnu"
+test "$(chroot "${rootfs}" gcc -print-multi-directory)" = "."
+chroot "${rootfs}" gcc -print-multi-lib # the output may vary. just run it
+test "$(chroot "${rootfs}" gcc -print-multi-os-directory)" = "../lib"
+
+test "$(chroot "${rootfs}" gcc -print-sysroot)" = "$sysroot"
+(chroot "${rootfs}" gcc -print-sysroot-headers-suffix 2>&1 || true) | grep -q "not configured with sysroot"

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/test_std.sh
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/test_std.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils libgcc libc
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "aarch64" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-15-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-aarch64-linux-gnu_gcc
+        cpp-15-aarch64-linux-gnu_cc1
+        binutils-aarch64-linux-gnu_assembler
+        binutils-aarch64-linux-gnu_linker
+        libgcc-15-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s aarch64-linux-gnu-gcc "${rootfs}/usr/bin/gcc"
+    ln -s aarch64-linux-gnu-as "${rootfs}/usr/bin/as"
+    ln -s aarch64-linux-gnu-ld "${rootfs}/usr/bin/ld"
+
+    cp testfiles/test_std.c "${rootfs}/test_std.c"
+    cp testfiles/test_std.h "${rootfs}/test_std.h"
+
+    chroot "${rootfs}" gcc /test_std.c -o /test_std
+    chroot "${rootfs}" /test_std
+
+    # try again with a bunch of C standards
+    # for std in c99 c11 c17 c23; do
+    #     rm -f "${rootfs}/test_std"
+    #     chroot "${rootfs}" gcc -std="$std" -DSTD="$std" /test_std.c -o /test_std
+    #     chroot "${rootfs}" /test_std
+    # done
+fi

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/testfiles/hello.c
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/testfiles/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\n");
+    return 0;
+}

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/testfiles/test_std.c
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/testfiles/test_std.c
@@ -1,0 +1,223 @@
+#include "test_std.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <assert.h>
+#include <stdint.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdalign.h>
+#include <signal.h>
+
+
+int main() {
+    printf("Running basic standard library checks...\n");
+    TestCase tests[] = {
+        {"Arithmetic", check_arithmetic},
+        {"File I/O", check_file_io},
+        {"Concurrency", check_concurrency},
+        {"Memory", check_memory},
+        {"Time", check_time},
+        {"Environment Variables and Args", check_env},
+        {"Atomics", check_atomic},
+        {"Process Control", check_process_control},
+        {"Signals", check_signals},
+    };
+
+    int overall_result = 1;
+    for (int i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        TestResult result;
+        tests[i].test_func(&result);
+        if (result.passed) {
+            printf("Test %d (%s) passed\n", i + 1, tests[i].name);
+        } else {
+            printf("Test %d (%s) failed: %s\n", i + 1, tests[i].name, result.message);
+            overall_result = 0;
+        }
+    }
+
+    if (!overall_result) {
+        printf("Some tests failed.\n");
+        return 1;
+    } else {
+        printf("\nAll basic checks passed!\n");
+        return 0;
+    }
+}
+
+void check_arithmetic(TestResult* result) {
+    if (10 + 5 != 15) { result->passed = 0; result->message = "Integer addition failed"; return; }
+    if (10 - 5 != 5) { result->passed = 0; result->message = "Integer subtraction failed"; return; }
+    if (10 * 5 != 50) { result->passed = 0; result->message = "Integer multiplication failed"; return; }
+    if (10 / 5 != 2) { result->passed = 0; result->message = "Integer division failed"; return; }
+    if (10 % 3 != 1) { result->passed = 0; result->message = "Integer modulus failed"; return; }
+
+    double a = 10.0;
+    double b = 5.0;
+    if (a / b != 2.0) { result->passed = 0; result->message = "Floating point division failed"; return; }
+
+// we have infinity only in C23
+#ifdef INFINITY
+    double c = 1.0;
+    double d = 0.0;
+    if (!(c / d == INFINITY)) { result->passed = 0; result->message = "Division by zero did not yield infinity"; return; }
+#endif
+
+    result->passed = 1;
+    result->message = "Arithmetic tests passed";
+}
+
+void check_file_io(TestResult* result) {
+    const char* filename = "test_file.txt";
+    const char* test_data = "Hello from C file I/O!";
+    FILE* file = fopen(filename, "w");
+    if (!file) { result->passed = 0; result->message = "File creation failed"; return; }
+    if (fwrite(test_data, 1, strlen(test_data), file) != strlen(test_data)) {
+        fclose(file);
+        result->passed = 0; result->message = "File write failed"; return;
+    }
+    fclose(file);
+    file = fopen(filename, "r");
+    if (!file) { result->passed = 0; result->message = "File open failed"; return; }
+    char buffer[256];
+    size_t read_bytes = fread(buffer, 1, sizeof(buffer)-1, file);
+    if (read_bytes <= 0) {
+        fclose(file);
+        result->passed = 0; result->message = "File read failed"; return;
+    }
+    buffer[read_bytes] = '\0';
+    fclose(file);
+    if (strcmp(buffer, test_data) != 0) { result->passed = 0; result->message = "File contents do not match"; return; }
+    if (remove(filename) != 0) { result->passed = 0; result->message = "File removal failed"; return; }
+    result->passed = 1;
+    result->message = "File I/O tests passed";
+}
+
+void* thread_func(void* arg) {
+    int* counter = (int*)arg;
+    for (int i = 0; i < 100000; i++) {
+        __atomic_fetch_add(counter, 1, __ATOMIC_SEQ_CST);
+    }
+    return NULL;
+}
+
+void check_concurrency(TestResult* result) {
+    pthread_t threads[10];
+    int counter = 0;
+    for (int i = 0; i < 10; i++) {
+        if (pthread_create(&threads[i], NULL, thread_func, &counter) != 0) {
+            result->passed = 0; result->message = "Thread creation failed"; return;
+        }
+    }
+    for (int i = 0; i < 10; i++) {
+        if (pthread_join(threads[i], NULL) != 0) {
+            result->passed = 0; result->message = "Thread join failed"; return;
+        }
+    }
+    if (counter != 1000000) { result->passed = 0; result->message = "Counter value incorrect"; return; }
+    result->passed = 1;
+    result->message = "Concurrency tests passed";
+}
+
+void check_memory(TestResult* result) {
+    if (sizeof(int32_t) != 4) { result->passed = 0; result->message = "size_of::<int32_t>() failed"; return; }
+    if (sizeof(double) != 8) { result->passed = 0; result->message = "size_of::<double>() failed"; return; }
+    if (alignof(int32_t) != 4) { result->passed = 0; result->message = "align_of::<int32_t>() failed"; return; }
+    if (alignof(double) != 8) { result->passed = 0; result->message = "align_of::<double>() failed"; return; }
+
+    struct AlignedStruct {
+        char a;
+        int32_t b;
+    };
+    if (sizeof(struct AlignedStruct) != 8) { result->passed = 0; result->message = "size_of::<AlignedStruct>() failed"; return; }
+
+    result->passed = 1;
+    result->message = "Memory tests passed";
+}
+
+void check_time(TestResult* result) {
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    usleep(50000); // sleep for 50 milliseconds
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_nsec - start.tv_nsec) / 1000000;
+    if (elapsed_ms < 50) { result->passed = 0; result->message = "Sleep duration incorrect"; return; }
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    if (tv.tv_sec < 1700000000) { result->passed = 0; result->message = "System time is likely incorrect or too far in the past"; return; }
+
+    result->passed = 1;
+    result->message = "Time tests passed";
+}
+
+void check_env(TestResult* result) {
+    const char* test_key = "C_TEST_VAR";
+    const char* test_val = "c_test_value";
+    if (setenv(test_key, test_val, 1) != 0) { result->passed = 0; result->message = "Failed to set env var"; return; }
+    char* var_val = getenv(test_key);
+    if (!var_val || strcmp(var_val, test_val) != 0) { result->passed = 0; result->message = "Failed to get correct environment variable value"; return; }
+
+    int argc = 1;
+    char* argv[] = {"program_name", NULL};
+    if (argc < 1) { result->passed = 0; result->message = "Command line arguments check failed"; return; }
+
+    result->passed = 1;
+    result->message = "Environment tests passed";
+}
+
+void check_atomic(TestResult* result) {
+    atomic_int atomic_counter = 0;
+    atomic_fetch_add(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 1) { result->passed = 0; result->message = "Atomic increment failed"; return; }
+    atomic_fetch_sub(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 0) { result->passed = 0; result->message = "Atomic decrement failed"; return; }
+    result->passed = 1;
+    result->message = "Atomic tests passed";
+}
+
+void check_process_control(TestResult* result) {
+    pid_t pid = fork();
+    if (pid < 0) { result->passed = 0; result->message = "Fork failed"; return; }
+    if (pid == 0) {
+        // Child process
+        exit(42);
+    } else {
+        // Parent process
+        int status;
+        if (waitpid(pid, &status, 0) < 0) { result->passed = 0; result->message = "Waitpid failed"; return; }
+        if (WIFEXITED(status)) {
+            int exit_status = WEXITSTATUS(status);
+            if (exit_status != 42) { result->passed = 0; result->message = "Child exit status incorrect"; return; }
+        } else {
+            result->passed = 0; result->message = "Child did not exit normally"; return;
+        }
+    }
+    result->passed = 1;
+    result->message = "Process control tests passed";
+}
+
+void check_signals(TestResult* result) {
+    // Simple signal handling test
+    struct sigaction sa;
+    sa.sa_handler = SIG_IGN; // Ignore the signal
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGUSR1, &sa, NULL) != 0) { result->passed = 0; result->message = "Sigaction failed"; return; }
+
+    // Send the signal to self
+    if (raise(SIGUSR1) != 0) { result->passed = 0; result->message = "Raise signal failed"; return; }
+
+    result->passed = 1;
+    result->message = "Signal handling tests passed";
+}

--- a/tests/spread/integration/gcc-aarch64-linux-gnu/testfiles/test_std.h
+++ b/tests/spread/integration/gcc-aarch64-linux-gnu/testfiles/test_std.h
@@ -1,0 +1,25 @@
+#ifndef TEST_STD_H
+#define TEST_STD_H
+
+typedef struct {
+    int passed;
+    const char* message;
+} TestResult;
+
+typedef struct {
+    const char* name;
+    void (*test_func)(TestResult* result);
+} TestCase;
+
+void check_arithmetic(TestResult* result);
+void check_file_io(TestResult* result);
+void* thread_func(void* arg);
+void check_concurrency(TestResult* result);
+void check_memory(TestResult* result);
+void check_time(TestResult* result);
+void check_env(TestResult* result);
+void check_atomic(TestResult* result);
+void check_process_control(TestResult* result);
+void check_signals(TestResult* result);
+
+#endif // TEST_STD_H

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/task.yaml
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for gcc-x86-64-linux-gnu
+
+variants:
+    - dump
+    - hello
+    - help_and_version
+    - print
+    - std
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/test_dump.sh
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/test_dump.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs dumpmachine dumpversion dumpspecs
+
+rootfs="$(install-slices gcc-x86-64-linux-gnu_gcc)"
+ln -s "x86_64-linux-gnu-gcc" "${rootfs}/usr/bin/gcc"
+
+dumpmachine=$(chroot "${rootfs}" gcc -dumpmachine)
+test "$dumpmachine" = "x86_64-linux-gnu"
+dumpversion=$(chroot "${rootfs}" gcc -dumpversion)
+test "$dumpversion" = "15"
+
+# shellcheck disable=SC2063
+dumpspecs=$(chroot "${rootfs}" gcc -dumpspecs | grep '^*' | tr '\n' ' ')
+expected_keys=("asm" "cc1" "cpp" "link" "lib")
+for key in "${expected_keys[@]}"; do
+    # shellcheck disable=SC2063
+    echo "$dumpspecs" | grep -q "*${key}:"
+done

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/test_hello.sh
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/test_hello.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" ]]; then
+    cross=true
+elif [[ "$arch" == "x86_64" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-15-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-x86-64-linux-gnu_gcc
+        cpp-15-x86-64-linux-gnu_cc1
+        binutils-x86-64-linux-gnu_assembler
+        binutils-x86-64-linux-gnu_linker
+        libgcc-15-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s x86_64-linux-gnu-as "$rootfs/usr/bin/as"
+    ln -s x86_64-linux-gnu-ld "$rootfs/usr/bin/ld"
+    ln -s x86_64-linux-gnu-gcc "$rootfs/usr/bin/gcc"
+
+    cp testfiles/hello.c "${rootfs}/hello.c"
+
+    chroot "${rootfs}" gcc /hello.c -o /hello
+    chroot "${rootfs}" /hello | grep -q "Hello from C!"
+fi

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/test_help_and_version.sh
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/test_help_and_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs
+
+rootfs="$(install-slices gcc-x86-64-linux-gnu_gcc)"
+ln -s "x86_64-linux-gnu-gcc" "${rootfs}/usr/bin/gcc"
+
+# something like: Usage: gcc [options] file...
+help=$(chroot "${rootfs}" gcc --help | head -n1)
+echo "$help" | grep -q "Usage: gcc"
+
+# something like: gcc (Ubuntu 15.2.0-19ubuntu2) 15.2.0
+version=$(chroot "${rootfs}" gcc --version | head -n1)
+echo "$version" | grep -q "gcc"
+echo "$version" | grep -q "15."

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/test_print.sh
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/test_print.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libgcc libexec libc multiarch
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" ]]; then
+    cross=true
+elif [[ "$arch" == "x86_64" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    gcc_dir="gcc-cross"
+    sysroot="/"
+else
+    gcc_dir="gcc"
+    sysroot=""
+fi
+
+rootfs="$(install-slices gcc-x86-64-linux-gnu_gcc)"
+    ln -s "x86_64-linux-gnu-gcc" "${rootfs}/usr/bin/gcc"
+
+test "$(chroot "${rootfs}" gcc -print-search-dirs | head -n 1)" = "install: /usr/lib/$gcc_dir/x86_64-linux-gnu/15/"
+chroot "${rootfs}" gcc -print-search-dirs | head -n 2 | tail -n 1 | grep -q "/usr/libexec/$gcc_dir/x86_64-linux-gnu/15/"
+
+test "$(chroot "${rootfs}" gcc -print-libgcc-file-name)" = "libgcc.a"
+chroot "${rootfs}" gcc -print-file-name=libc.so.6 | grep -q "libc.so.6"
+
+# create a fake program called 'foo' in libexec dir to test -print-prog-name
+touch "${rootfs}/usr/libexec/$gcc_dir/x86_64-linux-gnu/15/foo"
+chmod +x "${rootfs}/usr/libexec/$gcc_dir/x86_64-linux-gnu/15/foo"
+
+chroot "${rootfs}" gcc -print-prog-name=foo
+test "$(chroot "${rootfs}" gcc -print-prog-name=foo)" = "/usr/libexec/$gcc_dir/x86_64-linux-gnu/15/foo"
+
+# we're not configured for multiple architectures
+test "$(chroot "${rootfs}" gcc -print-multiarch)" = "x86_64-linux-gnu"
+test "$(chroot "${rootfs}" gcc -print-multi-directory)" = "."
+chroot "${rootfs}" gcc -print-multi-lib # the output may vary. just run it
+test "$(chroot "${rootfs}" gcc -print-multi-os-directory)" = "../lib"
+
+test "$(chroot "${rootfs}" gcc -print-sysroot)" = "$sysroot"
+(chroot "${rootfs}" gcc -print-sysroot-headers-suffix 2>&1 || true) | grep -q "not configured with sysroot"

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/test_std.sh
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/test_std.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils libgcc libc
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" ]]; then
+    cross=true
+elif [[ "$arch" == "x86_64" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-15-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-x86-64-linux-gnu_gcc
+        cpp-15-x86-64-linux-gnu_cc1
+        binutils-x86-64-linux-gnu_assembler
+        binutils-x86-64-linux-gnu_linker
+        libgcc-15-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s x86_64-linux-gnu-as "$rootfs/usr/bin/as"
+    ln -s x86_64-linux-gnu-ld "$rootfs/usr/bin/ld"
+    ln -s x86_64-linux-gnu-gcc "$rootfs/usr/bin/gcc"
+
+    cp testfiles/test_std.c "${rootfs}/test_std.c"
+    cp testfiles/test_std.h "${rootfs}/test_std.h"
+
+    chroot "${rootfs}" gcc /test_std.c -o /test_std
+    chroot "${rootfs}" /test_std
+
+    # try again with a bunch of C standards
+    # for std in c99 c11 c17 c23; do
+    #     rm -f "${rootfs}/test_std"
+    #     chroot "${rootfs}" gcc -std="$std" -DSTD="$std" /test_std.c -o /test_std
+    #     chroot "${rootfs}" /test_std
+    # done
+fi

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/testfiles/hello.c
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/testfiles/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\n");
+    return 0;
+}

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/testfiles/test_std.c
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/testfiles/test_std.c
@@ -1,0 +1,223 @@
+#include "test_std.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <assert.h>
+#include <stdint.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdalign.h>
+#include <signal.h>
+
+
+int main() {
+    printf("Running basic standard library checks...\n");
+    TestCase tests[] = {
+        {"Arithmetic", check_arithmetic},
+        {"File I/O", check_file_io},
+        {"Concurrency", check_concurrency},
+        {"Memory", check_memory},
+        {"Time", check_time},
+        {"Environment Variables and Args", check_env},
+        {"Atomics", check_atomic},
+        {"Process Control", check_process_control},
+        {"Signals", check_signals},
+    };
+
+    int overall_result = 1;
+    for (int i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        TestResult result;
+        tests[i].test_func(&result);
+        if (result.passed) {
+            printf("Test %d (%s) passed\n", i + 1, tests[i].name);
+        } else {
+            printf("Test %d (%s) failed: %s\n", i + 1, tests[i].name, result.message);
+            overall_result = 0;
+        }
+    }
+
+    if (!overall_result) {
+        printf("Some tests failed.\n");
+        return 1;
+    } else {
+        printf("\nAll basic checks passed!\n");
+        return 0;
+    }
+}
+
+void check_arithmetic(TestResult* result) {
+    if (10 + 5 != 15) { result->passed = 0; result->message = "Integer addition failed"; return; }
+    if (10 - 5 != 5) { result->passed = 0; result->message = "Integer subtraction failed"; return; }
+    if (10 * 5 != 50) { result->passed = 0; result->message = "Integer multiplication failed"; return; }
+    if (10 / 5 != 2) { result->passed = 0; result->message = "Integer division failed"; return; }
+    if (10 % 3 != 1) { result->passed = 0; result->message = "Integer modulus failed"; return; }
+
+    double a = 10.0;
+    double b = 5.0;
+    if (a / b != 2.0) { result->passed = 0; result->message = "Floating point division failed"; return; }
+
+// we have infinity only in C23
+#ifdef INFINITY
+    double c = 1.0;
+    double d = 0.0;
+    if (!(c / d == INFINITY)) { result->passed = 0; result->message = "Division by zero did not yield infinity"; return; }
+#endif
+
+    result->passed = 1;
+    result->message = "Arithmetic tests passed";
+}
+
+void check_file_io(TestResult* result) {
+    const char* filename = "test_file.txt";
+    const char* test_data = "Hello from C file I/O!";
+    FILE* file = fopen(filename, "w");
+    if (!file) { result->passed = 0; result->message = "File creation failed"; return; }
+    if (fwrite(test_data, 1, strlen(test_data), file) != strlen(test_data)) {
+        fclose(file);
+        result->passed = 0; result->message = "File write failed"; return;
+    }
+    fclose(file);
+    file = fopen(filename, "r");
+    if (!file) { result->passed = 0; result->message = "File open failed"; return; }
+    char buffer[256];
+    size_t read_bytes = fread(buffer, 1, sizeof(buffer)-1, file);
+    if (read_bytes <= 0) {
+        fclose(file);
+        result->passed = 0; result->message = "File read failed"; return;
+    }
+    buffer[read_bytes] = '\0';
+    fclose(file);
+    if (strcmp(buffer, test_data) != 0) { result->passed = 0; result->message = "File contents do not match"; return; }
+    if (remove(filename) != 0) { result->passed = 0; result->message = "File removal failed"; return; }
+    result->passed = 1;
+    result->message = "File I/O tests passed";
+}
+
+void* thread_func(void* arg) {
+    int* counter = (int*)arg;
+    for (int i = 0; i < 100000; i++) {
+        __atomic_fetch_add(counter, 1, __ATOMIC_SEQ_CST);
+    }
+    return NULL;
+}
+
+void check_concurrency(TestResult* result) {
+    pthread_t threads[10];
+    int counter = 0;
+    for (int i = 0; i < 10; i++) {
+        if (pthread_create(&threads[i], NULL, thread_func, &counter) != 0) {
+            result->passed = 0; result->message = "Thread creation failed"; return;
+        }
+    }
+    for (int i = 0; i < 10; i++) {
+        if (pthread_join(threads[i], NULL) != 0) {
+            result->passed = 0; result->message = "Thread join failed"; return;
+        }
+    }
+    if (counter != 1000000) { result->passed = 0; result->message = "Counter value incorrect"; return; }
+    result->passed = 1;
+    result->message = "Concurrency tests passed";
+}
+
+void check_memory(TestResult* result) {
+    if (sizeof(int32_t) != 4) { result->passed = 0; result->message = "size_of::<int32_t>() failed"; return; }
+    if (sizeof(double) != 8) { result->passed = 0; result->message = "size_of::<double>() failed"; return; }
+    if (alignof(int32_t) != 4) { result->passed = 0; result->message = "align_of::<int32_t>() failed"; return; }
+    if (alignof(double) != 8) { result->passed = 0; result->message = "align_of::<double>() failed"; return; }
+
+    struct AlignedStruct {
+        char a;
+        int32_t b;
+    };
+    if (sizeof(struct AlignedStruct) != 8) { result->passed = 0; result->message = "size_of::<AlignedStruct>() failed"; return; }
+
+    result->passed = 1;
+    result->message = "Memory tests passed";
+}
+
+void check_time(TestResult* result) {
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    usleep(50000); // sleep for 50 milliseconds
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_nsec - start.tv_nsec) / 1000000;
+    if (elapsed_ms < 50) { result->passed = 0; result->message = "Sleep duration incorrect"; return; }
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    if (tv.tv_sec < 1700000000) { result->passed = 0; result->message = "System time is likely incorrect or too far in the past"; return; }
+
+    result->passed = 1;
+    result->message = "Time tests passed";
+}
+
+void check_env(TestResult* result) {
+    const char* test_key = "C_TEST_VAR";
+    const char* test_val = "c_test_value";
+    if (setenv(test_key, test_val, 1) != 0) { result->passed = 0; result->message = "Failed to set env var"; return; }
+    char* var_val = getenv(test_key);
+    if (!var_val || strcmp(var_val, test_val) != 0) { result->passed = 0; result->message = "Failed to get correct environment variable value"; return; }
+
+    int argc = 1;
+    char* argv[] = {"program_name", NULL};
+    if (argc < 1) { result->passed = 0; result->message = "Command line arguments check failed"; return; }
+
+    result->passed = 1;
+    result->message = "Environment tests passed";
+}
+
+void check_atomic(TestResult* result) {
+    atomic_int atomic_counter = 0;
+    atomic_fetch_add(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 1) { result->passed = 0; result->message = "Atomic increment failed"; return; }
+    atomic_fetch_sub(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 0) { result->passed = 0; result->message = "Atomic decrement failed"; return; }
+    result->passed = 1;
+    result->message = "Atomic tests passed";
+}
+
+void check_process_control(TestResult* result) {
+    pid_t pid = fork();
+    if (pid < 0) { result->passed = 0; result->message = "Fork failed"; return; }
+    if (pid == 0) {
+        // Child process
+        exit(42);
+    } else {
+        // Parent process
+        int status;
+        if (waitpid(pid, &status, 0) < 0) { result->passed = 0; result->message = "Waitpid failed"; return; }
+        if (WIFEXITED(status)) {
+            int exit_status = WEXITSTATUS(status);
+            if (exit_status != 42) { result->passed = 0; result->message = "Child exit status incorrect"; return; }
+        } else {
+            result->passed = 0; result->message = "Child did not exit normally"; return;
+        }
+    }
+    result->passed = 1;
+    result->message = "Process control tests passed";
+}
+
+void check_signals(TestResult* result) {
+    // Simple signal handling test
+    struct sigaction sa;
+    sa.sa_handler = SIG_IGN; // Ignore the signal
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGUSR1, &sa, NULL) != 0) { result->passed = 0; result->message = "Sigaction failed"; return; }
+
+    // Send the signal to self
+    if (raise(SIGUSR1) != 0) { result->passed = 0; result->message = "Raise signal failed"; return; }
+
+    result->passed = 1;
+    result->message = "Signal handling tests passed";
+}

--- a/tests/spread/integration/gcc-x86-64-linux-gnu/testfiles/test_std.h
+++ b/tests/spread/integration/gcc-x86-64-linux-gnu/testfiles/test_std.h
@@ -1,0 +1,25 @@
+#ifndef TEST_STD_H
+#define TEST_STD_H
+
+typedef struct {
+    int passed;
+    const char* message;
+} TestResult;
+
+typedef struct {
+    const char* name;
+    void (*test_func)(TestResult* result);
+} TestCase;
+
+void check_arithmetic(TestResult* result);
+void check_file_io(TestResult* result);
+void* thread_func(void* arg);
+void check_concurrency(TestResult* result);
+void check_memory(TestResult* result);
+void check_time(TestResult* result);
+void check_env(TestResult* result);
+void check_atomic(TestResult* result);
+void check_process_control(TestResult* result);
+void check_signals(TestResult* result);
+
+#endif // TEST_STD_H


### PR DESCRIPTION
# Proposed changes

slices for `gcc-aarch64-linux-gnu` and `gcc-x86-64-linux-gnu`. they just contain the symlinks to `gcc-15` but some things rely on those symlinks.

all the tests are identical to the `gcc-15-$arch` tests, with `-15` removed.

`cpp-$arch` is also sliced since the deb depends on it for copyright.

this is a trivial backport of https://github.com/canonical/chisel-releases/pull/836

this backport goes as far as it can. the pattern for packaging gcc on jammy is different.

## Related issues/PRs

### Forward porting

- https://github.com/canonical/chisel-releases/pull/836
- https://github.com/canonical/chisel-releases/pull/896 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/895

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)