### PR TITLE
test(26.04): expand systemd slice coverage

### DIFF
--- a/tests/spread/integration/systemd/task.yaml
+++ b/tests/spread/integration/systemd/task.yaml
@@ -4,5 +4,7 @@ variants:
     - standard
     - detect-virt
     - run0
+    - control
+    - observability
 
 execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/systemd/test_control.sh
+++ b/tests/spread/integration/systemd/test_control.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#spellchecker: ignore rootfs hostnamectl localectl timedatectl loginctl
+
+rootfs="$(install-slices \
+  systemd_hostname \
+  systemd_locale \
+  systemd_login \
+  systemd_timedate)"
+
+commands=(
+  hostnamectl
+  localectl
+  timedatectl
+  loginctl
+)
+
+for command in "${commands[@]}"; do
+  chroot "$rootfs" "/usr/bin/$command" --help 2>&1 | grep -Fiq "$command"
+  chroot "$rootfs" "/usr/bin/$command" --version 2>&1 | grep -Fiq "systemd"
+done

--- a/tests/spread/integration/systemd/test_observability.sh
+++ b/tests/spread/integration/systemd/test_observability.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#spellchecker: ignore rootfs journalctl networkctl
+
+rootfs="$(install-slices \
+  systemd_journal \
+  systemd_network)"
+
+chroot "$rootfs" /usr/bin/journalctl --help 2>&1 | grep -Fiq "journalctl"
+chroot "$rootfs" /usr/bin/journalctl --version 2>&1 | grep -Fiq "systemd"
+chroot "$rootfs" /usr/bin/journalctl --list-boots 2>&1 | grep -Fiq "no journal files"
+
+chroot "$rootfs" /usr/bin/networkctl --help 2>&1 | grep -Fiq "networkctl"
+chroot "$rootfs" /usr/bin/networkctl --version 2>&1 | grep -Fiq "systemd"
+chroot "$rootfs" /usr/bin/networkctl list 2>&1 | grep -Fiq "failed to connect system bus"

--- a/tests/spread/integration/systemd/test_observability.sh
+++ b/tests/spread/integration/systemd/test_observability.sh
@@ -11,4 +11,4 @@ chroot "$rootfs" /usr/bin/journalctl --list-boots 2>&1 | grep -Fiq "no journal f
 
 chroot "$rootfs" /usr/bin/networkctl --help 2>&1 | grep -Fiq "networkctl"
 chroot "$rootfs" /usr/bin/networkctl --version 2>&1 | grep -Fiq "systemd"
-chroot "$rootfs" /usr/bin/networkctl list 2>&1 | grep -Fiq "failed to connect system bus"
+chroot "$rootfs" /usr/bin/networkctl list 2>&1 | grep -Eiq "connect.*bus|bus.*connect"


### PR DESCRIPTION
# Proposed changes

Adds two spread variants to improve coverage for the systemd slices split out in #878.

The new `control` variant exercises the hostname, locale, login, and timedate helper slices by checking their command metadata in a chroot. The new `observability` variant covers the journal and network slices with help/version checks plus expected behavior when no journal files or system bus are present.

## Related issues/PRs

Related to #989. This is intended as a first coverage increment, not complete closure of the issue.

### Forward porting

Not applicable: this test targets the `ubuntu-26.04` systemd split.

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [ ] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Local checks run:

- `bash -n tests/spread/integration/systemd/test_*.sh`
- parsed `tests/spread/integration/systemd/task.yaml` with Python/YAML
- `git diff --check`
