### PR TITLE
fix: revoke needless perms

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -120,8 +120,6 @@ jobs:
     if: ${{ needs.spread-tests.outputs.tests-conclusion == 'success' }}
     env:
       main-branch-path: files-from-main
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Proposed changes

revoke needless permissions from spread.yaml workflow. partially fixes https://github.com/canonical/chisel-releases/issues/1009. this workflow just uploads the pr comment as job artefact, not actually post the comment itself. pr-comment posting is still blocked, but at least the actions are running. tested in https://github.com/canonical/chisel-releases/issues/1008 (in last commits, now reverted)

## Related issues/PRs

### Forward porting

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)