### PR TITLE
chore(25.10): Forward Port PR #552 - dlt-viewer

### DIFF
--- a/slices/dlt-viewer.yaml
+++ b/slices/dlt-viewer.yaml
@@ -1,0 +1,49 @@
+package: dlt-viewer
+
+essential:
+  - dlt-viewer_copyright
+
+slices:
+  bins:
+    contents:
+      /usr/bin/dlt-parser:
+      /usr/bin/dlt-viewer:
+      /usr/lib/*-linux-*/dlt-viewer/plugins/**:
+    essential:
+      - dlt-viewer_viewer-libs
+
+  commander:
+    contents:
+      /usr/bin/dlt-commander:
+    essential:
+      - dlt-viewer_libs
+
+  data:
+    contents:
+      /usr/share/dlt-viewer/**:
+
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libqdlt.so*:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libqt6core6t64_libs
+      - libstdc++6_libs
+
+  viewer-libs:
+    essential:
+      - dlt-viewer_libs
+      - libegl1_libs
+      - libopengl0_libs
+      - libqt6gui6_libs
+      - libqt6network6_libs
+      - libqt6printsupport6_libs
+      - libqt6serialport6_libs
+      - libqt6widgets6_libs
+      - libxkbcommon0_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/dlt-viewer/copyright:

--- a/slices/libavahi-common-data.yaml
+++ b/slices/libavahi-common-data.yaml
@@ -1,0 +1,13 @@
+package: libavahi-common-data
+
+essential:
+  - libavahi-common-data_copyright
+
+slices:
+  data:
+    contents:
+      /usr/lib/*-linux-*/avahi/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/libavahi-common-data/copyright:

--- a/slices/libavahi-common3.yaml
+++ b/slices/libavahi-common3.yaml
@@ -7,6 +7,7 @@ slices:
   libs:
     # NOTE: libavahi-common3 deb also depends on libavahi-common-data
     essential:
+      - libavahi-common-data_data
       - libc6_libs
     contents:
       /usr/lib/*-linux-*/libavahi-common.so.3*:

--- a/slices/libb2-1.yaml
+++ b/slices/libb2-1.yaml
@@ -1,0 +1,15 @@
+package: libb2-1
+
+essential:
+  - libb2-1_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/libb2-1/copyright:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libb2.so*:
+    essential:
+      - libc6_libs
+      - libgomp1_libs

--- a/slices/libdouble-conversion3.yaml
+++ b/slices/libdouble-conversion3.yaml
@@ -1,0 +1,17 @@
+package: libdouble-conversion3
+
+essential:
+  - libdouble-conversion3_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libdouble-conversion.so*:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libdouble-conversion3/copyright:

--- a/slices/libegl-mesa0.yaml
+++ b/slices/libegl-mesa0.yaml
@@ -1,0 +1,13 @@
+package: libegl-mesa0
+
+essential:
+  - libegl-mesa0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libEGL_mesa.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libegl-mesa0/copyright:

--- a/slices/libegl1.yaml
+++ b/slices/libegl1.yaml
@@ -1,0 +1,16 @@
+package: libegl1
+
+essential:
+  - libegl1_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/libegl1/copyright:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libEGL.so*:
+    essential:
+      - libc6_libs
+      - libegl-mesa0_libs
+      - libglvnd0_libs

--- a/slices/libice6.yaml
+++ b/slices/libice6.yaml
@@ -1,0 +1,17 @@
+package: libice6
+
+essential:
+  - libice6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libICE.so.6*:
+    essential:
+      - libbsd0_libs
+      - libc6_libs
+      - x11-common_resources
+
+  copyright:
+    contents:
+      /usr/share/doc/libice6/copyright:

--- a/slices/libmd4c0.yaml
+++ b/slices/libmd4c0.yaml
@@ -1,0 +1,15 @@
+package: libmd4c0
+
+essential:
+  - libmd4c0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libmd4c.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libmd4c0/copyright:

--- a/slices/libmtdev1t64.yaml
+++ b/slices/libmtdev1t64.yaml
@@ -1,0 +1,15 @@
+package: libmtdev1t64
+
+essential:
+  - libmtdev1t64_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libmtdev.so.1*:
+    essential:
+      - libc6_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libmtdev1t64/copyright:

--- a/slices/libopengl0.yaml
+++ b/slices/libopengl0.yaml
@@ -1,0 +1,16 @@
+package: libopengl0
+
+essential:
+  - libopengl0_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/libopengl0/copyright:
+
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libOpenGL.so*:
+    essential:
+      - libc6_libs
+      - libglvnd0_libs

--- a/slices/libpcre2-16-0.yaml
+++ b/slices/libpcre2-16-0.yaml
@@ -1,0 +1,15 @@
+package: libpcre2-16-0
+
+essential:
+  - libpcre2-16-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libpcre2-16.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpcre2-16-0/copyright:

--- a/slices/libqt5core5t64.yaml
+++ b/slices/libqt5core5t64.yaml
@@ -1,0 +1,25 @@
+package: libqt5core5t64
+
+essential:
+  - libqt5core5t64_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/libqt5core5t64/copyright:
+
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5Core.so*:
+    essential:
+      - libc6_libs
+      - libdouble-conversion3_libs
+      - libgcc-s1_libs
+      - libglib2.0-0t64_libs
+      - libicu76_libs
+      - libpcre2-16-0_libs
+      - libstdc++6_libs
+      - libzstd1_libs
+      - shared-mime-info_bins
+      - shared-mime-info_data
+      - zlib1g_libs

--- a/slices/libqt5dbus5t64.yaml
+++ b/slices/libqt5dbus5t64.yaml
@@ -1,0 +1,19 @@
+package: libqt5dbus5t64
+
+essential:
+  - libqt5dbus5t64_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5DBus.so*:
+    essential:
+      - libc6_libs
+      - libdbus-1-3_libs
+      - libgcc-s1_libs
+      - libqt5core5t64_libs
+      - libstdc++6_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt5dbus5t64/copyright:

--- a/slices/libqt5gui5t64.yaml
+++ b/slices/libqt5gui5t64.yaml
@@ -1,0 +1,49 @@
+package: libqt5gui5t64
+
+essential:
+  - libqt5gui5t64_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5EglFS*.so*:
+      /usr/lib/*-linux-*/libQt5Gui.so*:
+      /usr/lib/*-linux-*/libQt5XcbQpa.so*:
+      /usr/lib/*-linux-*/qt5/plugins/egldeviceintegrations/libqeglfs*.so*:
+      /usr/lib/*-linux-*/qt5/plugins/generic/**:
+      /usr/lib/*-linux-*/qt5/plugins/imageformats/**:
+      /usr/lib/*-linux-*/qt5/plugins/platforminputcontexts/**:
+      /usr/lib/*-linux-*/qt5/plugins/platforms/libq*.so*:
+      /usr/lib/*-linux-*/qt5/plugins/xcbglintegrations/libqxcb-*-integration.so*:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libfontconfig1_libs
+      - libgbm1_libs
+      - libgcc-s1_libs
+      - libgl1_libs
+      - libglib2.0-0t64_libs
+      - libharfbuzz0b_libs
+      - libmd4c0_libs
+      - libpng16-16t64_libs
+      - libqt5core5t64_libs
+      - libqt5dbus5t64_libs
+      - libqt5network5t64_libs
+      - libstdc++6_libs
+      - libudev1_libs
+      - libx11-6_libs
+      - libx11-xcb1_libs
+      - libxcb-glx0_libs
+      - libxcb-randr0_libs
+      - libxcb-render0_libs
+      - libxcb-shape0_libs
+      - libxcb-shm0_libs
+      - libxcb-sync1_libs
+      - libxcb-xfixes0_libs
+      - libxcb1_libs
+      - libxrender1_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt5gui5t64/copyright:

--- a/slices/libqt5network5t64.yaml
+++ b/slices/libqt5network5t64.yaml
@@ -1,0 +1,24 @@
+package: libqt5network5t64
+
+essential:
+  - libqt5network5t64_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5Network.so*:
+      /usr/lib/*-linux-*/qt5/plugins/bearer/libqconnmanbearer.so*:
+      /usr/lib/*-linux-*/qt5/plugins/bearer/libqgenericbearer.so*:
+      /usr/lib/*-linux-*/qt5/plugins/bearer/libqnmbearer.so*:
+    essential:
+      - libc6_libs
+      - libglib2.0-0t64_libs
+      - libgssapi-krb5-2_libs
+      - libqt5core5t64_libs
+      - libqt5dbus5t64_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt5network5t64/copyright:

--- a/slices/libqt5printsupport5t64.yaml
+++ b/slices/libqt5printsupport5t64.yaml
@@ -1,0 +1,21 @@
+package: libqt5printsupport5t64
+
+essential:
+  - libqt5printsupport5t64_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5PrintSupport.so*:
+      /usr/lib/*-linux-*/qt5/plugins/printsupport/libcupsprintersupport.so*:
+    essential:
+      - libc6_libs
+      - libglib2.0-0t64_libs
+      - libqt5core5t64_libs
+      - libqt5dbus5t64_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt5printsupport5t64/copyright:

--- a/slices/libqt5serialport5.yaml
+++ b/slices/libqt5serialport5.yaml
@@ -1,0 +1,19 @@
+package: libqt5serialport5
+
+essential:
+  - libqt5serialport5_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5SerialPort.so*:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libqt5core5t64_libs
+      - libstdc++6_libs
+      - libudev1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt5serialport5/copyright:

--- a/slices/libqt5widgets5t64.yaml
+++ b/slices/libqt5widgets5t64.yaml
@@ -1,0 +1,18 @@
+package: libqt5widgets5t64
+
+essential:
+  - libqt5widgets5t64_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt5Widgets.so*:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libqt5core5t64_libs
+      - libstdc++6_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt5widgets5t64/copyright:

--- a/slices/libqt6core6t64.yaml
+++ b/slices/libqt6core6t64.yaml
@@ -1,0 +1,30 @@
+package: libqt6core6t64
+
+essential:
+  - libqt6core6t64_copyright
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/libqt6core6t64/copyright:
+
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6Core.so*:
+    essential:
+      - libb2-1_libs
+      - libc6_libs
+      - libdouble-conversion3_libs
+      - libgcc-s1_libs
+      - libglib2.0-0t64_libs
+      - libicu76_libs
+      - libpcre2-16-0_libs
+      - libstdc++6_libs
+      - libzstd1_libs
+      - shared-mime-info_bins
+      - shared-mime-info_data
+      - zlib1g_libs
+
+  doc:
+    contents:
+      /usr/share/doc/libqt6core6t64/**:

--- a/slices/libqt6dbus6.yaml
+++ b/slices/libqt6dbus6.yaml
@@ -1,0 +1,19 @@
+package: libqt6dbus6
+
+essential:
+  - libqt6dbus6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6DBus.so*:
+    essential:
+      - libc6_libs
+      - libdbus-1-3_libs
+      - libgcc-s1_libs
+      - libqt6core6t64_libs
+      - libstdc++6_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt6dbus6/copyright:

--- a/slices/libqt6gui6.yaml
+++ b/slices/libqt6gui6.yaml
@@ -1,0 +1,47 @@
+package: libqt6gui6
+
+essential:
+  - libqt6gui6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6Gui.so*:
+      /usr/lib/*-linux-*/libQt6XcbQpa.so*:
+      /usr/lib/*-linux-*/qt6/plugins/generic/**:
+      /usr/lib/*-linux-*/qt6/plugins/imageformats/**:
+      /usr/lib/*-linux-*/qt6/plugins/platforminputcontexts/**:
+      /usr/lib/*-linux-*/qt6/plugins/platforms/libq*.so*:
+      /usr/lib/*-linux-*/qt6/plugins/xcbglintegrations/libqxcb-*-integration.so*:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libfontconfig1_libs
+      - libgbm1_libs
+      - libgcc-s1_libs
+      - libgl1_libs
+      - libglib2.0-0t64_libs
+      - libharfbuzz0b_libs
+      - libmd4c0_libs
+      - libpng16-16t64_libs
+      - libqt6core6t64_libs
+      - libqt6dbus6_libs
+      - libqt6network6_libs
+      - libstdc++6_libs
+      - libudev1_libs
+      - libx11-6_libs
+      - libx11-xcb1_libs
+      - libxcb-glx0_libs
+      - libxcb-randr0_libs
+      - libxcb-render0_libs
+      - libxcb-shape0_libs
+      - libxcb-shm0_libs
+      - libxcb-sync1_libs
+      - libxcb-xfixes0_libs
+      - libxcb1_libs
+      - libxrender1_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt6gui6/copyright:

