### PR TITLE
feat(26.04): add `rustfmt` and `rustfmt-1.93`

### DIFF
--- a/slices/rustfmt-1.93.yaml
+++ b/slices/rustfmt-1.93.yaml
@@ -6,6 +6,11 @@ essential:
 slices:
   cargo-fmt:
     essential:
+      # NOTE: although libc6_libs and libgcc-s1_libs
+      # are transitively included by depending on
+      # rustfmt-1.93_rustfmt, we also declare them
+      # here since are also direct dependencies for
+      # cargo-fmt
       libc6_libs:
       libgcc-s1_libs:
       rustfmt-1.93_rustfmt:  # needs rustfmt bin

--- a/slices/rustfmt-1.93.yaml
+++ b/slices/rustfmt-1.93.yaml
@@ -6,7 +6,9 @@ essential:
 slices:
   cargo-fmt:
     essential:
-      rustfmt-1.93_rustfmt:
+      libc6_libs:
+      libgcc-s1_libs:
+      rustfmt-1.93_rustfmt:  # needs rustfmt bin
     contents:
       /usr/lib/rust-1.93/bin/cargo-fmt:
 

--- a/slices/rustfmt-1.93.yaml
+++ b/slices/rustfmt-1.93.yaml
@@ -1,0 +1,23 @@
+package: rustfmt-1.93
+
+essential:
+  rustfmt-1.93_copyright:
+
+slices:
+  cargo-fmt:
+    essential:
+      rustfmt-1.93_rustfmt:
+    contents:
+      /usr/lib/rust-1.93/bin/cargo-fmt:
+
+  rustfmt:
+    essential:
+      libc6_libs:
+      libgcc-s1_libs:
+      libstd-rust-1.93-dev_libs:
+    contents:
+      /usr/lib/rust-1.93/bin/rustfmt:
+
+  copyright:
+    contents:
+      /usr/share/doc/rustfmt-1.93/copyright:

--- a/slices/rustfmt.yaml
+++ b/slices/rustfmt.yaml
@@ -1,0 +1,22 @@
+package: rustfmt
+
+essential:
+  rustfmt_copyright:
+
+slices:
+  cargo-fmt:
+    essential:
+      rustfmt-1.93_cargo-fmt:
+      rustfmt_rustfmt:
+    contents:
+      /usr/bin/cargo-fmt:  # symlink to ../lib/rust-1.93/bin/cargo-fmt
+
+  rustfmt:
+    essential:
+      rustfmt-1.93_rustfmt:
+    contents:
+      /usr/bin/rustfmt:  # symlink to ../lib/rust-1.93/bin/rustfmt
+
+  copyright:
+    contents:
+      /usr/share/doc/rustfmt/copyright:

--- a/tests/spread/integration/rustfmt-1.93/task.yaml
+++ b/tests/spread/integration/rustfmt-1.93/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for rustfmt-1.93
+
+variants:
+    - format
+    - help_and_version
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/rustfmt-1.93/test_format.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_format.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustfmt
+
+arch=$(uname -m)
+case "${arch}" in
+aarch64) chisel_arch="arm64" ;;
+x86_64) chisel_arch="amd64" ;;
+*)
+  echo "Unsupported architecture: ${arch}"
+  exit 1
+  ;;
+esac
+
+# Test rustfmt reformats a badly formatted file
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_rustfmt)"
+
+cp testfiles/messy.rs "$rootfs/messy.rs"
+
+# Before: no space before brace
+grep -q 'fn main(){' "$rootfs/messy.rs"
+
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt /messy.rs
+
+# After: proper formatting with space before brace
+grep -q 'fn main() {' "$rootfs/messy.rs"
+
+# Test cargo fmt reformats a project
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
+ln -s /usr/lib/rust-1.93/bin/cargo-fmt "$rootfs/usr/bin/cargo-fmt"
+ln -s /usr/lib/rust-1.93/bin/rustfmt "$rootfs/usr/bin/rustfmt"
+
+mkdir -p "$rootfs/dev"
+touch "$rootfs/dev/null"
+chmod +x "$rootfs/dev/null"
+
+cp -r testfiles/hello_fmt "$rootfs"
+
+# Before: no space before brace
+grep -q 'fn main(){' "$rootfs/hello_fmt/src/main.rs"
+
+chroot "$rootfs" cargo-1.93 -Z unstable-options -C /hello_fmt fmt
+
+# After: proper formatting with space before brace
+grep -q 'fn main() {' "$rootfs/hello_fmt/src/main.rs"

