### PR TITLE
feat(26.04): add `python3.14` slices

### DIFF
--- a/slices/libpython3.14-minimal.yaml
+++ b/slices/libpython3.14-minimal.yaml
@@ -1,0 +1,126 @@
+package: libpython3.14-minimal
+
+# Most of the python3.14 standard libraries are split into
+# two major packages:
+# - libpython3.14-minimal (this one)
+# - libpython3.14-stdlib
+# While the libpython3.14-stdlib package has been chiselled logically
+# into granular slices, the same hasn't been done for this package.
+# The reason is simple, the libraries in this package are tightly
+# dependent upon each other.
+essential:
+  - libpython3.14-minimal_copyright
+
+slices:
+  config:
+    contents:
+      /etc/python3.14/sitecustomize.py:
+
+  libs:
+    essential:
+      - libc6_libs
+      - libpython3.14-minimal_config
+      - libssl3t64_libs
+    contents:
+      /usr/lib/python3.14/__future__.py:
+      /usr/lib/python3.14/_ast_unparse.py:
+      /usr/lib/python3.14/_collections_abc.py:
+      /usr/lib/python3.14/_colorize.py:
+      /usr/lib/python3.14/_compat_pickle.py:
+      /usr/lib/python3.14/_opcode_metadata.py:
+      /usr/lib/python3.14/_py_abc.py:
+      /usr/lib/python3.14/_py_warnings.py:
+      /usr/lib/python3.14/_sitebuiltins.py:
+      /usr/lib/python3.14/_strptime.py:
+      /usr/lib/python3.14/_sysconfigdata__*-linux-*.py:
+      /usr/lib/python3.14/_threading_local.py:
+      /usr/lib/python3.14/_weakrefset.py:
+      /usr/lib/python3.14/abc.py:
+      /usr/lib/python3.14/annotationlib.py:
+      /usr/lib/python3.14/argparse.py:
+      /usr/lib/python3.14/ast.py:
+      /usr/lib/python3.14/base64.py:
+      /usr/lib/python3.14/bisect.py:
+      /usr/lib/python3.14/calendar.py:
+      /usr/lib/python3.14/codecs.py:
+      /usr/lib/python3.14/collections/**:
+      /usr/lib/python3.14/compileall.py:
+      /usr/lib/python3.14/compression/**:
+      /usr/lib/python3.14/configparser.py:
+      /usr/lib/python3.14/contextlib.py:
+      /usr/lib/python3.14/copy.py:
+      /usr/lib/python3.14/copyreg.py:
+      /usr/lib/python3.14/csv.py:
+      /usr/lib/python3.14/dataclasses.py:
+      /usr/lib/python3.14/datetime.py:
+      /usr/lib/python3.14/dis.py:
+      /usr/lib/python3.14/email/**:
+      /usr/lib/python3.14/encodings/**:
+      /usr/lib/python3.14/enum.py:
+      /usr/lib/python3.14/filecmp.py:
+      /usr/lib/python3.14/fnmatch.py:
+      /usr/lib/python3.14/functools.py:
+      /usr/lib/python3.14/genericpath.py:
+      /usr/lib/python3.14/getopt.py:
+      /usr/lib/python3.14/glob.py:
+      /usr/lib/python3.14/hashlib.py:
+      /usr/lib/python3.14/heapq.py:
+      /usr/lib/python3.14/importlib/**:
+      /usr/lib/python3.14/inspect.py:
+      /usr/lib/python3.14/io.py:
+      /usr/lib/python3.14/ipaddress.py:
+      /usr/lib/python3.14/json/**:
+      /usr/lib/python3.14/keyword.py:
+      /usr/lib/python3.14/lib-dynload/_hashlib.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_ssl.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/linecache.py:
+      /usr/lib/python3.14/locale.py:
+      /usr/lib/python3.14/logging/**:
+      /usr/lib/python3.14/opcode.py:
+      /usr/lib/python3.14/operator.py:
+      /usr/lib/python3.14/optparse.py:
+      /usr/lib/python3.14/os.py:
+      /usr/lib/python3.14/pathlib/**:
+      /usr/lib/python3.14/pickle.py:
+      /usr/lib/python3.14/pkgutil.py:
+      /usr/lib/python3.14/platform.py:
+      /usr/lib/python3.14/posixpath.py:
+      /usr/lib/python3.14/py_compile.py:
+      /usr/lib/python3.14/quopri.py:
+      /usr/lib/python3.14/random.py:
+      /usr/lib/python3.14/re/**:
+      /usr/lib/python3.14/reprlib.py:
+      /usr/lib/python3.14/runpy.py:
+      /usr/lib/python3.14/selectors.py:
+      /usr/lib/python3.14/signal.py:
+      /usr/lib/python3.14/site.py:
+      /usr/lib/python3.14/sitecustomize.py:
+      /usr/lib/python3.14/socket.py:
+      /usr/lib/python3.14/sre_compile.py:
+      /usr/lib/python3.14/sre_constants.py:
+      /usr/lib/python3.14/sre_parse.py:
+      /usr/lib/python3.14/ssl.py:
+      /usr/lib/python3.14/stat.py:
+      /usr/lib/python3.14/string/**:
+      /usr/lib/python3.14/stringprep.py:
+      /usr/lib/python3.14/struct.py:
+      /usr/lib/python3.14/subprocess.py:
+      /usr/lib/python3.14/sysconfig/**:
+      /usr/lib/python3.14/tempfile.py:
+      /usr/lib/python3.14/textwrap.py:
+      /usr/lib/python3.14/threading.py:
+      /usr/lib/python3.14/token.py:
+      /usr/lib/python3.14/tokenize.py:
+      /usr/lib/python3.14/traceback.py:
+      /usr/lib/python3.14/tracemalloc.py:
+      /usr/lib/python3.14/types.py:
+      /usr/lib/python3.14/typing.py:
+      /usr/lib/python3.14/urllib/**:
+      /usr/lib/python3.14/warnings.py:
+      /usr/lib/python3.14/weakref.py:
+      /usr/lib/python3.14/zipfile/**:
+      /usr/lib/python3.14/zipimport.py:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpython3.14-minimal/copyright:

--- a/slices/libpython3.14-minimal.yaml
+++ b/slices/libpython3.14-minimal.yaml
@@ -9,7 +9,7 @@ package: libpython3.14-minimal
 # The reason is simple, the libraries in this package are tightly
 # dependent upon each other.
 essential:
-  - libpython3.14-minimal_copyright
+  libpython3.14-minimal_copyright:
 
 slices:
   config:
@@ -18,9 +18,9 @@ slices:
 
   libs:
     essential:
-      - libc6_libs
-      - libpython3.14-minimal_config
-      - libssl3t64_libs
+      libc6_libs:
+      libpython3.14-minimal_config:
+      libssl3t64_libs:
     contents:
       /usr/lib/python3.14/__future__.py:
       /usr/lib/python3.14/_ast_unparse.py:

--- a/slices/libpython3.14-minimal.yaml
+++ b/slices/libpython3.14-minimal.yaml
@@ -92,6 +92,7 @@ slices:
       /usr/lib/python3.14/reprlib.py:
       /usr/lib/python3.14/runpy.py:
       /usr/lib/python3.14/selectors.py:
+      /usr/lib/python3.14/shutil.py:
       /usr/lib/python3.14/signal.py:
       /usr/lib/python3.14/site.py:
       /usr/lib/python3.14/sitecustomize.py:

--- a/slices/libpython3.14-stdlib.yaml
+++ b/slices/libpython3.14-stdlib.yaml
@@ -1,0 +1,434 @@
+package: libpython3.14-stdlib
+
+essential:
+  - libpython3.14-stdlib_copyright
+
+# The slices in this package have been grouped with inspiration from the
+# Python 3.14 Standard Library
+# (https://docs.python.org/3.14/library/index.html).
+#
+# Aside from the "core" slice which contains the minimal libraries that
+# should come from this package and the "extra" slice which contains
+# miscellaneous libraries, all the other slice definitions are sorted by
+# their names. The "core" slice is placed at the very beginning and the
+# "extra" slice at the very end.
+slices:
+  # The "core" slice provides a very minimal libpython3.14-stdlib
+  core:
+    essential:
+      - libbz2-1.0_libs
+      - libc6_libs
+      # Adding libgcc-s1 here because it is required for the arm arch.
+      # In practice, libc6 should bring it anyway, BUT, there is a circular
+      # dependency in the archives, where libc6 depends on libgcc-s1 and
+      # vice versa. We don't allow that circular dependency to exist in Chisel
+      # and libgcc-s1 already depends on libc6, so we'll have to include this
+      # line here, explicitly.
+      - libgcc-s1_libs
+      - liblzma5_libs
+      - libpython3.14-minimal_libs
+      - media-types_data
+      - netbase_config
+    contents:
+      /usr/lib/python3.14/_pydatetime.py:
+      /usr/lib/python3.14/_pylong.py:
+      /usr/lib/python3.14/bz2.py:
+      /usr/lib/python3.14/contextvars.py:
+      /usr/lib/python3.14/gettext.py:
+      /usr/lib/python3.14/gzip.py:
+      /usr/lib/python3.14/http/__init__.py:
+      /usr/lib/python3.14/http/client.py:
+      /usr/lib/python3.14/lib-dynload/_bz2.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_codecs_*.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_lzma.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_multibytecodec.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_queue.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/mmap.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lzma.py:
+      /usr/lib/python3.14/mimetypes.py:
+      /usr/lib/python3.14/ntpath.py:
+      /usr/lib/python3.14/queue.py:
+      /usr/lib/python3.14/shutil.py:
+      /usr/lib/python3.14/socketserver.py:
+      /usr/lib/python3.14/tarfile.py:
+
+  # Shared AIX (IBM) support functions
+  aix-support:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_aix_support.py:
+
+  # Generic Operating System Services
+  # https://docs.python.org/3.14/library/allos.html
+  all-os:
+    essential:
+      - libffi8_libs
+      - libncursesw6_libs
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_unix
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.14/_pyio.py:
+      /usr/lib/python3.14/ctypes/**:
+      /usr/lib/python3.14/curses/**:
+      /usr/lib/python3.14/getpass.py:
+      /usr/lib/python3.14/lib-dynload/_ctypes*.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_curses*.cpython-314-*-linux-*.so:
+
+  # Concurrent Execution
+  # https://docs.python.org/3.14/library/concurrency.html
+  concurrency:
+    essential:
+      - libpython3.14-stdlib_all-os
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_crypto
+    contents:
+      /usr/lib/python3.14/concurrent/**:
+      /usr/lib/python3.14/lib-dynload/_interpchannels.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_interpqueues.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_interpreters.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_multiprocessing.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_posixshmem.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/multiprocessing/**:
+      /usr/lib/python3.14/sched.py:
+
+  # Cryptographic Services
+  # https://docs.python.org/3.14/library/crypto.html
+  crypto:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/hmac.py:
+      /usr/lib/python3.14/lib-dynload/_hmac.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/secrets.py:
+
+  # Custom Python Interpreters
+  # https://docs.python.org/3.14/library/custominterp.html
+  custom-interpreters:
+    essential:
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_text
+    contents:
+      /usr/lib/python3.14/code.py:
+      /usr/lib/python3.14/codeop.py:
+
+  # Data Persistence
+  # https://docs.python.org/3.14/library/persistence.html
+  data-persistence:
+    essential:
+      - libdb5.3t64_libs
+      - libpython3.14-stdlib_core
+      - libsqlite3-0_libs
+    contents:
+      /usr/lib/python3.14/dbm/**:
+      /usr/lib/python3.14/lib-dynload/_dbm.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_sqlite3.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/shelve.py:
+      /usr/lib/python3.14/sqlite3/**:
+
+  # Data Types
+  # https://docs.python.org/3.14/library/datatypes.html
+  data-types:
+    essential:
+      - libpython3.14-stdlib_core
+      - tzdata_zoneinfo
+    contents:
+      /usr/lib/python3.14/graphlib.py:
+      /usr/lib/python3.14/lib-dynload/_zoneinfo.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/pprint.py:
+      /usr/lib/python3.14/zoneinfo/**:
+
+  # Debugging and Profiling
+  # https://docs.python.org/3.14/library/debug.html
+  debug:
+    essential:
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_custom-interpreters
+      - libpython3.14-stdlib_data-types
+      - libpython3.14-stdlib_frameworks
+      - libpython3.14-stdlib_text
+    contents:
+      /usr/lib/python3.14/bdb.py:
+      /usr/lib/python3.14/cProfile.py:
+      /usr/lib/python3.14/lib-dynload/_lsprof.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_remote_debugging.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/pdb.py:
+      /usr/lib/python3.14/profile.py:
+      /usr/lib/python3.14/pstats.py:
+      /usr/lib/python3.14/timeit.py:
+      /usr/lib/python3.14/trace.py:
+
+  # Development Tools
+  # https://docs.python.org/3.14/library/development.html
+  development-tools:
+    essential:
+      - libpython3.14-stdlib_all-os
+      - libpython3.14-stdlib_concurrency
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_data-types
+      - libpython3.14-stdlib_debug
+      - libpython3.14-stdlib_distribution
+      - libpython3.14-stdlib_internet
+      - libpython3.14-stdlib_ipc
+      - libpython3.14-stdlib_markup-tools
+      - libpython3.14-stdlib_net-data
+      - libpython3.14-stdlib_numeric
+      - libpython3.14-stdlib_text
+      - libpython3.14-stdlib_unix
+    contents:
+      /usr/lib/python3.14/__phello__/**:
+      /usr/lib/python3.14/doctest.py:
+      /usr/lib/python3.14/lib-dynload/_testbuffer.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testcapi.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testclinic.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testimportmultiple.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testinternalcapi.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testmultiphase.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testsinglephase.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_xxtestfuzz.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/xxlimited.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/xxlimited_35.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/xxsubtype.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/test/**:
+      /usr/lib/python3.14/unittest/**:
+
+  # Software Packaging and Distribution
+  # https://docs.python.org/3.14/library/distribution.html
+  distribution:
+    essential:
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_osx-support
+    contents:
+      /usr/lib/python3.14/_distutils_system_mod.py:
+      /usr/lib/python3.14/venv/**:
+      /usr/lib/python3.14/zipapp.py:
+
+  # File Formats
+  # https://docs.python.org/3.14/library/fileformats.html
+  file-formats:
+    essential:
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_frameworks
+      - libpython3.14-stdlib_markup-tools
+    contents:
+      /usr/lib/python3.14/netrc.py:
+      /usr/lib/python3.14/plistlib.py:
+      /usr/lib/python3.14/tomllib/**:
+
+  # File and Directory Access
+  # https://docs.python.org/3.14/library/filesys.html
+  filesys:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/fileinput.py:
+
+  # Program Frameworks
+  # https://docs.python.org/3.14/library/frameworks.html
+  frameworks:
+    essential:
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_text
+    contents:
+      /usr/lib/python3.14/cmd.py:
+      /usr/lib/python3.14/shlex.py:
+      /usr/lib/python3.14/turtle.py:
+
+  # Importing Modules
+  # https://docs.python.org/3.14/library/modules.html
+  importing:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/modulefinder.py:
+
+  # Internet Protocols and Support
+  # https://docs.python.org/3.14/library/internet.html
+  internet:
+    essential:
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_crypto
+      - libpython3.14-stdlib_file-formats
+      - libpython3.14-stdlib_frameworks
+      - libpython3.14-stdlib_ipc
+      - libpython3.14-stdlib_markup-tools
+      - libpython3.14-stdlib_numeric
+      - libpython3.14-stdlib_pydoc
+      - libuuid1_libs
+    contents:
+      /usr/lib/python3.14/ftplib.py:
+      /usr/lib/python3.14/http/cookiejar.py:
+      /usr/lib/python3.14/http/cookies.py:
+      /usr/lib/python3.14/http/server.py:
+      /usr/lib/python3.14/imaplib.py:
+      /usr/lib/python3.14/lib-dynload/_uuid.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/nturl2path.py:
+      /usr/lib/python3.14/poplib.py:
+      /usr/lib/python3.14/smtplib.py:
+      /usr/lib/python3.14/uuid.py:
+      /usr/lib/python3.14/webbrowser.py:
+      /usr/lib/python3.14/wsgiref/**:
+      /usr/lib/python3.14/xmlrpc/**:
+
+  # Networking and Interprocess Communication
+  # https://docs.python.org/3.14/library/ipc.html
+  ipc:
+    essential:
+      - libpython3.14-stdlib_concurrency
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/asyncio/**:
+      /usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-*-linux-*.so:
+
+  # Python Language Services
+  # https://docs.python.org/3.14/library/language.html
+  language:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/pickletools.py:
+      /usr/lib/python3.14/pyclbr.py:
+      /usr/lib/python3.14/symtable.py:
+      /usr/lib/python3.14/tabnanny.py:
+
+  # Structured Markup Processing Tools (HTML, XML)
+  # https://docs.python.org/3.14/library/markup.html
+  markup-tools:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_markupbase.py:
+      /usr/lib/python3.14/html/**:
+      /usr/lib/python3.14/xml/**:
+
+  # Multimedia Services
+  # https://docs.python.org/3.14/library/mm.html
+  multimedia:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/colorsys.py:
+      /usr/lib/python3.14/wave.py:
+
+  # Internet Data Handling
+  # https://docs.python.org/3.14/library/netdata.html
+  net-data:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/mailbox.py:
+
+  # Numeric and Mathematical Modules
+  # https://docs.python.org/3.14/library/numeric.html
+  numeric:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_pydecimal.py:
+      /usr/lib/python3.14/decimal.py:
+      /usr/lib/python3.14/fractions.py:
+      /usr/lib/python3.14/lib-dynload/_decimal.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/numbers.py:
+      /usr/lib/python3.14/statistics.py:
+
+  # Shared OS X support functions
+  osx-support:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_osx_support.py:
+
+  # Shared Apple support functions
+  apple-support:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_apple_support.py:
+
+  # Shared IOS support functions
+  ios-support:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_ios_support.py:
+
+  # Shared Android support functions
+  android-support:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/_android_support.py:
+
+  # pydoc - Documentation generator and online help system
+  # https://docs.python.org/3.14/library/pydoc.html
+  pydoc:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/pydoc.py:
+      /usr/lib/python3.14/pydoc_data/**:
+
+  pyrepl:
+    essential:
+      - base-files_home  # To suppress pyrepl warning of failing to save history.
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_custom-interpreters
+    contents:
+      /usr/lib/python3.14/_pyrepl/**:
+
+  # Text Processing Services
+  # https://docs.python.org/3.14/library/text.html
+  text:
+    essential:
+      - libpython3.14-stdlib_core
+      - libreadline8t64_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/python3.14/difflib.py:
+      /usr/lib/python3.14/lib-dynload/readline.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/rlcompleter.py:
+
+  # Unix Specific Services
+  # https://docs.python.org/3.14/library/unix.html
+  unix:
+    essential:
+      - libcrypt1_libs
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_frameworks
+    contents:
+      /usr/lib/python3.14/lib-dynload/resource.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/termios.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/pty.py:
+      /usr/lib/python3.14/tty.py:
+
+  zstd:
+    essential:
+      - libpython3.14-stdlib_core
+    contents:
+      /usr/lib/python3.14/lib-dynload/_zstd.cpython-314-*-linux-*.so:
+
+  # Outliers and Deprecated Modules
+  # The "extra" slice consists of easter-eggs and deprecated modules
+  extras:
+    essential:
+      - libnsl2_libs
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_internet
+      - libtirpc3t64_libs
+    contents:
+      /usr/lib/python3.14/__hello__.py:
+      /usr/lib/python3.14/_sysconfig_vars__linux_*-linux-*.json:
+      /usr/lib/python3.14/antigravity.py:
+
+      # These are not used. Added for sake of completeness
+      /usr/lib/python3.14/lib-dynload/_testclinic_limited.cpython-314-*-linux-*.so:
+      /usr/lib/python3.14/lib-dynload/_testlimitedcapi.cpython-314-*-linux-*.so:
+
+      /usr/lib/python3.14/this.py:
+
+  copyright:
+    essential:
+      - libpython3.14-minimal_copyright
+    contents:
+      /usr/share/doc/libpython3.14-stdlib:

--- a/slices/libpython3.14-stdlib.yaml
+++ b/slices/libpython3.14-stdlib.yaml
@@ -48,7 +48,6 @@ slices:
       /usr/lib/python3.14/mimetypes.py:
       /usr/lib/python3.14/ntpath.py:
       /usr/lib/python3.14/queue.py:
-      /usr/lib/python3.14/shutil.py:
       /usr/lib/python3.14/socketserver.py:
       /usr/lib/python3.14/tarfile.py:
 

--- a/slices/libpython3.14-stdlib.yaml
+++ b/slices/libpython3.14-stdlib.yaml
@@ -1,7 +1,7 @@
 package: libpython3.14-stdlib
 
 essential:
-  - libpython3.14-stdlib_copyright
+  libpython3.14-stdlib_copyright:
 
 # The slices in this package have been grouped with inspiration from the
 # Python 3.14 Standard Library
@@ -16,19 +16,19 @@ slices:
   # The "core" slice provides a very minimal libpython3.14-stdlib
   core:
     essential:
-      - libbz2-1.0_libs
-      - libc6_libs
+      libbz2-1.0_libs:
+      libc6_libs:
       # Adding libgcc-s1 here because it is required for the arm arch.
       # In practice, libc6 should bring it anyway, BUT, there is a circular
       # dependency in the archives, where libc6 depends on libgcc-s1 and
       # vice versa. We don't allow that circular dependency to exist in Chisel
       # and libgcc-s1 already depends on libc6, so we'll have to include this
       # line here, explicitly.
-      - libgcc-s1_libs
-      - liblzma5_libs
-      - libpython3.14-minimal_libs
-      - media-types_data
-      - netbase_config
+      libgcc-s1_libs:
+      liblzma5_libs:
+      libpython3.14-minimal_libs:
+      media-types_data:
+      netbase_config:
     contents:
       /usr/lib/python3.14/_pydatetime.py:
       /usr/lib/python3.14/_pylong.py:
@@ -55,7 +55,7 @@ slices:
   # Shared AIX (IBM) support functions
   aix-support:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_aix_support.py:
 
@@ -63,11 +63,11 @@ slices:
   # https://docs.python.org/3.14/library/allos.html
   all-os:
     essential:
-      - libffi8_libs
-      - libncursesw6_libs
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_unix
-      - libtinfo6_libs
+      libffi8_libs:
+      libncursesw6_libs:
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_unix:
+      libtinfo6_libs:
     contents:
       /usr/lib/python3.14/_pyio.py:
       /usr/lib/python3.14/ctypes/**:
@@ -80,9 +80,9 @@ slices:
   # https://docs.python.org/3.14/library/concurrency.html
   concurrency:
     essential:
-      - libpython3.14-stdlib_all-os
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_crypto
+      libpython3.14-stdlib_all-os:
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_crypto:
     contents:
       /usr/lib/python3.14/concurrent/**:
       /usr/lib/python3.14/lib-dynload/_interpchannels.cpython-314-*-linux-*.so:
@@ -97,7 +97,7 @@ slices:
   # https://docs.python.org/3.14/library/crypto.html
   crypto:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/hmac.py:
       /usr/lib/python3.14/lib-dynload/_hmac.cpython-314-*-linux-*.so:
@@ -107,8 +107,8 @@ slices:
   # https://docs.python.org/3.14/library/custominterp.html
   custom-interpreters:
     essential:
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_text
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_text:
     contents:
       /usr/lib/python3.14/code.py:
       /usr/lib/python3.14/codeop.py:
@@ -117,9 +117,9 @@ slices:
   # https://docs.python.org/3.14/library/persistence.html
   data-persistence:
     essential:
-      - libdb5.3t64_libs
-      - libpython3.14-stdlib_core
-      - libsqlite3-0_libs
+      libdb5.3t64_libs:
+      libpython3.14-stdlib_core:
+      libsqlite3-0_libs:
     contents:
       /usr/lib/python3.14/dbm/**:
       /usr/lib/python3.14/lib-dynload/_dbm.cpython-314-*-linux-*.so:
@@ -131,8 +131,8 @@ slices:
   # https://docs.python.org/3.14/library/datatypes.html
   data-types:
     essential:
-      - libpython3.14-stdlib_core
-      - tzdata_zoneinfo
+      libpython3.14-stdlib_core:
+      tzdata_zoneinfo:
     contents:
       /usr/lib/python3.14/graphlib.py:
       /usr/lib/python3.14/lib-dynload/_zoneinfo.cpython-314-*-linux-*.so:
@@ -143,11 +143,11 @@ slices:
   # https://docs.python.org/3.14/library/debug.html
   debug:
     essential:
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_custom-interpreters
-      - libpython3.14-stdlib_data-types
-      - libpython3.14-stdlib_frameworks
-      - libpython3.14-stdlib_text
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_custom-interpreters:
+      libpython3.14-stdlib_data-types:
+      libpython3.14-stdlib_frameworks:
+      libpython3.14-stdlib_text:
     contents:
       /usr/lib/python3.14/bdb.py:
       /usr/lib/python3.14/cProfile.py:
@@ -163,19 +163,19 @@ slices:
   # https://docs.python.org/3.14/library/development.html
   development-tools:
     essential:
-      - libpython3.14-stdlib_all-os
-      - libpython3.14-stdlib_concurrency
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_data-types
-      - libpython3.14-stdlib_debug
-      - libpython3.14-stdlib_distribution
-      - libpython3.14-stdlib_internet
-      - libpython3.14-stdlib_ipc
-      - libpython3.14-stdlib_markup-tools
-      - libpython3.14-stdlib_net-data
-      - libpython3.14-stdlib_numeric
-      - libpython3.14-stdlib_text
-      - libpython3.14-stdlib_unix
+      libpython3.14-stdlib_all-os:
+      libpython3.14-stdlib_concurrency:
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_data-types:
+      libpython3.14-stdlib_debug:
+      libpython3.14-stdlib_distribution:
+      libpython3.14-stdlib_internet:
+      libpython3.14-stdlib_ipc:
+      libpython3.14-stdlib_markup-tools:
+      libpython3.14-stdlib_net-data:
+      libpython3.14-stdlib_numeric:
+      libpython3.14-stdlib_text:
+      libpython3.14-stdlib_unix:
     contents:
       /usr/lib/python3.14/__phello__/**:
       /usr/lib/python3.14/doctest.py:
@@ -197,8 +197,8 @@ slices:
   # https://docs.python.org/3.14/library/distribution.html
   distribution:
     essential:
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_osx-support
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_osx-support:
     contents:
       /usr/lib/python3.14/_distutils_system_mod.py:
       /usr/lib/python3.14/venv/**:
@@ -208,9 +208,9 @@ slices:
   # https://docs.python.org/3.14/library/fileformats.html
   file-formats:
     essential:
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_frameworks
-      - libpython3.14-stdlib_markup-tools
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_frameworks:
+      libpython3.14-stdlib_markup-tools:
     contents:
       /usr/lib/python3.14/netrc.py:
       /usr/lib/python3.14/plistlib.py:
@@ -220,7 +220,7 @@ slices:
   # https://docs.python.org/3.14/library/filesys.html
   filesys:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/fileinput.py:
 
@@ -228,8 +228,8 @@ slices:
   # https://docs.python.org/3.14/library/frameworks.html
   frameworks:
     essential:
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_text
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_text:
     contents:
       /usr/lib/python3.14/cmd.py:
       /usr/lib/python3.14/shlex.py:
@@ -239,7 +239,7 @@ slices:
   # https://docs.python.org/3.14/library/modules.html
   importing:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/modulefinder.py:
 
@@ -247,15 +247,15 @@ slices:
   # https://docs.python.org/3.14/library/internet.html
   internet:
     essential:
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_crypto
-      - libpython3.14-stdlib_file-formats
-      - libpython3.14-stdlib_frameworks
-      - libpython3.14-stdlib_ipc
-      - libpython3.14-stdlib_markup-tools
-      - libpython3.14-stdlib_numeric
-      - libpython3.14-stdlib_pydoc
-      - libuuid1_libs
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_crypto:
+      libpython3.14-stdlib_file-formats:
+      libpython3.14-stdlib_frameworks:
+      libpython3.14-stdlib_ipc:
+      libpython3.14-stdlib_markup-tools:
+      libpython3.14-stdlib_numeric:
+      libpython3.14-stdlib_pydoc:
+      libuuid1_libs:
     contents:
       /usr/lib/python3.14/ftplib.py:
       /usr/lib/python3.14/http/cookiejar.py:
@@ -275,8 +275,8 @@ slices:
   # https://docs.python.org/3.14/library/ipc.html
   ipc:
     essential:
-      - libpython3.14-stdlib_concurrency
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_concurrency:
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/asyncio/**:
       /usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-*-linux-*.so:
@@ -285,7 +285,7 @@ slices:
   # https://docs.python.org/3.14/library/language.html
   language:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/pickletools.py:
       /usr/lib/python3.14/pyclbr.py:
@@ -296,7 +296,7 @@ slices:
   # https://docs.python.org/3.14/library/markup.html
   markup-tools:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_markupbase.py:
       /usr/lib/python3.14/html/**:
@@ -306,7 +306,7 @@ slices:
   # https://docs.python.org/3.14/library/mm.html
   multimedia:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/colorsys.py:
       /usr/lib/python3.14/wave.py:
@@ -315,7 +315,7 @@ slices:
   # https://docs.python.org/3.14/library/netdata.html
   net-data:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/mailbox.py:
 
@@ -323,7 +323,7 @@ slices:
   # https://docs.python.org/3.14/library/numeric.html
   numeric:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_pydecimal.py:
       /usr/lib/python3.14/decimal.py:
@@ -335,28 +335,28 @@ slices:
   # Shared OS X support functions
   osx-support:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_osx_support.py:
 
   # Shared Apple support functions
   apple-support:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_apple_support.py:
 
   # Shared IOS support functions
   ios-support:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_ios_support.py:
 
   # Shared Android support functions
   android-support:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/_android_support.py:
 
@@ -364,16 +364,16 @@ slices:
   # https://docs.python.org/3.14/library/pydoc.html
   pydoc:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/pydoc.py:
       /usr/lib/python3.14/pydoc_data/**:
 
   pyrepl:
     essential:
-      - base-files_home  # To suppress pyrepl warning of failing to save history.
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_custom-interpreters
+      base-files_home:  # To suppress pyrepl warning of failing to save history.
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_custom-interpreters:
     contents:
       /usr/lib/python3.14/_pyrepl/**:
 
@@ -381,9 +381,9 @@ slices:
   # https://docs.python.org/3.14/library/text.html
   text:
     essential:
-      - libpython3.14-stdlib_core
-      - libreadline8t64_libs
-      - libtinfo6_libs
+      libpython3.14-stdlib_core:
+      libreadline8t64_libs:
+      libtinfo6_libs:
     contents:
       /usr/lib/python3.14/difflib.py:
       /usr/lib/python3.14/lib-dynload/readline.cpython-314-*-linux-*.so:
@@ -393,9 +393,9 @@ slices:
   # https://docs.python.org/3.14/library/unix.html
   unix:
     essential:
-      - libcrypt1_libs
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_frameworks
+      libcrypt1_libs:
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_frameworks:
     contents:
       /usr/lib/python3.14/lib-dynload/resource.cpython-314-*-linux-*.so:
       /usr/lib/python3.14/lib-dynload/termios.cpython-314-*-linux-*.so:
@@ -404,7 +404,7 @@ slices:
 
   zstd:
     essential:
-      - libpython3.14-stdlib_core
+      libpython3.14-stdlib_core:
     contents:
       /usr/lib/python3.14/lib-dynload/_zstd.cpython-314-*-linux-*.so:
 
@@ -412,10 +412,10 @@ slices:
   # The "extra" slice consists of easter-eggs and deprecated modules
   extras:
     essential:
-      - libnsl2_libs
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_internet
-      - libtirpc3t64_libs
+      libnsl2_libs:
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_internet:
+      libtirpc3t64_libs:
     contents:
       /usr/lib/python3.14/__hello__.py:
       /usr/lib/python3.14/_sysconfig_vars__linux_*-linux-*.json:
@@ -429,6 +429,6 @@ slices:
 
   copyright:
     essential:
-      - libpython3.14-minimal_copyright
+      libpython3.14-minimal_copyright:
     contents:
       /usr/share/doc/libpython3.14-stdlib:

--- a/slices/python3-minimal.yaml
+++ b/slices/python3-minimal.yaml
@@ -29,7 +29,7 @@ slices:
 
   python3:
     essential:
-      python3.13-minimal_bins:
+      python3.14-minimal_bins:
     contents:
       /usr/bin/python3:
 

--- a/slices/python3.14-minimal.yaml
+++ b/slices/python3.14-minimal.yaml
@@ -1,0 +1,22 @@
+package: python3.14-minimal
+
+essential:
+  - python3.14-minimal_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libexpat1_libs
+      - libpython3.14-minimal_libs
+      - zlib1g_libs
+    contents:
+      /usr/bin/python3.14:
+      # The next two directories are created to mimic the behaviour in
+      # the "postinst" script.
+      /usr/local/lib/python3.14/: {make: true, mode: 02775}
+      /usr/local/lib/python3.14/dist-packages/: {make: true, mode: 02775}
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.14-minimal/copyright:

--- a/slices/python3.14-minimal.yaml
+++ b/slices/python3.14-minimal.yaml
@@ -1,15 +1,15 @@
 package: python3.14-minimal
 
 essential:
-  - python3.14-minimal_copyright
+  python3.14-minimal_copyright:
 
 slices:
   bins:
     essential:
-      - libc6_libs
-      - libexpat1_libs
-      - libpython3.14-minimal_libs
-      - zlib1g_libs
+      libc6_libs:
+      libexpat1_libs:
+      libpython3.14-minimal_libs:
+      zlib1g_libs:
     contents:
       /usr/bin/python3.14:
       # The next two directories are created to mimic the behaviour in

--- a/slices/python3.14-venv.yaml
+++ b/slices/python3.14-venv.yaml
@@ -1,0 +1,17 @@
+package: python3.14-venv
+
+essential:
+  - python3.14-venv_copyright
+
+slices:
+  ensurepip:
+    essential:
+      - python3-pip-whl_wheels
+      - python3-setuptools-whl_wheels
+      - python3.14_standard
+    contents:
+      /usr/lib/python3.14/ensurepip/*.py:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.14-venv: {symlink: /usr/share/doc/python3.14}

--- a/slices/python3.14-venv.yaml
+++ b/slices/python3.14-venv.yaml
@@ -1,14 +1,14 @@
 package: python3.14-venv
 
 essential:
-  - python3.14-venv_copyright
+  python3.14-venv_copyright:
 
 slices:
   ensurepip:
     essential:
-      - python3-pip-whl_wheels
-      - python3-setuptools-whl_wheels
-      - python3.14_standard
+      python3-pip-whl_wheels:
+      python3-setuptools-whl_wheels:
+      python3.14_standard:
     contents:
       /usr/lib/python3.14/ensurepip/*.py:
 

--- a/slices/python3.14.yaml
+++ b/slices/python3.14.yaml
@@ -1,0 +1,64 @@
+package: python3.14
+
+essential:
+  - python3.14_copyright
+
+slices:
+  # The "core" slice provides a very minimal, yet functioning python3.14.
+  # It includes very few modules from the libpython3.14-stdlib package.
+  core:
+    essential:
+      - libpython3.14-stdlib_core
+      - media-types_data
+      - python3.14-minimal_bins
+
+  # The "standard" slice extends "core" with all the Python
+  # modules from the libpython3.14-stdlib package.
+  standard:
+    essential:
+      - libpython3.14-stdlib_aix-support
+      - libpython3.14-stdlib_all-os
+      - libpython3.14-stdlib_concurrency
+      - libpython3.14-stdlib_core
+      - libpython3.14-stdlib_crypto
+      - libpython3.14-stdlib_custom-interpreters
+      - libpython3.14-stdlib_data-persistence
+      - libpython3.14-stdlib_data-types
+      - libpython3.14-stdlib_debug
+      - libpython3.14-stdlib_development-tools
+      - libpython3.14-stdlib_distribution
+      - libpython3.14-stdlib_extras
+      - libpython3.14-stdlib_file-formats
+      - libpython3.14-stdlib_filesys
+      - libpython3.14-stdlib_frameworks
+      - libpython3.14-stdlib_importing
+      - libpython3.14-stdlib_internet
+      - libpython3.14-stdlib_ipc
+      - libpython3.14-stdlib_language
+      - libpython3.14-stdlib_markup-tools
+      - libpython3.14-stdlib_multimedia
+      - libpython3.14-stdlib_net-data
+      - libpython3.14-stdlib_numeric
+      - libpython3.14-stdlib_osx-support
+      - libpython3.14-stdlib_pydoc
+      - libpython3.14-stdlib_pyrepl
+      - libpython3.14-stdlib_text
+      - libpython3.14-stdlib_unix
+      - libpython3.14-stdlib_zstd
+      - python3.14_core
+      - tzdata_zoneinfo
+
+  # The "utlis" slice extends "core" with various tools.
+  utils:
+    essential:
+      - libpython3.14-stdlib_debug
+      - libpython3.14-stdlib_pydoc
+      - python3.14_core
+    contents:
+      /usr/bin/pdb3.14:
+      /usr/bin/pydoc3.14:
+      /usr/bin/pygettext3.14:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3.14/copyright:

--- a/slices/python3.14.yaml
+++ b/slices/python3.14.yaml
@@ -1,59 +1,59 @@
 package: python3.14
 
 essential:
-  - python3.14_copyright
+  python3.14_copyright:
 
 slices:
   # The "core" slice provides a very minimal, yet functioning python3.14.
   # It includes very few modules from the libpython3.14-stdlib package.
   core:
     essential:
-      - libpython3.14-stdlib_core
-      - media-types_data
-      - python3.14-minimal_bins
+      libpython3.14-stdlib_core:
+      media-types_data:
+      python3.14-minimal_bins:
 
   # The "standard" slice extends "core" with all the Python
   # modules from the libpython3.14-stdlib package.
   standard:
     essential:
-      - libpython3.14-stdlib_aix-support
-      - libpython3.14-stdlib_all-os
-      - libpython3.14-stdlib_concurrency
-      - libpython3.14-stdlib_core
-      - libpython3.14-stdlib_crypto
-      - libpython3.14-stdlib_custom-interpreters
-      - libpython3.14-stdlib_data-persistence
-      - libpython3.14-stdlib_data-types
-      - libpython3.14-stdlib_debug
-      - libpython3.14-stdlib_development-tools
-      - libpython3.14-stdlib_distribution
-      - libpython3.14-stdlib_extras
-      - libpython3.14-stdlib_file-formats
-      - libpython3.14-stdlib_filesys
-      - libpython3.14-stdlib_frameworks
-      - libpython3.14-stdlib_importing
-      - libpython3.14-stdlib_internet
-      - libpython3.14-stdlib_ipc
-      - libpython3.14-stdlib_language
-      - libpython3.14-stdlib_markup-tools
-      - libpython3.14-stdlib_multimedia
-      - libpython3.14-stdlib_net-data
-      - libpython3.14-stdlib_numeric
-      - libpython3.14-stdlib_osx-support
-      - libpython3.14-stdlib_pydoc
-      - libpython3.14-stdlib_pyrepl
-      - libpython3.14-stdlib_text
-      - libpython3.14-stdlib_unix
-      - libpython3.14-stdlib_zstd
-      - python3.14_core
-      - tzdata_zoneinfo
+      libpython3.14-stdlib_aix-support:
+      libpython3.14-stdlib_all-os:
+      libpython3.14-stdlib_concurrency:
+      libpython3.14-stdlib_core:
+      libpython3.14-stdlib_crypto:
+      libpython3.14-stdlib_custom-interpreters:
+      libpython3.14-stdlib_data-persistence:
+      libpython3.14-stdlib_data-types:
+      libpython3.14-stdlib_debug:
+      libpython3.14-stdlib_development-tools:
+      libpython3.14-stdlib_distribution:
+      libpython3.14-stdlib_extras:
+      libpython3.14-stdlib_file-formats:
+      libpython3.14-stdlib_filesys:
+      libpython3.14-stdlib_frameworks:
+      libpython3.14-stdlib_importing:
+      libpython3.14-stdlib_internet:
+      libpython3.14-stdlib_ipc:
+      libpython3.14-stdlib_language:
+      libpython3.14-stdlib_markup-tools:
+      libpython3.14-stdlib_multimedia:
+      libpython3.14-stdlib_net-data:
+      libpython3.14-stdlib_numeric:
+      libpython3.14-stdlib_osx-support:
+      libpython3.14-stdlib_pydoc:
+      libpython3.14-stdlib_pyrepl:
+      libpython3.14-stdlib_text:
+      libpython3.14-stdlib_unix:
+      libpython3.14-stdlib_zstd:
+      python3.14_core:
+      tzdata_zoneinfo:
 
   # The "utlis" slice extends "core" with various tools.
   utils:
     essential:
-      - libpython3.14-stdlib_debug
-      - libpython3.14-stdlib_pydoc
-      - python3.14_core
+      libpython3.14-stdlib_debug:
+      libpython3.14-stdlib_pydoc:
+      python3.14_core:
     contents:
       /usr/bin/pdb3.14:
       /usr/bin/pydoc3.14:

--- a/slices/python3.yaml
+++ b/slices/python3.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libpython3-stdlib_core:
       python3-minimal_python3:
-      python3.13_core:
+      python3.14_core:
 
   standard:
     essential:
@@ -40,14 +40,14 @@ slices:
       libpython3-stdlib_text:
       libpython3-stdlib_unix:
       python3-minimal_bins:
-      python3.13_standard:
+      python3.14_standard:
       python3_core:
 
   utils:
     essential:
       libpython3-stdlib_debug:
       libpython3-stdlib_pydoc:
-      python3.13_utils:
+      python3.14_utils:
     contents:
       /usr/bin/pdb3:
       /usr/bin/pydoc3:

--- a/tests/spread/integration/python3-minimal/task.yaml
+++ b/tests/spread/integration/python3-minimal/task.yaml
@@ -7,9 +7,12 @@ execute: |
 
   # test py3versions
   rootfs_py3versions="$(install-slices python3-minimal_py3versions)"
-  chroot "$rootfs_py3versions" py3versions -d | grep "python3.13"
+  chroot "$rootfs_py3versions" py3versions --help | grep -iq "usage"
+  chroot "$rootfs_py3versions" py3versions --default | grep "python3.14"
 
   # test py3compile
   rootfs_py3compile="$(install-slices python3-minimal_py3compile)"
-  chroot "$rootfs_py3compile" py3compile -h
-  chroot "$rootfs_py3compile" py3clean -h
+  chroot "$rootfs_py3compile" py3compile --help | grep -iq "usage: py3compile"
+  chroot "$rootfs_py3compile" py3compile --version | grep -iq "py3compile 3.14"
+  chroot "$rootfs_py3compile" py3clean --help | grep -iq "usage: py3clean"
+  chroot "$rootfs_py3compile" py3clean --version | grep -iq "py3clean 3.14"

--- a/tests/spread/integration/python3-pip/task.yaml
+++ b/tests/spread/integration/python3-pip/task.yaml
@@ -3,8 +3,8 @@ summary: Integration tests for python3-pip
 execute: |
   rootfs="$(install-slices python3-pip_bins)"
 
-  cp /etc/resolv.conf "${rootfs}/etc/"
+  cp /etc/resolv.conf "$rootfs/etc/"
 
   # Smoke tests.
-  chroot ${rootfs} /usr/bin/pip --version
-  chroot ${rootfs} /usr/bin/pip install --upgrade setuptools
+  chroot "$rootfs" /usr/bin/pip --version
+  chroot "$rootfs" /usr/bin/pip install --upgrade setuptools

--- a/tests/spread/integration/python3.14-venv/task.yaml
+++ b/tests/spread/integration/python3.14-venv/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for python3.14-venv
+
+execute: |
+  rootfs="$(install-slices python3.14-venv_ensurepip)"
+
+  # copy etc/resolv.conf to the rootfs so that pip can resolve hostnames
+  mkdir -p "$rootfs/etc"
+  cp /etc/resolv.conf "$rootfs/etc/resolv.conf" 
+
+  chroot "$rootfs" python3.14 -m venv /my_env
+  test -d "$rootfs/my_env"
+
+  # test python
+  chroot "$rootfs" /my_env/bin/python3.14 --version | grep -iq "python 3.14"
+  chroot "$rootfs" /my_env/bin/python3.14 -c "import sys; print(sys.prefix)" | grep -iqx "/my_env"
+
+  # test pip
+  chroot "$rootfs" /my_env/bin/pip3.14 --version | grep -iq "pip"
+
+  # install some packages in the venv and check they are installed correctly
+  chroot "$rootfs" /my_env/bin/pip3.14 install requests==2.31.0
+  chroot "$rootfs" /my_env/bin/python3.14 \
+    -c "import requests; print(requests.__version__)" | \
+    grep -iqx "2.31.0"

--- a/tests/spread/integration/python3.14/task.yaml
+++ b/tests/spread/integration/python3.14/task.yaml
@@ -1,0 +1,23 @@
+summary: Integration tests for python3.14
+
+environment:
+  SLICE/core: "core"
+  SLICE/standard: "standard"
+
+execute: |
+  # Test different slice installations
+  echo "SLICE=${SLICE}"
+
+  rootfs="$(install-slices python3.14_${SLICE})"
+
+  cp test_${SLICE}.py "${rootfs}/"
+  chroot "$rootfs" python3.14 /test_${SLICE}.py
+
+  if [ "$SLICE" == "standard" ]; then
+    # Test that _pyrepl module is available in the standard slice
+    # This is tricky to test since python will not import _pyrepl in
+    # non-interactive mode by default. Hence we just test for the import
+    # failure directly.
+    # https://github.com/canonical/python-rock/issues/36
+    chroot "$rootfs" python3.14 -c "import _pyrepl;"
+  fi

--- a/tests/spread/integration/python3.14/test_core.py
+++ b/tests/spread/integration/python3.14/test_core.py
@@ -1,0 +1,49 @@
+"""
+Tests some of the core Python functionality
+"""
+
+import sys
+import os
+import socket
+import time
+
+
+def hello_world():
+    # Asserting the stdout would require additional modules (like StringIO)
+    # that are not available in the "core" slice. So this test case only tests
+    # the functionality, but not the outcome.
+    print("Hello, world!")
+
+
+def check_python_version():
+    print("Checking Python version...")
+    assert sys.version.startswith(
+        "3.14"
+    ), f"Wrong Python version installed: {sys.version}. Expected 3.13."
+
+
+def check_file_operations():
+    print("Checking file operations...")
+    filename = f"/test-file-{int(time.time())}"
+
+    original_content = "This is a test file."
+    with open(filename, "w") as f:
+        f.write(original_content)
+    with open(filename, "r") as f:
+        content = f.read()
+    assert content == original_content
+    os.remove(filename)
+    assert not os.path.exists(filename)
+    print(f"File operations are working. Content: {content}")
+
+
+def check_network_operations():
+    print("Checking network operations...")
+    print(socket.gethostname())
+
+
+if __name__ == "__main__":
+    hello_world()
+    check_python_version()
+    check_file_operations()
+    check_network_operations()

--- a/tests/spread/integration/python3.14/test_core.py
+++ b/tests/spread/integration/python3.14/test_core.py
@@ -17,9 +17,9 @@ def hello_world():
 
 def check_python_version():
     print("Checking Python version...")
-    assert sys.version.startswith(
-        "3.14"
-    ), f"Wrong Python version installed: {sys.version}. Expected 3.13."
+    assert sys.version.startswith("3.14"), (
+        f"Wrong Python version installed: {sys.version}. Expected 3.14."
+    )
 
 
 def check_file_operations():

--- a/tests/spread/integration/python3.14/test_standard.py
+++ b/tests/spread/integration/python3.14/test_standard.py
@@ -1,0 +1,313 @@
+"""
+Tests some of the standard Python functionality
+"""
+
+import html
+import json
+import urllib
+import uuid
+
+
+def check_json_loading():
+    print("Checking JSON loading...")
+
+    sample = '{"foo": ["bar"]}'
+    assert json.loads(sample) == {"foo": ["bar"]}
+
+
+def check_html_escaping():
+    print("Checking HTML escaping...")
+
+    sample = "Some <sample> & 'text' with \"HTML\" characters"
+    exp = "Some &lt;sample&gt; &amp; &#x27;text&#x27; with &quot;HTML&quot; characters"
+    assert html.escape(sample) == exp
+
+
+def check_uuid_gen():
+    print("Checking UUID generation...")
+
+    assert type(uuid.uuid1().int) == int
+
+
+def test_import_everything():
+    """
+    Module name gathered from https://docs.python.org/3.14/py-modindex.html
+    JS:
+     const moduleList = Array.from(document.getElementsByTagName('a')).map(e => e.href).filter(e => e.startsWith('https://docs.python.org/3.14/library/')).map(e => e.match(/library\/(.*)\.html/)[1])
+     for (m of moduleList) { console.log(`import ${m}`) }
+    """
+    import __future__
+    import __main__
+    import _thread
+    # import tkinter
+    import abc
+    # import aifc
+    import annotationlib
+    import argparse
+    import array
+    import ast
+    # import asynchat
+    import asyncio
+    # import asyncore
+    import atexit
+    # import audioop
+    import base64
+    import bdb
+    import binascii
+    import bisect
+    import builtins
+    import bz2
+    import calendar
+    # import cgi
+    # import cgitb
+    # import chunk
+    import cmath
+    import cmd
+    import code
+    import codecs
+    import codeop
+    import collections
+    import collections.abc
+    import colorsys
+    import compileall
+    import compression
+    import compression.zstd
+    import concurrent.futures
+    import concurrent.interpreters
+    import configparser
+    import contextlib
+    import contextvars
+    import copy
+    import copyreg
+    import profile
+    # import crypt
+    import csv
+    import ctypes
+    import curses
+    import curses.ascii
+    import curses.panel
+    import curses
+    import dataclasses
+    import datetime
+    import dbm
+    import decimal
+    import difflib
+    import dis
+    # import distutils
+    import doctest
+    import email
+    import email.charset
+    import email.contentmanager
+    import email.encoders
+    import email.errors
+    import email.generator
+    import email.header
+    import email.headerregistry
+    import email.iterators
+    import email.message
+    import email.mime
+    import email.parser
+    import email.policy
+    import email.utils
+    import codecs
+    # import ensurepip
+    import enum
+    import errno
+    import faulthandler
+    import fcntl
+    import filecmp
+    import fileinput
+    import fnmatch
+    import fractions
+    import ftplib
+    import functools
+    import gc
+    import getopt
+    import getpass
+    import gettext
+    import glob
+    import graphlib
+    import grp
+    import gzip
+    import hashlib
+    import heapq
+    import hmac
+    import html
+    import html.entities
+    import html.parser
+    import http
+    import http.client
+    import http.cookiejar
+    import http.cookies
+    import http.server
+    # import idlelib
+    import imaplib
+    # import imghdr
+    # import imp
+    import importlib
+    import importlib.metadata
+    import importlib.resources
+    import importlib.resources.abc
+    import importlib
+    import inspect
+    import io
+    import ipaddress
+    import itertools
+    import json
+    import keyword
+    import linecache
+    import locale
+    import logging
+    import logging.config
+    import logging.handlers
+    import lzma
+    import mailbox
+    # import mailcap
+    import marshal
+    import math
+    import mimetypes
+    import mmap
+    import modulefinder
+    # import msilib
+    # import msvcrt
+    import multiprocessing
+    import multiprocessing.shared_memory
+    import multiprocessing
+    import netrc
+    # import nis
+    # import nntplib
+    import numbers
+    import operator
+    import optparse
+    import os
+    import os.path
+    # import ossaudiodev
+    import pathlib
+    import pdb
+    import pickle
+    import pickletools
+    # import pipes
+    import pkgutil
+    import platform
+    import plistlib
+    import poplib
+    import posix
+    import pprint
+    import profile
+    import pty
+    import pwd
+    import py_compile
+    import pyclbr
+    import pydoc
+    import queue
+    import quopri
+    import random
+    import re
+    import readline
+    import reprlib
+    import resource
+    import rlcompleter
+    import runpy
+    import sched
+    import secrets
+    import select
+    import selectors
+    import shelve
+    import shlex
+    import shutil
+    import signal
+    import site
+    # import smtpd
+    import smtplib
+    # import sndhdr
+    import socket
+    import socketserver
+    # import spwd
+    import sqlite3
+    import ssl
+    import stat
+    import statistics
+    import string
+    import string.templatelib
+    import stringprep
+    import struct
+    import subprocess
+    # import sunau
+    import symtable
+    import sys
+    sys.monitoring
+    import sysconfig
+    import syslog
+    import tabnanny
+    import tarfile
+    # import telnetlib
+    import tempfile
+    import termios
+    import test
+    import textwrap
+    import threading
+    import time
+    import timeit
+    # import tkinter
+    # import tkinter.colorchooser
+    # import tkinter.dnd
+    # import tkinter.font
+    # import tkinter.messagebox
+    # import tkinter.scrolledtext
+    # import tkinter.ttk
+    import token
+    import tokenize
+    import tomllib
+    import trace
+    import traceback
+    import tracemalloc
+    import tty
+    # import turtle
+    import types
+    import typing
+    import unicodedata
+    import unittest
+    import unittest.mock
+    import urllib
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+    import urllib.robotparser
+    import site
+    # import uu
+    import uuid
+    import venv
+    import warnings
+    import wave
+    import weakref
+    import webbrowser
+    # import winreg
+    # import winsound
+    import wsgiref
+    # import xdrlib
+    import xml
+    import xml.dom
+    import xml.dom.minidom
+    import xml.dom.pulldom
+    import xml.etree.ElementTree
+    import pyexpat
+    import xml.sax
+    import xml.sax.handler
+    import xml.sax.saxutils
+    import xml.sax.xmlreader
+    import xmlrpc
+    import xmlrpc.client
+    import xmlrpc.server
+    import zipapp
+    import zipfile
+    import zipimport
+    import zlib
+    import zoneinfo
+
+
+
+if __name__ == "__main__":
+    check_json_loading()
+    check_html_escaping()
+    check_uuid_gen()
+    test_import_everything()

--- a/tests/spread/integration/python3/task.yaml
+++ b/tests/spread/integration/python3/task.yaml
@@ -10,5 +10,5 @@ execute: |
 
   rootfs="$(install-slices python3_${SLICE})"
 
-  cp ../python3.13/test_${SLICE}.py "${rootfs}/"
+  cp ../python3.14/test_${SLICE}.py "$rootfs"
   chroot "$rootfs" python3 /test_${SLICE}.py


### PR DESCRIPTION
# Proposed changes

forward port of python3.14 slices PR by @saengowp

this PR also adapts the more generic `python3` and `python3-minimal` slices to point at `python3.14` -- the default python for 26.04

## Related issues/PRs

- closes https://github.com/canonical/chisel-releases/issues/962
- unblocks https://github.com/canonical/chisel-releases/pull/936

### Forward porting

- https://github.com/canonical/chisel-releases/pull/751
- https://github.com/canonical/chisel-releases/pull/965 **(this PR)**

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)