### PR TITLE
feat(26.04): update `xdg-user-dirs`

### DIFF
--- a/slices/xdg-user-dirs.yaml
+++ b/slices/xdg-user-dirs.yaml
@@ -19,7 +19,7 @@ slices:
       xdg-user-dirs_config:
     contents:
       /usr/bin/xdg-user-dir:
-  
+
   bins:
     essential:
       libc6_libs:

--- a/slices/xdg-user-dirs.yaml
+++ b/slices/xdg-user-dirs.yaml
@@ -14,9 +14,16 @@ slices:
 
   scripts:
     essential:
+      base-files_bin:
+      dash_bins:
       xdg-user-dirs_config:
     contents:
       /usr/bin/xdg-user-dir:
+  
+  bins:
+    essential:
+      libc6_libs:
+    contents:
       /usr/bin/xdg-user-dirs-update:
 
   copyright:

--- a/tests/spread/integration/xdg-user-dirs/task.yaml
+++ b/tests/spread/integration/xdg-user-dirs/task.yaml
@@ -1,8 +1,7 @@
 summary: Integration tests for xdg-user-dirs
 
-execute: |
-  rootfs="$(install-slices xdg-user-dirs_scripts)"
+variants:
+    - xdg-user-dirs-update
+    - xdg-user-dir
 
-  test -d ${rootfs}/etc/xdg/autostart
-  test -f ${rootfs}/etc/xdg/user-dirs.conf
-  test -f ${rootfs}/etc/xdg/user-dirs.defaults
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/xdg-user-dirs/test_xdg-user-dir.sh
+++ b/tests/spread/integration/xdg-user-dirs/test_xdg-user-dir.sh
@@ -4,3 +4,4 @@
 rootfs="$(install-slices xdg-user-dirs_scripts)"
 
 chroot "$rootfs" xdg-user-dir | grep -iqx '/root'
+

--- a/tests/spread/integration/xdg-user-dirs/test_xdg-user-dir.sh
+++ b/tests/spread/integration/xdg-user-dirs/test_xdg-user-dir.sh
@@ -4,4 +4,3 @@
 rootfs="$(install-slices xdg-user-dirs_scripts)"
 
 chroot "$rootfs" xdg-user-dir | grep -iqx '/root'
-

--- a/tests/spread/integration/xdg-user-dirs/test_xdg-user-dir.sh
+++ b/tests/spread/integration/xdg-user-dirs/test_xdg-user-dir.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#spellchecker: ignore rootfs
+
+rootfs="$(install-slices xdg-user-dirs_scripts)"
+
+chroot "$rootfs" xdg-user-dir | grep -iqx '/root'

--- a/tests/spread/integration/xdg-user-dirs/test_xdg-user-dirs-update.sh
+++ b/tests/spread/integration/xdg-user-dirs/test_xdg-user-dirs-update.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#spellchecker: ignore rootfs
+
+rootfs="$(install-slices xdg-user-dirs_bins)"
+
+chroot "$rootfs" xdg-user-dirs-update --help | grep -qi "usage: xdg-user-dirs-update"
+
+chroot "$rootfs" xdg-user-dirs-update --force --dummy-output /tmp/dummy_output --set DESKTOP /tmp/desktop
+test -f "$rootfs/tmp/dummy_output"
+grep -q "XDG_DESKTOP_DIR=\"/tmp/desktop\"" "$rootfs/tmp/dummy_output"
+grep -q "# This file is written by xdg-user-dirs-update" "$rootfs/tmp/dummy_output"


### PR DESCRIPTION
# Proposed changes

classify `xdg-user-dirs-update` as a bin. added tests for both `xdg-user-dirs-update` and `xdg-user-dir`.

## Related issues/PRs
n/a

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)