--- a/tests/spread/integration/rustfmt-1.93/test_format.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_format.sh
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
 # spellchecker: ignore rootfs rustfmt
 
-arch=$(uname -m)
-case "${arch}" in
-aarch64) chisel_arch="arm64" ;;
-x86_64) chisel_arch="amd64" ;;
-*)
-  echo "Unsupported architecture: ${arch}"
-  exit 1
-  ;;
-esac
-
 # Test rustfmt reformats a badly formatted file
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_rustfmt)"
+rootfs="$(install-slices rustfmt-1.93_rustfmt)"
 
 cp testfiles/messy.rs "$rootfs/messy.rs"
 
@@ -25,7 +15,7 @@ chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt /messy.rs
 grep -q 'fn main() {' "$rootfs/messy.rs"
 
 # Test cargo fmt reformats a project
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
+rootfs="$(install-slices rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
 ln -s /usr/lib/rust-1.93/bin/cargo-fmt "$rootfs/usr/bin/cargo-fmt"
 ln -s /usr/lib/rust-1.93/bin/rustfmt "$rootfs/usr/bin/rustfmt"
 

--- a/tests/spread/integration/rustfmt-1.93/test_format.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_format.sh
@@ -7,12 +7,12 @@ rootfs="$(install-slices rustfmt-1.93_rustfmt)"
 cp testfiles/messy.rs "$rootfs/messy.rs"
 
 # Before: no space before brace
-grep -q 'fn main(){' "$rootfs/messy.rs"
+grep -Fq 'fn main(){' "$rootfs/messy.rs"
 
 chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt /messy.rs
 
 # After: proper formatting with space before brace
-grep -q 'fn main() {' "$rootfs/messy.rs"
+grep -Fq 'fn main() {' "$rootfs/messy.rs"
 
 # Test cargo fmt reformats a project
 rootfs="$(install-slices rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
@@ -26,9 +26,9 @@ chmod +x "$rootfs/dev/null"
 cp -r testfiles/hello_fmt "$rootfs"
 
 # Before: no space before brace
-grep -q 'fn main(){' "$rootfs/hello_fmt/src/main.rs"
+grep -Fq 'fn main(){' "$rootfs/hello_fmt/src/main.rs"
 
 chroot "$rootfs" cargo-1.93 -Z unstable-options -C /hello_fmt fmt
 
 # After: proper formatting with space before brace
-grep -q 'fn main() {' "$rootfs/hello_fmt/src/main.rs"
+grep -Fq 'fn main() {' "$rootfs/hello_fmt/src/main.rs"

--- a/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
@@ -1,25 +1,15 @@
 #!/usr/bin/env bash
 # spellchecker: ignore rootfs rustfmt
 
-arch=$(uname -m)
-case "${arch}" in
-aarch64) chisel_arch="arm64" ;;
-x86_64) chisel_arch="amd64" ;;
-*)
-  echo "Unsupported architecture: ${arch}"
-  exit 1
-  ;;
-esac
-
 # test rustfmt slice
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_rustfmt)"
+rootfs="$(install-slices rustfmt-1.93_rustfmt)"
 # somewhat unexpectedly, the `rustfmt` version associated with Rust 1.93 is NOT 1.93
 # instead, it has its own version number; for Rust 1.93, that's 1.8.0
 chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8.0'
 chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --help | grep -q 'Format Rust code'
 
 # test cargo-fmt slice
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_cargo-fmt)"
+rootfs="$(install-slices rustfmt-1.93_cargo-fmt)"
 # installing cargo-fmt also makes rustfmt available
 chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8.0'
 chroot "$rootfs" /usr/lib/rust-1.93/bin/cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'

