### PR TITLE
chore(25.10): forward port libevent-extra-2.1-7t64

### DIFF
--- a/slices/libevent-extra-2.1-7t64.yaml
+++ b/slices/libevent-extra-2.1-7t64.yaml
@@ -1,0 +1,16 @@
+package: libevent-extra-2.1-7t64
+
+essential:
+  - libevent-extra-2.1-7t64_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libevent-core-2.1-7t64_libs
+    contents:
+      /usr/lib/*-linux-*/libevent_extra-2.1.so.7*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libevent-extra-2.1-7t64/copyright:


### PR DESCRIPTION
# Proposed changes

Forward port of libevent-extra-2.1-7t64.

## Related issues/PRs

- #913

### Forward porting

See #913.

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)