### PR TITLE
feat(26.04): cherrypick `sensible-utils` and `ucf` slice renames

### DIFF
--- a/slices/sensible-utils.yaml
+++ b/slices/sensible-utils.yaml
@@ -4,7 +4,7 @@ essential:
   sensible-utils_copyright:
 
 slices:
-  bins:
+  scripts:
     contents:
       /usr/bin/select-editor:
       /usr/bin/sensible-browser:

--- a/slices/ucf.yaml
+++ b/slices/ucf.yaml
@@ -6,9 +6,9 @@ essential:
 # Uses /usr/share/ucf/ucf_helper_functions.sh for some debhelper functions
 # during install and removal.
 slices:
-  bins:
+  scripts:
     essential:
-      sensible-utils_bins:
+      sensible-utils_scripts:
     contents:
       /usr/bin/ucf:
       /usr/bin/ucfq:


### PR DESCRIPTION
# Proposed changes

rename slice names from `bins` to `scripts`. this PR does not include any additional tests but is just a fastforward of the braking changes from https://github.com/canonical/chisel-releases/pull/985

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/985

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