--- a/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
@@ -5,13 +5,13 @@
 rootfs="$(install-slices rustfmt-1.93_rustfmt)"
 # somewhat unexpectedly, the `rustfmt` version associated with Rust 1.93 is NOT 1.93
 # instead, it has its own version number; for Rust 1.93, that's 1.8.0
-chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8.0'
-chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --help | grep -q 'Format Rust code'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -Fiq 'rustfmt 1.8.0'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --help | grep -Fq 'Format Rust code'
 
 # test cargo-fmt slice
 rootfs="$(install-slices rustfmt-1.93_cargo-fmt)"
 # installing cargo-fmt also makes rustfmt available
-chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8.0'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -Fiq 'rustfmt 1.8.0'
 chroot "$rootfs" /usr/lib/rust-1.93/bin/cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
 
 # test with `cargo fmt`

--- a/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustfmt
+
+arch=$(uname -m)
+case "${arch}" in
+aarch64) chisel_arch="arm64" ;;
+x86_64) chisel_arch="amd64" ;;
+*)
+  echo "Unsupported architecture: ${arch}"
+  exit 1
+  ;;
+esac
+
+# test rustfmt slice
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_rustfmt)"
+# somewhat unexpectedly, the `rustfmt` version associated with Rust 1.93 is NOT 1.93
+# instead, it has its own version number; for Rust 1.93, that's 1.8.0
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8.0'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --help | grep -q 'Format Rust code'
+
+# test cargo-fmt slice
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_cargo-fmt)"
+# installing cargo-fmt also makes rustfmt available
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8.0'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
+
+# test with `cargo fmt`
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
+ln -s cargo-1.93 "$rootfs/usr/bin/cargo"
+ln -s /usr/lib/rust-1.93/bin/cargo-fmt "$rootfs/usr/bin/cargo-fmt"
+ln -s /usr/lib/rust-1.93/bin/rustfmt "$rootfs/usr/bin/rustfmt"
+chroot "$rootfs" cargo fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'

--- a/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
@@ -15,7 +15,7 @@ chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -q 'rustfmt 1.8
 chroot "$rootfs" /usr/lib/rust-1.93/bin/cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
 
 # test with `cargo fmt`
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
+rootfs="$(install-slices rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
 ln -s cargo-1.93 "$rootfs/usr/bin/cargo"
 ln -s /usr/lib/rust-1.93/bin/cargo-fmt "$rootfs/usr/bin/cargo-fmt"
 ln -s /usr/lib/rust-1.93/bin/rustfmt "$rootfs/usr/bin/rustfmt"

--- a/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt-1.93/test_help_and_version.sh
@@ -12,11 +12,11 @@ chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --help | grep -Fq 'Format Rust c
 rootfs="$(install-slices rustfmt-1.93_cargo-fmt)"
 # installing cargo-fmt also makes rustfmt available
 chroot "$rootfs" /usr/lib/rust-1.93/bin/rustfmt --version | grep -Fiq 'rustfmt 1.8.0'
-chroot "$rootfs" /usr/lib/rust-1.93/bin/cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/cargo-fmt --help | grep -Fq 'This utility formats all bin and lib files of the current crate using rustfmt'
 
 # test with `cargo fmt`
 rootfs="$(install-slices rustfmt-1.93_cargo-fmt cargo-1.93_cargo)"
 ln -s cargo-1.93 "$rootfs/usr/bin/cargo"
 ln -s /usr/lib/rust-1.93/bin/cargo-fmt "$rootfs/usr/bin/cargo-fmt"
 ln -s /usr/lib/rust-1.93/bin/rustfmt "$rootfs/usr/bin/rustfmt"
-chroot "$rootfs" cargo fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
+chroot "$rootfs" cargo fmt --help | grep -Fq 'This utility formats all bin and lib files of the current crate using rustfmt'

