### PR TITLE
feat(24.04): `libpam0g-dev` tests

### DIFF
--- a/tests/spread/integration/libpam0g-dev/hello-pam.c
+++ b/tests/spread/integration/libpam0g-dev/hello-pam.c
@@ -44,3 +44,4 @@ int main(void) {
 
     return 0;
 }
+

--- a/tests/spread/integration/libpam0g-dev/hello-pam.c
+++ b/tests/spread/integration/libpam0g-dev/hello-pam.c
@@ -1,24 +1,10 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <security/pam_appl.h>
-#include <security/pam_modules.h>
-
-static int conversation(int num_msg, const struct pam_message **msg,
-                        struct pam_response **resp, void *appdata_ptr) {
-    (void)num_msg;
-    (void)msg;
-    (void)resp;
-    (void)appdata_ptr;
-
-    return PAM_CONV_ERR;
-}
 
 int main(void) {
     pam_handle_t *handle = NULL;
-    struct pam_conv conv = {
-        .conv = conversation,
-        .appdata_ptr = NULL,
-    };
+    struct pam_conv conv = {};
     int status = pam_start("hello-pam", "user", &conv, &handle);
     if (status != PAM_SUCCESS) {
         fprintf(stderr, "PAM error: %s: %s\n", "pam_start", pam_strerror(handle, status));

--- a/tests/spread/integration/libpam0g-dev/hello-pam.c
+++ b/tests/spread/integration/libpam0g-dev/hello-pam.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+
+static int conversation(int num_msg, const struct pam_message **msg,
+                        struct pam_response **resp, void *appdata_ptr) {
+    (void)num_msg;
+    (void)msg;
+    (void)resp;
+    (void)appdata_ptr;
+
+    return PAM_CONV_ERR;
+}
+
+int main(void) {
+    pam_handle_t *handle = NULL;
+    struct pam_conv conv = {
+        .conv = conversation,
+        .appdata_ptr = NULL,
+    };
+    int status = pam_start("hello-pam", "user", &conv, &handle);
+    if (status != PAM_SUCCESS) {
+        fprintf(stderr, "PAM error: %s: %s\n", "pam_start", pam_strerror(handle, status));
+    }
+
+    if (status == PAM_SUCCESS) {
+        status = pam_authenticate(handle, 0);
+        if (status != PAM_SUCCESS) {
+            fprintf(stderr, "PAM error: %s: %s\n", "pam_authenticate", pam_strerror(handle, status));
+        }
+    }
+
+    if (status == PAM_SUCCESS) {
+        puts("PAM says: Hello, world!");
+    }
+
+    if (handle != NULL) {
+        status = pam_end(handle, status);
+        if (status != PAM_SUCCESS) {
+            fprintf(stderr, "PAM error: %s: %s\n", "pam_end", pam_strerror(handle, status));
+        }
+    }
+
+    return 0;
+}

--- a/tests/spread/integration/libpam0g-dev/task.yaml
+++ b/tests/spread/integration/libpam0g-dev/task.yaml
@@ -1,0 +1,6 @@
+summary: Integration tests for libpam0g-dev
+
+variants:
+    - hello
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/libpam0g-dev/test_hello.sh
+++ b/tests/spread/integration/libpam0g-dev/test_hello.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#spellchecker: ignore rootfs libc libpam lpam
+
+rootfs="$(install-slices gcc_gcc libc6-dev_libs libpam0g-dev_headers)"
+
+cp hello-pam.c "$rootfs/hello-pam.c"
+chroot "$rootfs" gcc -c -o hello-pam.o hello-pam.c
+
+# can't link since we don't have the actual library
+chroot "$rootfs" gcc -o hello-pam hello-pam.o -lpam 2>&1 | grep -q "cannot find -lpam"
+
+# so let's link it it a different rootfs with the library slices
+rootfs_libs=$(install-slices gcc_gcc libc6-dev_libs libpam0g-dev_libs)
+cp "$rootfs/hello-pam.o" "$rootfs_libs/hello-pam.o"
+chroot "$rootfs_libs" gcc -o hello-pam hello-pam.o -lpam
+
+# we can't run here since we don't have all the other PAM stuff
+chroot "$rootfs_libs" ./hello-pam 2>&1 | grep -q "Critical error"
+
+# create a rootfs in which we can run the hello-pam successfully
+rootfs_runtime=$(install-slices libpam-modules_libs libpam-runtime_config)
+cat > "$rootfs_runtime/etc/pam.d/hello-pam" <<EOF
+auth    required    pam_permit.so
+account required    pam_permit.so
+session required    pam_permit.so
+EOF
+cp "$rootfs_libs/hello-pam" "$rootfs_runtime/hello-pam"
+chroot "$rootfs_runtime" ./hello-pam | grep -q "PAM says: Hello, world!"


### PR DESCRIPTION
# Proposed changes

this PR adds tests for `libpam0g-dev`

1) compiling a test program to an object file using only the `_headers` slice
2) linking the above object using only `_libs` slice
3) run the above program in a rootfs with simple pam config

## Related issues/PRs
n/a

### Forward porting

- https://github.com/canonical/chisel-releases/pull/955 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/956
- https://github.com/canonical/chisel-releases/pull/957

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)