### PR TITLE
feat(26.04): add libsasl2-modules slices

### DIFF
--- a/slices/libsasl2-modules.yaml
+++ b/slices/libsasl2-modules.yaml
@@ -1,0 +1,22 @@
+package: libsasl2-modules
+
+essential:
+  libsasl2-modules_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libssl3t64_libs:
+    contents:
+      /usr/lib/*-linux-*/sasl2/libanonymous.so*:
+      /usr/lib/*-linux-*/sasl2/libcrammd5.so*:
+      /usr/lib/*-linux-*/sasl2/libdigestmd5.so*:
+      /usr/lib/*-linux-*/sasl2/liblogin.so*:
+      /usr/lib/*-linux-*/sasl2/libntlm.so*:
+      /usr/lib/*-linux-*/sasl2/libplain.so*:
+      /usr/lib/*-linux-*/sasl2/libscram.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsasl2-modules/copyright:

--- a/slices/libsasl2-modules.yaml
+++ b/slices/libsasl2-modules.yaml
@@ -20,4 +20,4 @@ slices:
   copyright:
     contents:
       /usr/share/doc/libsasl2-modules/copyright:
-      
+

--- a/slices/libsasl2-modules.yaml
+++ b/slices/libsasl2-modules.yaml
@@ -20,4 +20,3 @@ slices:
   copyright:
     contents:
       /usr/share/doc/libsasl2-modules/copyright:
-

--- a/slices/libsasl2-modules.yaml
+++ b/slices/libsasl2-modules.yaml
@@ -20,3 +20,4 @@ slices:
   copyright:
     contents:
       /usr/share/doc/libsasl2-modules/copyright:
+      


### PR DESCRIPTION
# Proposed changes
This PR introduces Chisel slice definitions for `libsasl2-modules` targeting Ubuntu 26.04. It includes the necessary binary and configuration slices, along with a functional integration test.

Created `libsasl2-modules_libs` and `libsasl2-modules_copyright` slices.

As this are libraries, I have not added any tests.
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->