--- a/tests/spread/integration/rustfmt-1.93/testfiles/hello_fmt/Cargo.toml
+++ b/tests/spread/integration/rustfmt-1.93/testfiles/hello_fmt/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "hello_fmt"
+version = "0.1.0"
+edition = "2021"

--- a/tests/spread/integration/rustfmt-1.93/testfiles/hello_fmt/src/main.rs
+++ b/tests/spread/integration/rustfmt-1.93/testfiles/hello_fmt/src/main.rs
@@ -1,0 +1,1 @@
+fn main(){println!("Hello, world!");}

--- a/tests/spread/integration/rustfmt-1.93/testfiles/messy.rs
+++ b/tests/spread/integration/rustfmt-1.93/testfiles/messy.rs
@@ -1,0 +1,1 @@
+fn main(){let x=1;println!("{}",x);}

--- a/tests/spread/integration/rustfmt/task.yaml
+++ b/tests/spread/integration/rustfmt/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for rustfmt
+
+variants:
+    - format
+    - help_and_version
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/rustfmt/test_format.sh
+++ b/tests/spread/integration/rustfmt/test_format.sh
@@ -7,12 +7,12 @@ rootfs="$(install-slices rustfmt_rustfmt)"
 cp testfiles/messy.rs "$rootfs/messy.rs"
 
 # Before: no space before brace
-grep -q 'fn main(){' "$rootfs/messy.rs"
+grep -Fq 'fn main(){' "$rootfs/messy.rs"
 
 chroot "$rootfs" rustfmt /messy.rs
 
 # After: proper formatting with space before brace
-grep -q 'fn main() {' "$rootfs/messy.rs"
+grep -Fq 'fn main() {' "$rootfs/messy.rs"
 
 # Test cargo fmt reformats a project
 rootfs="$(install-slices rustfmt_cargo-fmt cargo_cargo)"
@@ -24,9 +24,9 @@ chmod +x "$rootfs/dev/null"
 cp -r testfiles/hello_fmt "$rootfs"
 
 # Before: no space before brace
-grep -q 'fn main(){' "$rootfs/hello_fmt/src/main.rs"
+grep -Fq 'fn main(){' "$rootfs/hello_fmt/src/main.rs"
 
 chroot "$rootfs" cargo -Z unstable-options -C /hello_fmt fmt
 
 # After: proper formatting with space before brace
-grep -q 'fn main() {' "$rootfs/hello_fmt/src/main.rs"
+grep -Fq 'fn main() {' "$rootfs/hello_fmt/src/main.rs"

--- a/tests/spread/integration/rustfmt/test_format.sh
+++ b/tests/spread/integration/rustfmt/test_format.sh
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
 # spellchecker: ignore rootfs rustfmt
 
-arch=$(uname -m)
-case "${arch}" in
-aarch64) chisel_arch="arm64" ;;
-x86_64) chisel_arch="amd64" ;;
-*)
-  echo "Unsupported architecture: ${arch}"
-  exit 1
-  ;;
-esac
-
 # Test rustfmt reformats a badly formatted file
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt_rustfmt)"
+rootfs="$(install-slices rustfmt_rustfmt)"
 
 cp testfiles/messy.rs "$rootfs/messy.rs"
 
@@ -25,7 +15,7 @@ chroot "$rootfs" rustfmt /messy.rs
 grep -q 'fn main() {' "$rootfs/messy.rs"
 
 # Test cargo fmt reformats a project
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt_cargo-fmt cargo_cargo)"
+rootfs="$(install-slices rustfmt_cargo-fmt cargo_cargo)"
 
 mkdir -p "$rootfs/dev"
 touch "$rootfs/dev/null"

