### PR TITLE
fix(24.04): base-files as essential of apparmor package

### DIFF
--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -2,6 +2,10 @@ package: apparmor
 
 essential:
   - apparmor_copyright
+  # Make sure base-files is extracted before any other slices of apparmor to
+  # to avoid creating /lib and /sbin directories instead of symlinks.
+  - base-files_lib
+  - base-files_bin
 
 slices:
   # Also relies on debconf, however it is solely used by install hook


### PR DESCRIPTION
# Proposed changes

`apparmor_extras` does not declare `base-files_lib` as an essential and install content under `/lib`. Given the way Chisel resolves dependencies and orders packages extraction, this lead to `apparmor` being extract before `base-files`, creating a `/lib` directory, preventing from successfully creating a symlink to `/usr/lib/` when `base-files` is extracted. A similar issue exists with `/usr/sbin`.

This results in `apparmor_extras` being unusable.

This is currently not detected by `chisel debug check-release-archives`. Fixes in Chisel are under considerations.

Several other packages are in a similar situation, except that with their name they are sorted **after** `base-files`, so the issue is not blocking their installation. 

This fix enforce `base-files_lib` and `base-files_bin` as essentials at the **package level**, forcing Chisel to extract `base-files` before `apparmor`.


### Forward porting

Later releases are not affected.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
