### PR TITLE
feat: add link to chisel releases navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [The Basics](#the-basics)
 - [Using a Specific Chisel Release](#using-a-specific-chisel-release)
 - [Adding New Slice Definitions](#adding-new-slice-definitions)
+- [Chisel Releases Navigator](#chisel-releases-navigator)
 
 ## The Basics
 
@@ -68,3 +69,7 @@ Chisel will use the corresponding Git branch from this repository if it exists.
 We welcome and encourage community contributions! To better understand how to
 write and propose new package slice definitions, please read the
 [contributing guidelines](./CONTRIBUTING.md).
+
+## Chisel Releases Navigator
+
+To easily navigate through the different Chisel releases, and what slice definitions are available in each, please refer to the [Chisel Releases Navigator](https://canonical.github.io/chisel-releases-navigator/).


### PR DESCRIPTION
# Proposed changes

add link to https://canonical.github.io/chisel-releases-navigator in the readme

new readme can be seen here: https://github.com/lczyk/chisel-releases/tree/chisel-releases-navigator-link?tab=readme-ov-file

the release notes for the current version of the Chisel Releases Navigator can be found here: https://github.com/canonical/chisel-releases-navigator/releases/tag/261102.1

## Related issues/PRs
n/a

### Forward porting
n/a

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)