### PR TITLE
fix(26.04): update `libnode127` dependency

### DIFF
--- a/slices/libnode127.yaml
+++ b/slices/libnode127.yaml
@@ -14,7 +14,7 @@ slices:
       libllhttp9.3_libs:
       libnghttp2-14_libs:
       libsimdjson29_libs:
-      libsimdutf29_libs:
+      libsimdutf31_libs:
       libsqlite3-0_libs:
       libssl3t64_libs:
       libstdc++6_libs:

--- a/slices/libsimdutf31.yaml
+++ b/slices/libsimdutf31.yaml
@@ -1,7 +1,7 @@
-package: libsimdutf29
+package: libsimdutf31
 
 essential:
-  libsimdutf29_copyright:
+  libsimdutf31_copyright:
 
 slices:
   libs:
@@ -10,8 +10,8 @@ slices:
       libgcc-s1_libs:
       libstdc++6_libs:
     contents:
-      /usr/lib/*-linux-*/libsimdutf.so.29*:
+      /usr/lib/*-linux-*/libsimdutf.so.31*:
 
   copyright:
     contents:
-      /usr/share/doc/libsimdutf29/copyright:
+      /usr/share/doc/libsimdutf31/copyright:


### PR DESCRIPTION
# Proposed changes

update `libsimdutf` to fix `libnode`

installability tests are expected to fail for this PR

## Related issues/PRs
n/a

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
