### PR TITLE
feat(26.04): golang 1.26

### DIFF
--- a/slices/golang-1.26-go.yaml
+++ b/slices/golang-1.26-go.yaml
@@ -1,0 +1,102 @@
+package: golang-1.26-go
+
+essential:
+  golang-1.26-go_copyright:
+
+slices:
+  # Note: The minimal slice provides a working Go installation
+  #       that can be used to build and run simple Go programs,
+  #       such as a "Hello World" program.
+  #       See tests/spread/integration/golang-1.26-go/test_minimal.sh
+  #       for more details.
+  minimal:
+    essential:
+      base-files_tmp:
+      golang-1.26-go_build-tools:
+      golang-1.26-go_headers:
+      golang-1.26-go_symlinks:
+      golang-1.26-src_src-with-tests:
+    contents:
+      /usr/lib/go-1.26/bin/go:
+      /usr/lib/go-1.26/bin/gofmt:
+
+  # Note: The core slice provides the source code within the golang-1.26-go
+  #       package in addition to the minimal slice.
+  core:
+    essential:
+      golang-1.26-go_cmd-src:
+      golang-1.26-go_go-env:
+      golang-1.26-go_internal-src:
+      golang-1.26-go_minimal:
+      golang-1.26-go_runtime-src:
+      golang-1.26-go_time-src:
+
+  # Note: The build-tools slice provides the essential Go tools for building
+  #       a minimal Go program, i.e., a single Hello World program.
+  build-tools:
+    contents:
+      /usr/lib/go-1.26/pkg/tool/linux_*/asm:
+      /usr/lib/go-1.26/pkg/tool/linux_*/compile:
+      /usr/lib/go-1.26/pkg/tool/linux_*/link:
+      # vet is used for go test
+      /usr/lib/go-1.26/pkg/tool/linux_*/vet:
+
+  cgo-tools:
+    essential:
+      gcc_gcc:
+      libc6-dev_core:
+      libc6-dev_libresolv:
+      libc6-dev_runtime:
+    contents:
+      /usr/lib/go-1.26/pkg/tool/linux_*/cgo:
+
+  cmd-src:
+    contents:
+      /usr/share/go-1.26/src/cmd/cgo/zdefaultcc.go:
+      /usr/share/go-1.26/src/cmd/go/internal/cfg/zdefaultcc.go:
+      /usr/share/go-1.26/src/cmd/internal/objabi/zbootstrap.go:
+
+  fix-tools:
+    contents:
+      /usr/lib/go-1.26/pkg/tool/linux_*/fix:
+
+  go-env:
+    contents:
+      /usr/lib/go-1.26/go.env:
+
+  headers:
+    contents:
+      /usr/share/go-1.26/pkg/include/*.h:
+
+  internal-src:
+    contents:
+      /usr/share/go-1.26/src/internal/buildcfg/zbootstrap.go:
+
+  profiling-tools:
+    contents:
+      /usr/lib/go-1.26/pkg/tool/linux_*/preprofile:
+
+  runtime-src:
+    contents:
+      /usr/share/go-1.26/src/internal/runtime/sys/zversion.go:
+
+  symlinks:
+    contents:
+      /usr/lib/go-1.26/api:      # Symlink to ../share/go-1.26/api
+      /usr/lib/go-1.26/lib:      # Symlink to ../share/go-1.26/lib
+      /usr/lib/go-1.26/misc:     # Symlink to ../share/go-1.26/misc
+      /usr/lib/go-1.26/pkg/include:  # Symlink to ../share/go-1.26/pkg/include
+      /usr/lib/go-1.26/src:      # Symlink to ../share/go-1.26/src
+      /usr/lib/go-1.26/test:     # Symlink to ../share/go-1.26/test
+
+  testing-tools:
+    contents:
+      /usr/lib/go-1.26/pkg/tool/linux_*/cover:
+
+  time-src:
+    contents:
+      /usr/share/go-1.26/src/time/tzdata/zzipdata.go:
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-1.26-go/copyright:

