### PR TITLE
fix(26.04): add missing libxres1 dependency for libatspi2.0-0t64

### DIFF
--- a/slices/libatspi2.0-0t64.yaml
+++ b/slices/libatspi2.0-0t64.yaml
@@ -11,6 +11,7 @@ slices:
       libglib2.0-0t64_core:
       libx11-6_libs:
       libxi6_libs:
+      libxres1_libs:
     contents:
       /usr/lib/*-linux-*/libatspi.so.0*:
 

--- a/slices/libxres1.yaml
+++ b/slices/libxres1.yaml
@@ -1,0 +1,17 @@
+package: libxres1
+
+essential:
+  libxres1_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libx11-6_libs:
+      libxext6_libs:
+    contents:
+      /usr/lib/*-linux-*/libXRes.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxres1/copyright:


### PR DESCRIPTION
# Proposed changes

[libatspi2.0-0t64](https://packages.ubuntu.com/resolute/libatspi2.0-0t64) in ubuntu 26.04 recently added a dependency to libxres1 which is missing in chisel and causes applications linked against libatspi2.0 to crash on startup.

<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

## Related issues/PRs

Related to #907 . This used to work in the PR, but the libxres1 dependency was added after the PR was merged.

There is also an open test PR for this, see #923 .

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

This only affects 26.04.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context
<!-- If relevant -->