### PR TITLE
fix(ci): pin `typer<0.26` for validate-hints workflow

### DIFF
--- a/.github/scripts/validate-hints/requirements.txt
+++ b/.github/scripts/validate-hints/requirements.txt
@@ -1,3 +1,6 @@
 spacy>=3.0.0
+# spacy pulls typer (typer<1.0.0,>=0.3.0); typer>=0.26 dropped click,
+# but spacy 3.7.5 still imports click via cli/_util.py -- pin below 0.26
+typer<0.26
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 pyyaml>=5.0.0


### PR DESCRIPTION
# Proposed changes

typer 0.26 dropped click as a hard dep, but spacy 3.7.5 still imports click eagerly via cli/_util.py, breaking validate_hints.py with ModuleNotFoundError: No module named 'click'.

with pinned version and same python as the validate hints workflow it works:

```bash
$ uv run --python 3.12 --with 'spacy==3.7.5' --with 'typer==0.25.1' --no-project python -c 'import click; print("click", click.__version__); import spacy; print("spacy", spacy.__version__)'
<string>:1: DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Click 9.1. Use feature detection or 'importlib.metadata.version("click")' instead.
click 8.4.1
spacy 3.7.5
```

with next `typer` v: 

```bash
$ uv run --python 3.12 --with 'spacy==3.7.5' --with 'typer==0.26.0' --no-project python -c 'import spacy'
Installed 41 packages in 65ms
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/marcin/Library/Caches/uv/archive-v0/xohS1ajSaAcJAkWI/lib/python3.12/site-packages/spacy/__init__.py", line 16, in <module>
    from .cli.info import info  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/marcin/Library/Caches/uv/archive-v0/xohS1ajSaAcJAkWI/lib/python3.12/site-packages/spacy/cli/__init__.py", line 4, in <module>
    from . import download as download_module  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/marcin/Library/Caches/uv/archive-v0/xohS1ajSaAcJAkWI/lib/python3.12/site-packages/spacy/cli/download.py", line 19, in <module>
    from ._util import SDIST_SUFFIX, WHEEL_SUFFIX, Arg, Opt, app
  File "/Users/marcin/Library/Caches/uv/archive-v0/xohS1ajSaAcJAkWI/lib/python3.12/site-packages/spacy/cli/_util.py", line 22, in <module>
    from click import NoSuchOption
ModuleNotFoundError: No module named 'click'
```

## Related issues/PRs

- unblocks #993 

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