--- a/slices/golang-1.26-src.yaml
+++ b/slices/golang-1.26-src.yaml
@@ -187,8 +187,8 @@ slices:
       /usr/share/go-1.26/src/runtime/**.s:
       /usr/share/go-1.26/src/runtime/*.go:
       /usr/share/go-1.26/src/runtime/*.py:
-      /usr/share/go-1.26/src/runtime/_mkmalloc/**:
       /usr/share/go-1.26/src/runtime/Makefile:
+      /usr/share/go-1.26/src/runtime/_mkmalloc/**:
       /usr/share/go-1.26/src/runtime/a*/**:
       /usr/share/go-1.26/src/runtime/c*/**:
       /usr/share/go-1.26/src/runtime/d*/**:
@@ -215,7 +215,6 @@ slices:
     essential:
       bash_bins:
       binutils_linker:
-      # TODO: Include binutils-${ARCH_TRIPLET}_loader as well.
       coreutils_bins:
       grep_bins:
     contents:

--- a/slices/golang-1.26-src.yaml
+++ b/slices/golang-1.26-src.yaml
@@ -1,0 +1,261 @@
+package: golang-1.26-src
+
+essential:
+  golang-1.26-src_copyright:
+
+slices:
+  # Note: This slice contains the source code of Go 1.26 as well as the tests.
+  # Due to Go's project layout convention, we cannot split the source code
+  # easily without Chisel's support for negative wildcards.
+  # To exclude the tests and test data, a command should be run after cutting
+  # this slice:
+  # find ${rootfs} -depth \( \
+  #    -name '*_test.go' -o \
+  #    \( -type d -name 'testdata' \) -o \
+  #    \( -type d -path '*/go-1.26/test' \) -o \
+  #    \( -type d -path '*/src/internal/testenv' \) -o \
+  #    \( -type d -path '*/src/internal/testpty' \) -o \
+  #    \( -type d -path '*/src/internal/testhash' \) -o \
+  #    \( -type d -path '*/src/internal/cgrouptest' \) -o \
+  #    \( -type d -path '*/src/internal/obscuretestdata' \) -o \
+  #    \( -type d -path '*/src/internal/coverage/test' \) -o \
+  #    \( -type d -path '*/src/internal/runtime/startlinetest' \) -o \
+  #    \( -type d -path '*/src/internal/runtime/wasitest' \) -o \
+  #    \( -type d -path '*/src/internal/trace/internal/testgen' \) -o \
+  #    \( -type d -path '*/src/internal/trace/testtrace' \) -o \
+  #    \( -type d -path '*/src/net/internal/cgotest' \) -o \
+  #    \( -type d -path '*/src/net/internal/socktest' \) -o \
+  #    \( -type d -path '*/src/os/exec/internal/fdtest' \) -o \
+  #    \( -type d -path '*/src/net/http/internal/testcert' \) -o \
+  #    \( -type d -path '*/src/crypto/internal/cryptotest' \) -o \
+  #    \( -type d -path '*/src/crypto/internal/fips140/check/checktest' \) -o \
+  #    \( -type d -path '*/src/crypto/internal/fips140test' \) -o \
+  #    \( -type d -path '*/src/crypto/mlkem/mlkemtest' \) -o \
+  #    \( -type d -path '*/src/embed/internal/embedtest' \) -o \
+  #    \( -type d -path '*/src/vendor/golang.org/x/net/nettest' \) \
+  #    \) -exec rm -rf {} +
+  src-with-tests:
+    essential:
+      golang-1.26-src_api:
+      golang-1.26-src_libs:
+    contents:
+      # Note: Some paths are explicitly listed to avoid conflicts with
+      # the paths defined in golang-1.26-go.
+      # src/cmd/** conflicts with
+      #   src/cmd/cgo/zdefaultcc.go
+      #   src/cmd/go/internal/cfg/zdefaultcc.go
+      #   src/cmd/internal/objabi/zbootstrap.go
+      # src/internal/** conflicts with
+      #   src/internal/buildcfg/zbootstrap.go
+      #   src/internal/runtime/sys/zversion.go
+      # src/time/** conflicts with
+      #   src/time/tzdata/zzipdata.go
+      /usr/share/go-1.26/misc/**:
+      /usr/share/go-1.26/src/Make.dist:
+      /usr/share/go-1.26/src/a*/**:
+      /usr/share/go-1.26/src/b*/**:
+      /usr/share/go-1.26/src/cmd/a*/**:
+      /usr/share/go-1.26/src/cmd/b*/**:
+      /usr/share/go-1.26/src/cmd/cgo/a*.go:
+      /usr/share/go-1.26/src/cmd/cgo/doc.go:
+      /usr/share/go-1.26/src/cmd/cgo/g*.go:
+      /usr/share/go-1.26/src/cmd/cgo/internal/**:
+      /usr/share/go-1.26/src/cmd/cgo/main.go:
+      /usr/share/go-1.26/src/cmd/cgo/out.go:
+      /usr/share/go-1.26/src/cmd/cgo/util.go:
+      /usr/share/go-1.26/src/cmd/co*/**:
+      /usr/share/go-1.26/src/cmd/d*/**:
+      /usr/share/go-1.26/src/cmd/f*/**:
+      /usr/share/go-1.26/src/cmd/go.mod:
+      /usr/share/go-1.26/src/cmd/go.sum:
+      /usr/share/go-1.26/src/cmd/go/*.go:
+      /usr/share/go-1.26/src/cmd/go/internal/a*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/b*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/ca*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/cfg/bench_test.go:
+      /usr/share/go-1.26/src/cmd/go/internal/cfg/cfg.go:
+      /usr/share/go-1.26/src/cmd/go/internal/cl*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/cm*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/d*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/e*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/f*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/g*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/h*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/i*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/l*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/m*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/r*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/s*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/t*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/v*/**:
+      /usr/share/go-1.26/src/cmd/go/internal/w*/**:
+      /usr/share/go-1.26/src/cmd/go/t*/**:
+      /usr/share/go-1.26/src/cmd/gof*/**:
+      /usr/share/go-1.26/src/cmd/internal/a*/**:
+      /usr/share/go-1.26/src/cmd/internal/b*/**:
+      /usr/share/go-1.26/src/cmd/internal/c*/**:
+      /usr/share/go-1.26/src/cmd/internal/d*/**:
+      /usr/share/go-1.26/src/cmd/internal/e*/**:
+      /usr/share/go-1.26/src/cmd/internal/f*/**:
+      /usr/share/go-1.26/src/cmd/internal/g*/**:
+      /usr/share/go-1.26/src/cmd/internal/h*/**:
+      /usr/share/go-1.26/src/cmd/internal/m*/**:
+      /usr/share/go-1.26/src/cmd/internal/obj/**:
+      /usr/share/go-1.26/src/cmd/internal/objabi/a*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/f*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/h*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/l*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/p*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/r*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/s*:
+      /usr/share/go-1.26/src/cmd/internal/objabi/u*:
+      /usr/share/go-1.26/src/cmd/internal/objfile/*.go:
+      /usr/share/go-1.26/src/cmd/internal/os*/**:
+      /usr/share/go-1.26/src/cmd/internal/p*/**:
+      /usr/share/go-1.26/src/cmd/internal/q*/**:
+      /usr/share/go-1.26/src/cmd/internal/r*/**:
+      /usr/share/go-1.26/src/cmd/internal/s*/**:
+      /usr/share/go-1.26/src/cmd/internal/t*/**:
+      /usr/share/go-1.26/src/cmd/l*/**:
+      /usr/share/go-1.26/src/cmd/n*/**:
+      /usr/share/go-1.26/src/cmd/o*/**:
+      /usr/share/go-1.26/src/cmd/p*/**:
+      /usr/share/go-1.26/src/cmd/r*/**:
+      /usr/share/go-1.26/src/cmd/t*/**:
+      /usr/share/go-1.26/src/cmd/v*/**:
+      /usr/share/go-1.26/src/cmp/**:
+      /usr/share/go-1.26/src/co*/**:
+      /usr/share/go-1.26/src/crypto/**:
+      /usr/share/go-1.26/src/d*/**:
+      /usr/share/go-1.26/src/e*/**:
+      /usr/share/go-1.26/src/f*/**:
+      /usr/share/go-1.26/src/go.mod:
+      /usr/share/go-1.26/src/go.sum:
+      /usr/share/go-1.26/src/go/**:
+      /usr/share/go-1.26/src/h*/**:
+      /usr/share/go-1.26/src/im*/**:
+      /usr/share/go-1.26/src/ind*/**:
+      /usr/share/go-1.26/src/internal/a*/**:
+      /usr/share/go-1.26/src/internal/bi*/**:
+      /usr/share/go-1.26/src/internal/buildcfg/c*:
+      /usr/share/go-1.26/src/internal/buildcfg/e*:
+      /usr/share/go-1.26/src/internal/by*/**:
+      /usr/share/go-1.26/src/internal/c*/**:
+      /usr/share/go-1.26/src/internal/d*/**:
+      /usr/share/go-1.26/src/internal/e*/**:
+      /usr/share/go-1.26/src/internal/f*/**:
+      /usr/share/go-1.26/src/internal/g*/**:
+      /usr/share/go-1.26/src/internal/l*/**:
+      /usr/share/go-1.26/src/internal/m*/**:
+      /usr/share/go-1.26/src/internal/n*/**:
+      /usr/share/go-1.26/src/internal/o*/**:
+      /usr/share/go-1.26/src/internal/p*/**:
+      /usr/share/go-1.26/src/internal/ra*/**:
+      /usr/share/go-1.26/src/internal/re*/**:
+      /usr/share/go-1.26/src/internal/ro*/**:
+      /usr/share/go-1.26/src/internal/runtime/a*/**:
+      /usr/share/go-1.26/src/internal/runtime/c*/**:
+      /usr/share/go-1.26/src/internal/runtime/e*/**:
+      /usr/share/go-1.26/src/internal/runtime/g*/**:
+      /usr/share/go-1.26/src/internal/runtime/m*/**:
+      /usr/share/go-1.26/src/internal/runtime/p*/**:
+      /usr/share/go-1.26/src/internal/runtime/st*/**:
+      /usr/share/go-1.26/src/internal/runtime/sys/c*:
+      /usr/share/go-1.26/src/internal/runtime/sys/d*:
+      /usr/share/go-1.26/src/internal/runtime/sys/e*:
+      /usr/share/go-1.26/src/internal/runtime/sys/i*:
+      /usr/share/go-1.26/src/internal/runtime/sys/n*:
+      /usr/share/go-1.26/src/internal/runtime/sys/s*:
+      /usr/share/go-1.26/src/internal/runtime/sysc*/**:
+      /usr/share/go-1.26/src/internal/runtime/w*/**:
+      /usr/share/go-1.26/src/internal/s*/**:
+      /usr/share/go-1.26/src/internal/t*/**:
+      /usr/share/go-1.26/src/internal/u*/**:
+      /usr/share/go-1.26/src/internal/x*/**:
+      /usr/share/go-1.26/src/internal/z*/**:
+      /usr/share/go-1.26/src/io*/**:
+      /usr/share/go-1.26/src/it*/**:
+      /usr/share/go-1.26/src/l*/**:
+      /usr/share/go-1.26/src/m*/**:
+      /usr/share/go-1.26/src/n*/**:
+      /usr/share/go-1.26/src/o*/**:
+      /usr/share/go-1.26/src/p*/**:
+      /usr/share/go-1.26/src/re*/**:
+      /usr/share/go-1.26/src/runtime/**.S:
+      /usr/share/go-1.26/src/runtime/**.c:
+      /usr/share/go-1.26/src/runtime/**.h:
+      /usr/share/go-1.26/src/runtime/**.s:
+      /usr/share/go-1.26/src/runtime/*.go:
+      /usr/share/go-1.26/src/runtime/*.py:
+      /usr/share/go-1.26/src/runtime/_mkmalloc/**:
+      /usr/share/go-1.26/src/runtime/Makefile:
+      /usr/share/go-1.26/src/runtime/a*/**:
+      /usr/share/go-1.26/src/runtime/c*/**:
+      /usr/share/go-1.26/src/runtime/d*/**:
+      /usr/share/go-1.26/src/runtime/m*/**:
+      /usr/share/go-1.26/src/runtime/p*/**:
+      /usr/share/go-1.26/src/runtime/r*/**:
+      /usr/share/go-1.26/src/runtime/s*/**:
+      /usr/share/go-1.26/src/runtime/t*/**:
+      /usr/share/go-1.26/src/s*/**:
+      /usr/share/go-1.26/src/te*/**:
+      /usr/share/go-1.26/src/time/*.go:
+      /usr/share/go-1.26/src/time/te*/**:
+      /usr/share/go-1.26/src/time/tzdata/tzdata.go:
+      /usr/share/go-1.26/src/u*/**:
+      /usr/share/go-1.26/src/v*/**:
+      /usr/share/go-1.26/src/w*/**:
+      /usr/share/go-1.26/test/**:
+
+  api:
+    contents:
+      /usr/share/go-1.26/api/*.txt:
+
+  bash-scripts:
+    essential:
+      bash_bins:
+      binutils_linker:
+      # TODO: Include binutils-${ARCH_TRIPLET}_loader as well.
+      coreutils_bins:
+      grep_bins:
+    contents:
+      /usr/share/go-1.26/src/all.bash:
+      /usr/share/go-1.26/src/bootstrap.bash:
+      /usr/share/go-1.26/src/buildall.bash:
+      /usr/share/go-1.26/src/clean.bash:
+      /usr/share/go-1.26/src/cmp.bash:
+      /usr/share/go-1.26/src/make.bash:
+      /usr/share/go-1.26/src/race.bash:
+      /usr/share/go-1.26/src/run.bash:
+
+  # The script goreposum.py is used by the codehost package
+  # usr/share/go-1.26/src/cmd/go/internal/modfetch/codehost/vcs.go
+  # as an extension passed to the `hg` command.
+  # This is deliberately kept out from the slice `src-with-tests` and left
+  # unsupported with empty essential, in the consideration of the rare usage of
+  # Mercurial VCS, and that it would otherwise bring in the dependencies of
+  # `mercurial` and `python3`, which are not needed to build Go applications.
+  hg-tools:
+    hint: Unsupported extension for Mercurial VCS
+    contents:
+      /usr/share/go-1.26/lib/hg/goreposum.py:
+
+  libs:
+    essential:
+      bash_bins:
+      coreutils_bins:
+      make_bins:
+    contents:
+      /usr/share/go-1.26/lib/fips140/Makefile:
+      /usr/share/go-1.26/lib/fips140/fips140.sum:
+      /usr/share/go-1.26/lib/fips140/inprocess.txt:
+      /usr/share/go-1.26/lib/fips140/v*.txt:
+      /usr/share/go-1.26/lib/fips140/v*.zip:
+      /usr/share/go-1.26/lib/time/mkzip.go:
+      /usr/share/go-1.26/lib/time/update.bash:
+      /usr/share/go-1.26/lib/time/zoneinfo.zip:
+      /usr/share/go-1.26/lib/wasm/*:
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-1.26-src/copyright:

--- a/slices/golang-1.26.yaml
+++ b/slices/golang-1.26.yaml
@@ -1,0 +1,20 @@
+package: golang-1.26
+
+essential:
+  golang-1.26_copyright:
+
+slices:
+  core:
+    essential:
+      # Note: Package golang-1.26-go is not available on i386.
+      golang-1.26-go_core:
+      golang-1.26-src_src-with-tests:
+
+  cgo-support:
+    essential:
+      golang-1.26-go_cgo-tools:
+      golang-1.26_core:
+
+  copyright:
+    contents:
+      /usr/share/doc/golang-1.26/copyright:

--- a/slices/golang-go.yaml
+++ b/slices/golang-go.yaml
@@ -6,15 +6,15 @@ essential:
 slices:
   core:
     essential:
-      golang-1.25-go_core:
+      golang-1.26-go_core:
     contents:
-      /usr/bin/go:  # Symlink to ../lib/go-1.25/bin/go
-      /usr/bin/gofmt:  # Symlink to ../lib/go-1.25/bin/gofmt
-      /usr/lib/go:  # Symlink to ../share/go-1.25
+      /usr/bin/go:  # Symlink to ../lib/go-1.26/bin/go
+      /usr/bin/gofmt:  # Symlink to ../lib/go-1.26/bin/gofmt
+      /usr/lib/go:  # Symlink to ../share/go-1.26
 
   cgo-tools:
     essential:
-      golang-1.25-go_cgo-tools:
+      golang-1.26-go_cgo-tools:
 
   copyright:
     contents:

--- a/slices/golang-src.yaml
+++ b/slices/golang-src.yaml
@@ -6,9 +6,9 @@ essential:
 slices:
   src-with-tests:
     essential:
-      golang-1.25-src_src-with-tests:
+      golang-1.26-src_src-with-tests:
     contents:
-      /usr/share/go:  # Symlink to go-1.25
+      /usr/share/go:  # Symlink to go-1.26
 
   copyright:
     contents:

--- a/slices/golang.yaml
+++ b/slices/golang.yaml
@@ -11,7 +11,7 @@ slices:
 
   cgo-support:
     essential:
-      golang-1.25-go_cgo-tools:
+      golang-1.26-go_cgo-tools:
       golang_core:
 
   copyright:

--- a/tests/spread/integration/golang-1.26-go/shared/epilogue.sh
+++ b/tests/spread/integration/golang-1.26-go/shared/epilogue.sh
@@ -1,0 +1,3 @@
+# cleanup
+umount -l "${rootfs}"/dev
+umount -l "${rootfs}"/proc

--- a/tests/spread/integration/golang-1.26-go/shared/prologue.sh
+++ b/tests/spread/integration/golang-1.26-go/shared/prologue.sh
@@ -1,3 +1,5 @@
+# TODO: remove the --arch and the ${arch} logic once
+# canonical/chisel #256 is merged.
 arch=$(uname -m)
 arch="${arch//_/-}"
 
@@ -10,12 +12,9 @@ echo "Unsupported architecture: ${arch}"
 exit 1
 fi
 
-rootfs="$(install-slices --arch "${chisel_arch}" \
-  golang_cgo-support \
-  ca-certificates_data \  # for `go get` to work properly
-)"
+rootfs="$(install-slices --arch "${chisel_arch}" golang-1.26-go_${SLICE} golang-1.26-go_minimal)"
 
-find ${rootfs} -depth \( \
+find "${rootfs}" -depth \( \
     -name '*_test.go' -o \
     \( -type d -name 'testdata' \) -o \
     \( -type d -path '*/go-1.26/test' \) -o \
@@ -41,36 +40,13 @@ find ${rootfs} -depth \( \
     \( -type d -path '*/src/vendor/golang.org/x/net/nettest' \) \
     \) -exec rm -rf {} +
 
