### PR TITLE
fix(ci): checkout PR head in validate-hints

### DIFF
--- a/.github/workflows/validate-hints.yaml
+++ b/.github/workflows/validate-hints.yaml
@@ -41,13 +41,13 @@ jobs:
     env:
       main-branch-path: files-from-main
     steps:
+      - uses: actions/checkout@v4
+
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
           ref: main
           path: ${{ env.main-branch-path }}
-
-      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR fixes the issue causing the `validate-hints` workflow to fail.

## Related issues/PRs
<!-- If any -->

This is blocking one of the most import PRs #903 .

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

N/A since this is against `main`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->