### PR TITLE
feat(24.04): add test for chrome-headless-shell

### DIFF
--- a/tests/spread/extra/chrome-headless-shell/task.yaml
+++ b/tests/spread/extra/chrome-headless-shell/task.yaml
@@ -1,0 +1,2 @@
+summary: Integration tests for chrome-headless-shell
+execute: bash -ex ./test.sh

--- a/tests/spread/extra/chrome-headless-shell/test.sh
+++ b/tests/spread/extra/chrome-headless-shell/test.sh
@@ -1,0 +1,75 @@
+if [ $(uname -m) != "x86_64" ]; then
+    echo "Skipping test: incompatible architecture"
+    exit 0
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends unzip
+
+required_slices=( \
+    libasound2t64_libs \
+    libatk-bridge2.0-0t64_libs \
+    libatk1.0-0t64_libs \
+    libatspi2.0-0t64_libs \
+    libcairo2_libs \
+    libcups2t64_libs \
+    libdbus-1-3_libs \
+    libdrm2_libs \
+    libfontconfig1_libs \
+    libgbm1_libs \
+    libglib2.0-0t64_libs \
+    libnspr4_libs \
+    libnss3_libs \
+    libpango-1.0-0_libs \
+    libx11-6_libs \
+    libxcb1_libs \
+    libxcomposite1_libs \
+    libxdamage1_libs \
+    libxext6_libs \
+    libxfixes3_libs \
+    libxkbcommon0_libs \
+    libxrandr2_libs \
+    libudev1_libs \
+    fonts-liberation_fonts \
+    fonts-freefont-ttf_fonts \
+    fonts-noto-color-emoji_fonts \
+    fonts-unifont_fonts \
+    fonts-ipafont-gothic_fonts \
+    fonts-wqy-zenhei_fonts \
+    fonts-tlwg-loma-otf_fonts \
+  )
+
+# install slices
+rootfs="$(install-slices ${required_slices[@]})"
+
+# download chrome-headless-shell . Link is from https://googlechromelabs.github.io/chrome-for-testing/ .
+chrome_version=145.0.7632.77
+chrome_sha256sum="6652fb5003107bc775318af76176e09a7769b01723dac2e2838883314191413e"
+
+mkdir $rootfs/chrome
+curl \
+    --fail \
+    --output $rootfs/chrome/chrome-headless-shell.zip \
+    https://storage.googleapis.com/chrome-for-testing-public/$chrome_version/linux64/chrome-headless-shell-linux64.zip
+
+# Validate checksum
+sha256sum $rootfs/chrome/chrome-headless-shell.zip | grep $chrome_sha256sum
+
+unzip -d $rootfs/chrome/ $rootfs/chrome/chrome-headless-shell.zip
+rm $rootfs/chrome/chrome-headless-shell.zip
+
+# chrome crashes without /proc and /dev mounted
+mkdir -p "${rootfs}"/proc
+mount --bind /proc "${rootfs}"/proc
+mkdir -p "${rootfs}/dev"
+mount --bind /dev "${rootfs}/dev"
+
+chroot "${rootfs}" /chrome/chrome-headless-shell-linux64/chrome-headless-shell \
+    --no-sandbox \
+    --single-process \
+    --print-to-pdf https://google.com
+
+# Cleanup
+umount "${rootfs}"/proc
+umount "${rootfs}"/dev
+apt-get remove -y unzip


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

As discussed in https://github.com/canonical/chisel-releases/pull/905#discussion_r2829036150 this adds the test that was originally part of #905 with some changes:

- added sha256 checksum validation of the chrome binary
- added umount of /proc and /dev
- moved script to its own file
- removed prepare/execute/restore
- moved test from integration/ to extra/ since chrome-headless-shell is not actually an ubuntu package

Since only the tests in integration/ are executed, the test is not currently running in CI. It's to be discussed whether extra/ is the correct approach and what would need to be changed to run these in CI as well. From my understanding this would require changes to spread.yaml on the main branch? So it would have to be changed in another PR.

## Related issues/PRs

will open forward port PRs when this is out of draft.

<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->