+# we need dev/sys mounted for some of them
+mkdir "${rootfs}"/dev
 mkdir "${rootfs}/proc"
-mount --bind /proc "${rootfs}/proc"
 
-mkdir "${rootfs}/dev"
-mount --bind /dev "${rootfs}/dev"
+mount --bind /dev "${rootfs}"/dev
+mount --bind /proc "${rootfs}/proc"
 
 mkdir -p "${rootfs}/tmp"
 
-mkdir "${rootfs}/app"
-cp -r hello "${rootfs}/"
-
-chroot "${rootfs}/" go version
-chroot "${rootfs}/" go run /hello/cmd/hello/main.go | grep "Hello, World!"
-
-chroot "${rootfs}/" gofmt /hello/cmd/hello/main.go > /dev/null
-
-chroot "${rootfs}/" go -C /hello test
-
-git clone https://github.com/canonical/chisel.git "${rootfs}/chisel"
-git -C "$rootfs/chisel" checkout v1.2.0
-cp /etc/resolv.conf "${rootfs}/etc/resolv.conf"
-
-chroot "${rootfs}/" go -C chisel build ./cmd/chisel
-chroot "${rootfs}/" ./chisel/chisel 2>&1 > /dev/null
-
-
-export CGO_ENABLED=1
-chroot "${rootfs}/" go run /hello/cmd/hello_cgo/main_cgo.go | grep "Hello from C!"
-
-umount "${rootfs}/proc"
-umount "${rootfs}/dev"
-rm -rf "${rootfs}/proc"
-rm -rf "${rootfs}/dev"
+echo -n "${rootfs}"

