### PR TITLE
ci(26.04): retry `chisel cut` in tests

### DIFF
--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -55,7 +55,7 @@ function chisel_cut() {
         #shellcheck disable=SC2086
         chisel cut \
             --ignore=unstable \
-	    --ignore=unmaintained \
+            --ignore=unmaintained \
             --release "$PROJECT_PATH" \
             --root "$rootfs" \
             $slices \


### PR DESCRIPTION
# Proposed changes

add a retry mechanism to `install_slices` helper, similar to that in `install_slices.py` tests

- ~~:warning: this PR includes a testing commit which triggers all the tests https://github.com/canonical/chisel-releases/pull/929/commits/959e0049eb1e062fc80f7d0cb6d120f25052cf8b it will need to be removed before merge~~

## Related issues/PRs

- closes https://github.com/canonical/chisel-releases/issues/743

### Forward porting

- https://github.com/canonical/chisel-releases/pull/929 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/941
- https://github.com/canonical/chisel-releases/pull/940
- https://github.com/canonical/chisel-releases/pull/939
- https://github.com/canonical/chisel-releases/pull/938

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)