### PR TITLE
fix(26.04): add missing dependency to libnode127

### DIFF
--- a/slices/libada-url0-3.yaml
+++ b/slices/libada-url0-3.yaml
@@ -1,0 +1,15 @@
+package: libada-url0-3
+
+essential:
+  libada-url0-3_copyright:
+
+slices:
+  libs:
+    essential:
+      libada-url0-3_libs:
+    contents:
+      /usr/lib/*-linux-*/libada-url0.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libada-url0-3/copyright:

--- a/slices/libada-url0-3.yaml
+++ b/slices/libada-url0-3.yaml
@@ -6,7 +6,10 @@ essential:
 slices:
   libs:
     essential:
-      libada-url0-3_libs:
+      libc6_libs:
+      libgcc-s1_libs:
+      libsimduft31_libs:
+      libstdc++6_libs:
     contents:
       /usr/lib/*-linux-*/libada-url0.so.3*:
 

--- a/slices/libada-url0-3.yaml
+++ b/slices/libada-url0-3.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_libs:
       libgcc-s1_libs:
-      libsimduft31_libs:
+      libsimdutf31_libs:
       libstdc++6_libs:
     contents:
       /usr/lib/*-linux-*/libada-url0.so.3*:

--- a/slices/libnode127.yaml
+++ b/slices/libnode127.yaml
@@ -6,6 +6,7 @@ essential:
 slices:
   libs:
     essential:
+      libada-url0-3_libs:
       libbrotli1_libs:
       libc6_libs:
       libcares2_libs:


### PR DESCRIPTION
# Proposed changes
Add missing libnode127 dependency

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