--- a/tests/spread/integration/golang-1.26-go/task.yaml
+++ b/tests/spread/integration/golang-1.26-go/task.yaml
@@ -1,0 +1,18 @@
+summary: Integration tests for golang-1.26-go 
+
+variants:
+  - build-tools
+  - cgo-tools
+  - fix-tools
+  - minimal
+  - profiling-tools
+  - testing-tools
+
+environment:
+  GOTOOLCHAIN: local
+
+execute: |
+  export "SLICE=${SPREAD_VARIANT}"
+  export "rootfs=$(bash -ex ./shared/prologue.sh)"
+  bash -ex ./test_${SPREAD_VARIANT}.sh
+  bash -ex ./shared/epilogue.sh

--- a/tests/spread/integration/golang-1.26-go/test_build-tools.sh
+++ b/tests/spread/integration/golang-1.26-go/test_build-tools.sh
@@ -1,0 +1,5 @@
+[ -n "${rootfs}" ] || { echo "rootfs not set"; exit 1; }
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool asm -V
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool compile -V
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool link -V
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool vet -V

--- a/tests/spread/integration/golang-1.26-go/test_cgo-tools.sh
+++ b/tests/spread/integration/golang-1.26-go/test_cgo-tools.sh
@@ -1,4 +1,4 @@
 chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool cgo -V
 cp ../golang/hello/cmd/hello_cgo/main_cgo.go "${rootfs}/main_cgo.go"
 chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool cgo main_cgo.go
