### PR TITLE
fix(26.04): correct config in `php8.5-common`

### DIFF
--- a/slices/php8.5-common.yaml
+++ b/slices/php8.5-common.yaml
@@ -69,7 +69,7 @@ slices:
         { copy: /usr/share/php8.5-common/common/sysvshm.ini }
       /etc/php/8.5/mods-available/tokenizer.ini:
         { copy: /usr/share/php8.5-common/common/tokenizer.ini }
-      /usr/lib/php/8.5/php.ini-production:
+      /usr/lib/php/8.5/php.ini-production.cli:
 
   copyright:
     contents:


### PR DESCRIPTION
# Proposed changes

include the intended `/usr/lib/php/8.5/php.ini-production.cli` instead of `/usr/lib/php/8.5/php.ini-production`

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/959

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)