--- a/slices/libqt6network6.yaml
+++ b/slices/libqt6network6.yaml
@@ -1,0 +1,27 @@
+package: libqt6network6
+
+essential:
+  - libqt6network6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6Network.so*:
+      /usr/lib/*-linux-*/qt6/plugins/networkinformation/*.so*:
+      /usr/lib/*-linux-*/qt6/plugins/tls/*.so*:
+    essential:
+      - libbrotli1_libs
+      - libc6_libs
+      - libgcc-s1_libs
+      - libglib2.0-0t64_libs
+      - libgssapi-krb5-2_libs
+      - libproxy1v5_libs
+      - libqt6core6t64_libs
+      - libqt6dbus6_libs
+      - libstdc++6_libs
+      - libzstd1_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt6network6/copyright:

--- a/slices/libqt6printsupport6.yaml
+++ b/slices/libqt6printsupport6.yaml
@@ -1,0 +1,23 @@
+package: libqt6printsupport6
+
+essential:
+  - libqt6printsupport6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6PrintSupport.so*:
+      /usr/lib/*-linux-*/qt6/plugins/printsupport/libcupsprintersupport.so*:
+    essential:
+      - libc6_libs
+      - libcups2t64_libs
+      - libgcc-s1_libs
+      - libglib2.0-0t64_libs
+      - libqt6core6t64_libs
+      - libqt6dbus6_libs
+      - libstdc++6_libs
+      - zlib1g_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt6printsupport6/copyright:

--- a/slices/libqt6serialport6.yaml
+++ b/slices/libqt6serialport6.yaml
@@ -1,0 +1,18 @@
+package: libqt6serialport6
+
+essential:
+  - libqt6serialport6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6SerialPort.so*:
+    essential:
+      - libc6_libs
+      - libqt6core6t64_libs
+      - libstdc++6_libs
+      - libudev1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt6serialport6/copyright:

--- a/slices/libqt6widgets6.yaml
+++ b/slices/libqt6widgets6.yaml
@@ -1,0 +1,18 @@
+package: libqt6widgets6
+
+essential:
+  - libqt6widgets6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libQt6Widgets.so*:
+    essential:
+      - libc6_libs
+      - libgcc-s1_libs
+      - libqt6core6t64_libs
+      - libstdc++6_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libqt6widgets6/copyright:

--- a/slices/libsm6.yaml
+++ b/slices/libsm6.yaml
@@ -1,0 +1,17 @@
+package: libsm6
+
+essential:
+  - libsm6_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libSM.so.6*:
+    essential:
+      - libc6_libs
+      - libice6_libs
+      - libuuid1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libsm6/copyright:

--- a/slices/libxcb-icccm4.yaml
+++ b/slices/libxcb-icccm4.yaml
@@ -1,0 +1,16 @@
+package: libxcb-icccm4
+
+essential:
+  - libxcb-icccm4_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-icccm.so.4*:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-icccm4/copyright:

--- a/slices/libxcb-image0.yaml
+++ b/slices/libxcb-image0.yaml
@@ -1,0 +1,18 @@
+package: libxcb-image0
+
+essential:
+  - libxcb-image0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-image.so.0*:
+    essential:
+      - libc6_libs
+      - libxcb-shm0_libs
+      - libxcb-util1_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-image0/copyright:

--- a/slices/libxcb-keysyms1.yaml
+++ b/slices/libxcb-keysyms1.yaml
@@ -1,0 +1,16 @@
+package: libxcb-keysyms1
+
+essential:
+  - libxcb-keysyms1_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-keysyms.so.1*:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-keysyms1/copyright:

--- a/slices/libxcb-render-util0.yaml
+++ b/slices/libxcb-render-util0.yaml
@@ -1,0 +1,17 @@
+package: libxcb-render-util0
+
+essential:
+  - libxcb-render-util0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-render-util.so.0*:
+    essential:
+      - libc6_libs
+      - libxcb-render0_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-render-util0/copyright:

--- a/slices/libxcb-util1.yaml
+++ b/slices/libxcb-util1.yaml
@@ -1,0 +1,16 @@
+package: libxcb-util1
+
+essential:
+  - libxcb-util1_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-util.so.1*:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-util1/copyright:

--- a/slices/libxcb-xinerama0.yaml
+++ b/slices/libxcb-xinerama0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-xinerama0
+
+essential:
+  - libxcb-xinerama0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-xinerama.so.0*:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-xinerama0/copyright:

