### PR TITLE
chore(26.04): add copyright to make

### DIFF
--- a/slices/make.yaml
+++ b/slices/make.yaml
@@ -1,5 +1,8 @@
 package: make
 
+essential:
+  make_copyright:
+
 slices:
   bins:
     essential:


### PR DESCRIPTION
# Proposed changes

Make has a `copyright` slice already, but it is not shipped alongside its slice(s).

## Related issues/PRs
None

### Forward porting
Ubuntu 26.04 is currently the latest release, so there are no forward ports to do.

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
