### PR TITLE
ci: skip `removed-slices` workflow running against devel

### DIFF
--- a/.github/workflows/removed-slices.yaml
+++ b/.github/workflows/removed-slices.yaml
@@ -14,7 +14,9 @@ jobs:
       files_main: "main-files"
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          # We do need to fetch all history for all branches.
+          fetch-depth: 0
 
         # NOTE: the github runner might have an older version of distro-info-data
         #  which does not know about the latest Ubuntu release, so we update it.


### PR DESCRIPTION
# Proposed changes

when checking for removed slices on PRs agains a devel branch we don't mind the slices being removed (in fact, that's the only time they *can* be removed)

## Related issues/PRs

- fixes https://github.com/canonical/chisel-releases/issues/707
- example of a successful run: https://github.com/lczyk/chisel-releases/actions/runs/22238884855/job/64337282790?pr=5

### Forward porting

n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)