--- a/tests/spread/integration/rustfmt/test_format.sh
+++ b/tests/spread/integration/rustfmt/test_format.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustfmt
+
+arch=$(uname -m)
+case "${arch}" in
+aarch64) chisel_arch="arm64" ;;
+x86_64) chisel_arch="amd64" ;;
+*)
+  echo "Unsupported architecture: ${arch}"
+  exit 1
+  ;;
+esac
+
+# Test rustfmt reformats a badly formatted file
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt_rustfmt)"
+
+cp testfiles/messy.rs "$rootfs/messy.rs"
+
+# Before: no space before brace
+grep -q 'fn main(){' "$rootfs/messy.rs"
+
+chroot "$rootfs" rustfmt /messy.rs
+
+# After: proper formatting with space before brace
+grep -q 'fn main() {' "$rootfs/messy.rs"
+
+# Test cargo fmt reformats a project
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt_cargo-fmt cargo_cargo)"
+
+mkdir -p "$rootfs/dev"
+touch "$rootfs/dev/null"
+chmod +x "$rootfs/dev/null"
+
+cp -r testfiles/hello_fmt "$rootfs"
+
+# Before: no space before brace
+grep -q 'fn main(){' "$rootfs/hello_fmt/src/main.rs"
+
+chroot "$rootfs" cargo -Z unstable-options -C /hello_fmt fmt
+
+# After: proper formatting with space before brace
+grep -q 'fn main() {' "$rootfs/hello_fmt/src/main.rs"

--- a/tests/spread/integration/rustfmt/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt/test_help_and_version.sh
@@ -3,19 +3,19 @@
 
 # test rustfmt slice
 rootfs="$(install-slices rustfmt_rustfmt)"
-chroot "$rootfs" rustfmt --version | grep -q 'rustfmt 1.8.0'
-chroot "$rootfs" rustfmt --help | grep -q 'Format Rust code'
-chroot "$rootfs" rustfmt --help | grep -q 'usage: rustfmt'
+chroot "$rootfs" rustfmt --version | grep -Fiq 'rustfmt 1.8.0'
+chroot "$rootfs" rustfmt --help | grep -Fq 'Format Rust code'
+chroot "$rootfs" rustfmt --help | grep -Fq 'usage: rustfmt'
 
 # test cargo-fmt slice
 rootfs="$(install-slices rustfmt_cargo-fmt)"
 # installing cargo-fmt also makes rustfmt available
-chroot "$rootfs" cargo-fmt --version | grep -q 'rustfmt 1.8.0'
-chroot "$rootfs" cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
-chroot "$rootfs" cargo-fmt --help | grep -q 'Usage: cargo fmt'
+chroot "$rootfs" cargo-fmt --version | grep -Fiq 'rustfmt 1.8.0'
+chroot "$rootfs" cargo-fmt --help | grep -Fq 'This utility formats all bin and lib files of the current crate using rustfmt'
+chroot "$rootfs" cargo-fmt --help | grep -Fq 'Usage: cargo fmt'
 
 # test with `cargo fmt`
 rootfs="$(install-slices rustfmt_cargo-fmt cargo_cargo)"
-chroot "$rootfs" cargo fmt --version | grep -q 'rustfmt 1.8.0'
-chroot "$rootfs" cargo fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
-chroot "$rootfs" cargo fmt --help | grep -q 'Usage: cargo fmt'
+chroot "$rootfs" cargo fmt --version | grep -Fiq 'rustfmt 1.8.0'
+chroot "$rootfs" cargo fmt --help | grep -Fq 'This utility formats all bin and lib files of the current crate using rustfmt'
+chroot "$rootfs" cargo fmt --help | grep -Fq 'Usage: cargo fmt'

--- a/tests/spread/integration/rustfmt/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt/test_help_and_version.sh
@@ -1,31 +1,21 @@
 #!/usr/bin/env bash
 # spellchecker: ignore rootfs rustfmt
 
-arch=$(uname -m)
-case "${arch}" in
-aarch64) chisel_arch="arm64" ;;
-x86_64) chisel_arch="amd64" ;;
-*)
-  echo "Unsupported architecture: ${arch}"
-  exit 1
-  ;;
-esac
-
 # test rustfmt slice
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt_rustfmt)"
+rootfs="$(install-slices rustfmt_rustfmt)"
 chroot "$rootfs" rustfmt --version | grep -q 'rustfmt 1.8.0'
 chroot "$rootfs" rustfmt --help | grep -q 'Format Rust code'
 chroot "$rootfs" rustfmt --help | grep -q 'usage: rustfmt'
 
 # test cargo-fmt slice
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt_cargo-fmt)"
+rootfs="$(install-slices rustfmt_cargo-fmt)"
 # installing cargo-fmt also makes rustfmt available
 chroot "$rootfs" cargo-fmt --version | grep -q 'rustfmt 1.8.0'
 chroot "$rootfs" cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
 chroot "$rootfs" cargo-fmt --help | grep -q 'Usage: cargo fmt'
 
 # test with `cargo fmt`
