### PR TITLE
feat(26.04): minimal fix of `systemd`

### DIFF
--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -190,7 +190,7 @@ slices:
       /usr/lib/systemd/system-generators/systemd-system-update-generator:
       /usr/lib/systemd/system-generators/systemd-sysv-generator:
       /usr/lib/systemd/system-generators/systemd-tpm2-generator:
-        arch: [amd64, arm64, armhf, riscv64]
+        arch: [amd64, arm64, riscv64]
 
   system-services:
     essential:


### PR DESCRIPTION
# Proposed changes

this is a minimal fix of missing files in `systemd` to unblock [libnode](https://github.com/canonical/chisel-releases/pull/873). `systemd` will still need a bunch of work, already PRed in https://github.com/canonical/chisel-releases/pull/878

https://github.com/canonical/chisel-releases/pull/878 will be able to easily rebase on top of this PR

## Related issues/PRs

- unblockshttps://github.com/canonical/chisel-releases/pull/873
- https://github.com/canonical/chisel-releases/pull/878

### Forward porting

n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)