### PR TITLE
feat(24.04): add libevent-extra-2.1-7t64

### DIFF
--- a/slices/libevent-extra-2.1-7t64.yaml
+++ b/slices/libevent-extra-2.1-7t64.yaml
@@ -1,0 +1,16 @@
+package: libevent-extra-2.1-7t64
+
+essential:
+  - libevent-extra-2.1-7t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libevent-core-2.1-7t64_libs
+    contents:
+      /usr/lib/*-linux-*/libevent_extra-2.1.so.7*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libevent-extra-2.1-7t64/copyright:


### PR DESCRIPTION
# Proposed changes

Adds the slice definition for the `libevent-extra-2.1-7t64`, there are already other `libevent*` definitions,
so this one was missing, needed to be able to package Bitcoin Core as a rock.

### Forward porting

I don't know how to forward port this to Ubuntu 26.04 if not available yet,
if any guidance is provided I can happily forward port this to 26.04.

Edit:

- #914.
- #915.


## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)