-rootfs="$(install-slices --arch "$chisel_arch" rustfmt_cargo-fmt cargo_cargo)"
+rootfs="$(install-slices rustfmt_cargo-fmt cargo_cargo)"
 chroot "$rootfs" cargo fmt --version | grep -q 'rustfmt 1.8.0'
 chroot "$rootfs" cargo fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
 chroot "$rootfs" cargo fmt --help | grep -q 'Usage: cargo fmt'

--- a/tests/spread/integration/rustfmt/test_help_and_version.sh
+++ b/tests/spread/integration/rustfmt/test_help_and_version.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustfmt
+
+arch=$(uname -m)
+case "${arch}" in
+aarch64) chisel_arch="arm64" ;;
+x86_64) chisel_arch="amd64" ;;
+*)
+  echo "Unsupported architecture: ${arch}"
+  exit 1
+  ;;
+esac
+
+# test rustfmt slice
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt_rustfmt)"
+chroot "$rootfs" rustfmt --version | grep -q 'rustfmt 1.8.0'
+chroot "$rootfs" rustfmt --help | grep -q 'Format Rust code'
+chroot "$rootfs" rustfmt --help | grep -q 'usage: rustfmt'
+
+# test cargo-fmt slice
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt_cargo-fmt)"
+# installing cargo-fmt also makes rustfmt available
+chroot "$rootfs" cargo-fmt --version | grep -q 'rustfmt 1.8.0'
+chroot "$rootfs" cargo-fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
+chroot "$rootfs" cargo-fmt --help | grep -q 'Usage: cargo fmt'
+
+# test with `cargo fmt`
+rootfs="$(install-slices --arch "$chisel_arch" rustfmt_cargo-fmt cargo_cargo)"
+chroot "$rootfs" cargo fmt --version | grep -q 'rustfmt 1.8.0'
+chroot "$rootfs" cargo fmt --help | grep -q 'This utility formats all bin and lib files of the current crate using rustfmt'
+chroot "$rootfs" cargo fmt --help | grep -q 'Usage: cargo fmt'

--- a/tests/spread/integration/rustfmt/testfiles/hello_fmt/Cargo.toml
+++ b/tests/spread/integration/rustfmt/testfiles/hello_fmt/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "hello_fmt"
+version = "0.1.0"
+edition = "2021"

--- a/tests/spread/integration/rustfmt/testfiles/hello_fmt/src/main.rs
+++ b/tests/spread/integration/rustfmt/testfiles/hello_fmt/src/main.rs
@@ -1,0 +1,1 @@
+fn main(){println!("Hello, world!");}

--- a/tests/spread/integration/rustfmt/testfiles/messy.rs
+++ b/tests/spread/integration/rustfmt/testfiles/messy.rs
@@ -1,0 +1,1 @@
+fn main(){let x=1;println!("{}",x);}


### PR DESCRIPTION
# Proposed changes

Add slice definitions for Rust's formatter, [`rustfmt`](https://github.com/rust-lang/rustfmt).

The [`rustfmt`](https://packages.ubuntu.com/resolute/rustfmt) package on Ubuntu 26.04 is just a re-export of [`rustfmt-1.93`](https://packages.ubuntu.com/resolute/rustfmt-1.93), so this PR includes slice definitions for both.

We already have `rustc`/`rustc-1.93` and `cargo`/`cargo-1.93` - this PR extends the list of supported Rust toolchain binaries.

## Related issues/PRs

None.

### Forward porting

Ubuntu 26.04 is currently the latest release, so there are no forward ports to do.

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
