### PR TITLE
ci(22.04): backport lxd launch update

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -25,9 +25,18 @@ backends:
       # but that would effectively change the host's LXC configurations.
 
       echo "Allocating $SPREAD_SYSTEM..."
-      lxc launch --ephemeral ubuntu:$release $SPREAD_SYSTEM
-      until lxc exec $SPREAD_SYSTEM -- systemctl status | grep "running"
-      do
+      lxc launch --ephemeral ubuntu:$release $SPREAD_SYSTEM || launch_rc=$?
+
+      if [ -n "${launch_rc-}" ]; then
+        FATAL "Failed to launch LXD instance for release $release"
+      fi
+
+      while true; do
+        status=$(lxc exec $SPREAD_SYSTEM -- systemctl is-system-running || true)
+        [ "$status" = "running" ] && break
+        if [ "$status" = "degraded" ]; then
+          FATAL "System is degraded, aborting"
+        fi
         sleep 5
       done
       lxc exec $SPREAD_SYSTEM -- apt-get update


### PR DESCRIPTION
# Proposed changes

improve the launch of text lxd machine. only relevant changes from https://github.com/canonical/chisel-releases/pull/1001 have been backported.

- use [`FATAL`](https://github.com/canonical/spread#Functions) to fail fast when lxd launch fails
- detect `degraded` status and, likewise, fail fast

## Related issues/PRs

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1001
- https://github.com/canonical/chisel-releases/pull/1008
- https://github.com/canonical/chisel-releases/pull/1012
- https://github.com/canonical/chisel-releases/pull/1013 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1014


## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)