### PR TITLE
fix(26.04): reset-failed call in lxd launch

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -49,6 +49,7 @@ backends:
       # See https://github.com/canonical/lxd/issues/16860
       if [ "$release" = "resolute" ]; then
         lxc exec $SPREAD_SYSTEM -q -- systemctl mask --now console-getty.service || true
+        lxc exec $SPREAD_SYSTEM -q -- systemctl reset-failed console-getty.service || true
       fi
 
       while true; do

--- a/spread.yaml
+++ b/spread.yaml
@@ -55,8 +55,8 @@ backends:
           # mask actually takes effect, then clear the failed unit so the
           # degraded state resolves. Anything else degraded is still fatal.
           if [ "$release" = "resolute" ]; then
-            lxc exec $SPREAD_SYSTEM -q -- systemctl mask --now console-getty.service || true
-            lxc exec $SPREAD_SYSTEM -q -- systemctl reset-failed console-getty.service || true
+            lxc exec $SPREAD_SYSTEM -q -- systemctl mask --now console-getty.service
+            lxc exec $SPREAD_SYSTEM -q -- systemctl reset-failed console-getty.service
             status=$(lxc exec $SPREAD_SYSTEM -- systemctl is-system-running 2>/dev/null || true)
             [ "$status" = "running" ] && break
           fi

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,19 +44,23 @@ backends:
         FATAL "Failed to launch LXD instance for release $release"
       fi
 
-      # Workaround for systemd 258+ regression where console-getty.service
-      # fails on container boot, leaving the system in 'degraded' state.
-      # See https://github.com/canonical/lxd/issues/16860
-      if [ "$release" = "resolute" ]; then
-        lxc exec $SPREAD_SYSTEM -q -- systemctl mask --now console-getty.service || true
-        lxc exec $SPREAD_SYSTEM -q -- systemctl reset-failed console-getty.service || true
-      fi
-
       while true; do
-        status=$(lxc exec $SPREAD_SYSTEM -- systemctl is-system-running || true)
+        status=$(lxc exec $SPREAD_SYSTEM -- systemctl is-system-running 2>/dev/null || true)
         [ "$status" = "running" ] && break
         if [ "$status" = "degraded" ]; then
-          FATAL "System is degraded, aborting"
+          # Workaround for systemd 258+ regression where console-getty.service
+          # fails on container boot, leaving the system in 'degraded' state.
+          # See https://github.com/canonical/lxd/issues/16860
+          # Mask here (not right after launch) so the system bus is up and the
+          # mask actually takes effect, then clear the failed unit so the
+          # degraded state resolves. Anything else degraded is still fatal.
+          if [ "$release" = "resolute" ]; then
+            lxc exec $SPREAD_SYSTEM -q -- systemctl mask --now console-getty.service || true
+            lxc exec $SPREAD_SYSTEM -q -- systemctl reset-failed console-getty.service || true
+            status=$(lxc exec $SPREAD_SYSTEM -- systemctl is-system-running 2>/dev/null || true)
+            [ "$status" = "running" ] && break
+          fi
+          FATAL "System is '$status', aborting"
         fi
         sleep 5
       done


### PR DESCRIPTION
# Proposed changes

quick follow up from https://github.com/canonical/chisel-releases/pull/1001. masking *works* fine and *is needed* but we also want to then clear the degraded status. `systemctl reset-failed console-getty.service` is a noop if not `degraded`.

edit: found a better fix with @alesancor1 . tldr; we also need to wait for the dbus of the lxd to launch before masking.

proof!: https://github.com/canonical/chisel-releases/actions/runs/26628698993/job/78471814070?pr=993

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/1001

### Forward porting

n/a, also no backports needed

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
