### PR TITLE
ci: update `pkg-deps` workflow

### DIFF
--- a/.github/workflows/pkg-deps.yaml
+++ b/.github/workflows/pkg-deps.yaml
@@ -13,8 +13,6 @@ jobs:
     env:
       branch: ${{ github.base_ref }}
       main-branch-path: files-from-main
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Proposed changes

replaces `mshick/add-pr-comment@v2` step with the new comment posting mechanism using `canonical/chisel-releases/.github/actions/upload-pr-comment`. this allows `pkg-deps` workflow to drop the `pull-requests: write` permissions

example of a successful run: https://github.com/lczyk/chisel-releases/pull/7

the following PRs into individual branches, change the `pkg-deps` workflow call to run on `pr`, not on `pr-target`. they should be merged after this PR

## Related issues/PRs

- related to https://github.com/canonical/chisel/pull/272
- https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
- https://github.com/canonical/chisel-releases/pull/947 **(this PR)**

### Forward porting

- https://github.com/canonical/chisel-releases/pull/948
- https://github.com/canonical/chisel-releases/pull/949
- https://github.com/canonical/chisel-releases/pull/950
- https://github.com/canonical/chisel-releases/pull/951
- https://github.com/canonical/chisel-releases/pull/952

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
