### PR TITLE
fix(24.04): add missing `apparmor` profiles

### DIFF
--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -133,6 +133,7 @@ slices:
       /etc/apparmor.d/abstractions/ssl_certs:
       /etc/apparmor.d/abstractions/ssl_keys:
       /etc/apparmor.d/abstractions/svn-repositories:
+      /etc/apparmor.d/abstractions/transmission-common:
       /etc/apparmor.d/abstractions/trash:
       /etc/apparmor.d/abstractions/ubuntu-bittorrent-clients:
       /etc/apparmor.d/abstractions/ubuntu-browsers:
@@ -173,6 +174,7 @@ slices:
       /etc/apparmor.d/abstractions/xad:
       /etc/apparmor.d/abstractions/xdg-desktop:
       /etc/apparmor.d/abstractions/xdg-open:
+      /etc/apparmor.d/balena-etcher:
       /etc/apparmor.d/brave:
       /etc/apparmor.d/buildah:
       /etc/apparmor.d/busybox:
@@ -188,6 +190,7 @@ slices:
       /etc/apparmor.d/evolution:
       /etc/apparmor.d/firefox:
       /etc/apparmor.d/flatpak:
+      /etc/apparmor.d/foliate:
       /etc/apparmor.d/geary:
       /etc/apparmor.d/github-desktop:
       /etc/apparmor.d/goldendict:
@@ -252,6 +255,7 @@ slices:
       /etc/apparmor.d/surfshark:
       /etc/apparmor.d/systemd-coredump:
       /etc/apparmor.d/thunderbird:
+      /etc/apparmor.d/transmission:
       /etc/apparmor.d/toybox:
       /etc/apparmor.d/trinity:
       /etc/apparmor.d/tunables/alias:
@@ -279,6 +283,7 @@ slices:
       /etc/apparmor.d/tunables/securityfs:
       /etc/apparmor.d/tunables/share:
       /etc/apparmor.d/tunables/sys:
+      /etc/apparmor.d/tunables/system:
       /etc/apparmor.d/tunables/xdg-user-dirs:
       /etc/apparmor.d/tunables/xdg-user-dirs.d/site.local:
         text: |
@@ -312,6 +317,7 @@ slices:
       /etc/apparmor.d/virtiofsd:
       /etc/apparmor.d/vivaldi-bin:
       /etc/apparmor.d/vpnns:
+      /etc/apparmor.d/wike:
       /etc/apparmor.d/wpcom:
       /var/cache/apparmor/:
 

--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -255,8 +255,8 @@ slices:
       /etc/apparmor.d/surfshark:
       /etc/apparmor.d/systemd-coredump:
       /etc/apparmor.d/thunderbird:
-      /etc/apparmor.d/transmission:
       /etc/apparmor.d/toybox:
+      /etc/apparmor.d/transmission:
       /etc/apparmor.d/trinity:
       /etc/apparmor.d/tunables/alias:
       /etc/apparmor.d/tunables/apparmorfs:


### PR DESCRIPTION
# Proposed changes

add missing profiles

## Related issues/PRs

- unblocks https://github.com/canonical/chisel-releases/pull/968

### Forward porting

- https://github.com/canonical/chisel-releases/pull/882
- _none missing from 25.10_
- https://github.com/canonical/chisel-releases/pull/987 **(this PR)**

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
