### PR TITLE
fix(26.04): add missing `apparmor` profiles

### DIFF
--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -43,6 +43,8 @@ slices:
       /etc/apparmor.d/Xorg:
       /etc/apparmor.d/abi/3.0:
       /etc/apparmor.d/abi/4.0:
+      /etc/apparmor.d/abi/4.0-ip:
+      /etc/apparmor.d/abi/5.0:
       /etc/apparmor.d/abi/kernel-5.4-outoftree-network:
       /etc/apparmor.d/abi/kernel-5.4-vanilla:
       /etc/apparmor.d/abstractions/X:
@@ -54,6 +56,7 @@ slices:
       /etc/apparmor.d/abstractions/apparmor_api/is_enabled:
       /etc/apparmor.d/abstractions/aspell:
       /etc/apparmor.d/abstractions/audio:
+      /etc/apparmor.d/abstractions/authd:
       /etc/apparmor.d/abstractions/authentication:
       /etc/apparmor.d/abstractions/base:
       /etc/apparmor.d/abstractions/bash:
@@ -84,6 +87,7 @@ slices:
       /etc/apparmor.d/abstractions/gio-open:
       /etc/apparmor.d/abstractions/gnome:
       /etc/apparmor.d/abstractions/gnupg:
+      /etc/apparmor.d/abstractions/golang:
       /etc/apparmor.d/abstractions/groff:
       /etc/apparmor.d/abstractions/gtk:
       /etc/apparmor.d/abstractions/gvfs-open:
@@ -115,6 +119,7 @@ slices:
       /etc/apparmor.d/abstractions/opencl-mesa:
       /etc/apparmor.d/abstractions/opencl-nvidia:
       /etc/apparmor.d/abstractions/opencl-pocl:
+      /etc/apparmor.d/abstractions/opengl:
       /etc/apparmor.d/abstractions/openssl:
       /etc/apparmor.d/abstractions/orbit2:
       /etc/apparmor.d/abstractions/p11-kit:


### PR DESCRIPTION
# Proposed changes

add missing profiles

## Related issues/PRs
n/a

### Forward porting

- https://github.com/canonical/chisel-releases/pull/988 **(this PR)**
- _none missing from 25.10_
- https://github.com/canonical/chisel-releases/pull/987

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