-grep -q "hello_from_c" "${rootfs}/_cgo_2.o"
+grep -Fq "hello_from_c" "${rootfs}/_cgo_2.o"

--- a/tests/spread/integration/golang-1.26-go/test_cgo-tools.sh
+++ b/tests/spread/integration/golang-1.26-go/test_cgo-tools.sh
@@ -1,0 +1,4 @@
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool cgo -V
+cp ../golang/hello/cmd/hello_cgo/main_cgo.go "${rootfs}/main_cgo.go"
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool cgo main_cgo.go
+grep -q "hello_from_c" "${rootfs}/_cgo_2.o"

--- a/tests/spread/integration/golang-1.26-go/test_fix-tools.sh
+++ b/tests/spread/integration/golang-1.26-go/test_fix-tools.sh
@@ -1,0 +1,1 @@
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool fix -V

--- a/tests/spread/integration/golang-1.26-go/test_minimal.sh
+++ b/tests/spread/integration/golang-1.26-go/test_minimal.sh
@@ -1,0 +1,2 @@
+cp ../golang/hello/cmd/hello/main.go "${rootfs}/hello.go"
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go run /hello.go | grep "Hello, World!"

--- a/tests/spread/integration/golang-1.26-go/test_profiling-tools.sh
+++ b/tests/spread/integration/golang-1.26-go/test_profiling-tools.sh
@@ -1,0 +1,1 @@
+(chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool preprofile 2>&1 || true) | grep "usage"

--- a/tests/spread/integration/golang-1.26-go/test_testing-tools.sh
+++ b/tests/spread/integration/golang-1.26-go/test_testing-tools.sh
@@ -1,0 +1,1 @@
+chroot "${rootfs}" /usr/lib/go-1.26/bin/go tool cover -V


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

This PR brings `golang-1.26` and its dependencies to chisel-release, and fixes the artifact packages of `golang-default` that were broken by the SRU (from 1.25 to 1.26). 

## Related issues/PRs
<!-- If any -->

N/A

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

N/A before the opening of `ubuntu-26.10`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->