--- a/slices/libxcb-xinput0.yaml
+++ b/slices/libxcb-xinput0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-xinput0
+
+essential:
+  - libxcb-xinput0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-xinput.so.0*:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-xinput0/copyright:

--- a/slices/libxcb-xkb1.yaml
+++ b/slices/libxcb-xkb1.yaml
@@ -1,0 +1,16 @@
+package: libxcb-xkb1
+
+essential:
+  - libxcb-xkb1_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxcb-xkb.so.1*:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-xkb1/copyright:

--- a/slices/libxkbcommon-x11-0.yaml
+++ b/slices/libxkbcommon-x11-0.yaml
@@ -1,0 +1,18 @@
+package: libxkbcommon-x11-0
+
+essential:
+  - libxkbcommon-x11-0_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libxkbcommon-x11.so.0*:
+    essential:
+      - libc6_libs
+      - libxcb-xkb1_libs
+      - libxcb1_libs
+      - libxkbcommon0_libs
+
+  copyright:
+    contents:
+      /usr/share/doc/libxkbcommon-x11-0/copyright:

--- a/slices/libxkbcommon0.yaml
+++ b/slices/libxkbcommon0.yaml
@@ -8,6 +8,7 @@ slices:
     essential:
       # NOTE: libxkbcommon0 deb also depends on xkb-data
       - libc6_libs
+      - xkb-data_data
     contents:
       /usr/lib/*-linux-*/libxkbcommon.so.0*:
 

--- a/slices/xkb-data.yaml
+++ b/slices/xkb-data.yaml
@@ -1,0 +1,13 @@
+package: xkb-data
+
+essential:
+  - xkb-data_copyright
+
+slices:
+  data:
+    contents:
+      /usr/share/X11/xkb/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/xkb-data/copyright:

--- a/tests/spread/integration/dlt-viewer/task.yaml
+++ b/tests/spread/integration/dlt-viewer/task.yaml
@@ -1,0 +1,20 @@
+summary: Integration tests for dlt-viewer and dlt-commander
+
+execute: |
+  apt install --update -y libdlt-dev gcc libc6-dev
+  gcc testdlt.c -ldlt -o testfile.dlt
+
+  rootfs_viewer="$(install-slices dlt-viewer_bins)"
+  cp testfile.dlt "${rootfs_viewer}/"
+
+  export QT_DEBUG_PLUGINS=1
+  export QT_QPA_PLATFORM=offscreen
+
+  chroot "${rootfs_viewer}" dlt-viewer -csv -s -t -c output.csv testfile.dlt
+  test -f "${rootfs_viewer}/output.csv"
+
+  rootfs_commander="$(install-slices dlt-viewer_commander)"
+  cp testfile.dlt "${rootfs_commander}/"
+
+  chroot "${rootfs_commander}" dlt-commander -csv -c output.csv testfile.dlt
+  test -f "${rootfs_commander}/output.csv"

--- a/tests/spread/integration/dlt-viewer/testdlt.c
+++ b/tests/spread/integration/dlt-viewer/testdlt.c
@@ -1,0 +1,24 @@
+#include <dlt/dlt.h>
+#include <unistd.h>
+
+DLT_DECLARE_CONTEXT(ctx);
+
+int main(void)
+{
+    /* Register application */
+    DLT_REGISTER_APP("TAPP", "Test Application");
+
+    /* Register context (3 arguments!) */
+    DLT_REGISTER_CONTEXT(ctx, "TCTX", "Test Context");
+
+    /* Emit some logs */
+    for (int i = 0; i < 5; i++) {
+        DLT_LOG(ctx, DLT_LOG_INFO, DLT_STRING("Hello from test"));
+        sleep(1);
+    }
+
+    /* Cleanup */
+    DLT_UNREGISTER_CONTEXT(ctx);
+    DLT_UNREGISTER_APP();
+    return 0;
+}


### PR DESCRIPTION
# Proposed changes
FP of #552 

I split out `dlt-commander` into a slice called `dlt-viewer_commander` from the `dlt-viewer_bins` slice. It is a lighter weight utility for doing cli operations on dlt files. `dlt-commander` is not included in the Noble package, so this is a new piece only present in the FP

## Related issues/PRs
#552 
#844 

### Forward porting
#844 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->