### PR TITLE
feat(26.04): add `rust-1.93-src` slices

### DIFF
--- a/slices/rust-1.93-src.yaml
+++ b/slices/rust-1.93-src.yaml
@@ -8,7 +8,7 @@ slices:
     contents:
       /usr/lib/rust-1.93/lib/rustlib/src/rust:
       /usr/lib/rust-1.93/rustlib/src/rust:
-      /usr/src/rustc-1.93.1/**:
+      /usr/src/rustc-1.93.*/**:
 
   copyright:
     contents:

--- a/slices/rust-1.93-src.yaml
+++ b/slices/rust-1.93-src.yaml
@@ -1,0 +1,15 @@
+package: rust-1.93-src
+
+essential:
+  rust-1.93-src_copyright:
+
+slices:
+  src:
+    contents:
+      /usr/lib/rust-1.93/lib/rustlib/src/rust:
+      /usr/lib/rust-1.93/rustlib/src/rust:
+      /usr/src/rustc-1.93.1/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/rust-1.93-src/copyright:

--- a/slices/rust-src.yaml
+++ b/slices/rust-src.yaml
@@ -1,0 +1,15 @@
+package: rust-src
+
+essential:
+  rust-src_copyright:
+
+slices:
+  src:
+    essential:
+      rust-1.93-src_src:
+    contents:
+      /usr/lib/rustlib/src/rust:  # symlink to ../../rust-1.93/lib/rustlib/src/rust
+
+  copyright:
+    contents:
+      /usr/share/doc/rust-src/copyright:

--- a/slices/rust-src.yaml
+++ b/slices/rust-src.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       rust-1.93-src_src:
     contents:
-      /usr/lib/rustlib/src/rust:  # symlink to ../../rust-1.93/lib/rustlib/src/rust
+      /usr/lib/rustlib/src/rust:  # Symlink to ../../rust-1.93/lib/rustlib/src/rust
 
   copyright:
     contents:

--- a/tests/spread/integration/rust-1.93-src/task.yaml
+++ b/tests/spread/integration/rust-1.93-src/task.yaml
@@ -1,0 +1,3 @@
+summary: Integration tests for rust-1.93-src
+
+execute: bash -ex ./test.sh

--- a/tests/spread/integration/rust-1.93-src/test.sh
+++ b/tests/spread/integration/rust-1.93-src/test.sh
@@ -1,17 +1,7 @@
 #!/usr/bin/env bash
 # spellchecker: ignore rootfs rustlib
 
-arch=$(uname -m)
-case "${arch}" in
-aarch64) chisel_arch="arm64" ;;
-x86_64) chisel_arch="amd64" ;;
-*)
-  echo "Unsupported architecture: ${arch}"
-  exit 1
-  ;;
-esac
-
-rootfs="$(install-slices --arch "$chisel_arch" rust-1.93-src_src)"
+rootfs="$(install-slices rust-1.93-src_src)"
 
 # The versioned package provides two symlinks to the source tree:
 #   /usr/lib/rust-1.93/lib/rustlib/src/rust -> ../../../../../src/rustc-1.93.1

--- a/tests/spread/integration/rust-1.93-src/test.sh
+++ b/tests/spread/integration/rust-1.93-src/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustlib
+
+arch=$(uname -m)
+case "${arch}" in
+aarch64) chisel_arch="arm64" ;;
+x86_64) chisel_arch="amd64" ;;
+*)
+  echo "Unsupported architecture: ${arch}"
+  exit 1
+  ;;
+esac
+
+rootfs="$(install-slices --arch "$chisel_arch" rust-1.93-src_src)"
+
+# The versioned package provides two symlinks to the source tree:
+#   /usr/lib/rust-1.93/lib/rustlib/src/rust -> ../../../../../src/rustc-1.93.1
+#   /usr/lib/rust-1.93/rustlib/src/rust     -> ../../../../src/rustc-1.93.1
+test -L "$rootfs/usr/lib/rust-1.93/lib/rustlib/src/rust"
+test -L "$rootfs/usr/lib/rust-1.93/rustlib/src/rust"
+
+# Verify both symlinks resolve to the source tree
+test -f "$rootfs/usr/lib/rust-1.93/lib/rustlib/src/rust/library/std/src/lib.rs"
+test -f "$rootfs/usr/lib/rust-1.93/lib/rustlib/src/rust/compiler/rustc/Cargo.toml"
+test -f "$rootfs/usr/lib/rust-1.93/rustlib/src/rust/library/std/src/lib.rs"
+test -f "$rootfs/usr/lib/rust-1.93/rustlib/src/rust/compiler/rustc/Cargo.toml"
+
+# Verify the actual source tree exists
+test -f "$rootfs/usr/src/rustc-1.93.1/library/std/src/lib.rs"
+test -f "$rootfs/usr/src/rustc-1.93.1/compiler/rustc/Cargo.toml"
+test -f "$rootfs/usr/src/rustc-1.93.1/Cargo.toml"

--- a/tests/spread/integration/rust-1.93-src/test.sh
+++ b/tests/spread/integration/rust-1.93-src/test.sh
@@ -4,8 +4,8 @@
 rootfs="$(install-slices rust-1.93-src_src)"
 
 # The versioned package provides two symlinks to the source tree:
-#   /usr/lib/rust-1.93/lib/rustlib/src/rust -> ../../../../../src/rustc-1.93.1
-#   /usr/lib/rust-1.93/rustlib/src/rust     -> ../../../../src/rustc-1.93.1
+#   /usr/lib/rust-1.93/lib/rustlib/src/rust -> ../../../../../src/rustc-1.93.*
+#   /usr/lib/rust-1.93/rustlib/src/rust     -> ../../../../src/rustc-1.93.*
 test -L "$rootfs/usr/lib/rust-1.93/lib/rustlib/src/rust"
 test -L "$rootfs/usr/lib/rust-1.93/rustlib/src/rust"
 
@@ -15,7 +15,13 @@ test -f "$rootfs/usr/lib/rust-1.93/lib/rustlib/src/rust/compiler/rustc/Cargo.tom
 test -f "$rootfs/usr/lib/rust-1.93/rustlib/src/rust/library/std/src/lib.rs"
 test -f "$rootfs/usr/lib/rust-1.93/rustlib/src/rust/compiler/rustc/Cargo.toml"
 
-# Verify the actual source tree exists
-test -f "$rootfs/usr/src/rustc-1.93.1/library/std/src/lib.rs"
-test -f "$rootfs/usr/src/rustc-1.93.1/compiler/rustc/Cargo.toml"
-test -f "$rootfs/usr/src/rustc-1.93.1/Cargo.toml"
+# Verify the actual source tree exists (don't pin the patch version)
+shopt -s nullglob  # no match -> empty array, not the literal glob
+src_dirs=("$rootfs"/usr/src/rustc-1.93.*)
+test "${#src_dirs[@]}" -eq 1   # exactly one source tree
+src_dir="${src_dirs[0]}"
+shopt -u nullglob
+test -d "$src_dir"
+test -f "$src_dir/library/std/src/lib.rs"
+test -f "$src_dir/compiler/rustc/Cargo.toml"
+test -f "$src_dir/Cargo.toml"

--- a/tests/spread/integration/rust-src/task.yaml
+++ b/tests/spread/integration/rust-src/task.yaml
@@ -1,0 +1,3 @@
+summary: Integration tests for rust-src
+
+execute: bash -ex ./test.sh

--- a/tests/spread/integration/rust-src/test.sh
+++ b/tests/spread/integration/rust-src/test.sh
@@ -4,7 +4,7 @@
 rootfs="$(install-slices rust-src_src)"
 
 # The unversioned symlink chain should resolve to the source tree
-# /usr/lib/rustlib/src/rust -> ../../rust-1.93/lib/rustlib/src/rust -> /usr/src/rustc-1.93.1
+# /usr/lib/rustlib/src/rust -> ../../rust-1.93/lib/rustlib/src/rust -> /usr/src/rustc-1.93.*
 test -L "$rootfs/usr/lib/rustlib/src/rust"
 test -f "$rootfs/usr/lib/rustlib/src/rust/library/std/src/lib.rs"
 test -f "$rootfs/usr/lib/rustlib/src/rust/library/core/src/lib.rs"
@@ -14,7 +14,13 @@ test -f "$rootfs/usr/lib/rustlib/src/rust/src/bootstrap/Cargo.toml"
 test -f "$rootfs/usr/lib/rustlib/src/rust/Cargo.toml"
 test -f "$rootfs/usr/lib/rustlib/src/rust/README.md"
 
-# Verify the actual source tree exists
-test -f "$rootfs/usr/src/rustc-1.93.1/library/std/src/lib.rs"
-test -f "$rootfs/usr/src/rustc-1.93.1/compiler/rustc/Cargo.toml"
-test -f "$rootfs/usr/src/rustc-1.93.1/Cargo.toml"
+# Verify the actual source tree exists (don't pin the patch version)
+shopt -s nullglob  # no match -> empty array, not the literal glob
+src_dirs=("$rootfs"/usr/src/rustc-1.93.*)
+test "${#src_dirs[@]}" -eq 1   # exactly one source tree
+src_dir="${src_dirs[0]}"
+shopt -u nullglob
+test -d "$src_dir"
+test -f "$src_dir/library/std/src/lib.rs"
+test -f "$src_dir/compiler/rustc/Cargo.toml"
+test -f "$src_dir/Cargo.toml"

--- a/tests/spread/integration/rust-src/test.sh
+++ b/tests/spread/integration/rust-src/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustlib
+
+arch=$(uname -m)
+case "${arch}" in
+aarch64) chisel_arch="arm64" ;;
+x86_64) chisel_arch="amd64" ;;
+*)
+  echo "Unsupported architecture: ${arch}"
+  exit 1
+  ;;
+esac
+
+rootfs="$(install-slices --arch "$chisel_arch" rust-src_src)"
+
+# The unversioned symlink chain should resolve to the source tree
+# /usr/lib/rustlib/src/rust -> ../../rust-1.93/lib/rustlib/src/rust -> /usr/src/rustc-1.93.1
+test -L "$rootfs/usr/lib/rustlib/src/rust"
+test -f "$rootfs/usr/lib/rustlib/src/rust/library/std/src/lib.rs"
+test -f "$rootfs/usr/lib/rustlib/src/rust/library/core/src/lib.rs"
+test -f "$rootfs/usr/lib/rustlib/src/rust/library/alloc/src/lib.rs"
+test -f "$rootfs/usr/lib/rustlib/src/rust/compiler/rustc/Cargo.toml"
+test -f "$rootfs/usr/lib/rustlib/src/rust/src/bootstrap/Cargo.toml"
+test -f "$rootfs/usr/lib/rustlib/src/rust/Cargo.toml"
+test -f "$rootfs/usr/lib/rustlib/src/rust/README.md"
+
+# Verify the actual source tree exists
+test -f "$rootfs/usr/src/rustc-1.93.1/library/std/src/lib.rs"
+test -f "$rootfs/usr/src/rustc-1.93.1/compiler/rustc/Cargo.toml"
+test -f "$rootfs/usr/src/rustc-1.93.1/Cargo.toml"

--- a/tests/spread/integration/rust-src/test.sh
+++ b/tests/spread/integration/rust-src/test.sh
@@ -1,17 +1,7 @@
 #!/usr/bin/env bash
 # spellchecker: ignore rootfs rustlib
 
-arch=$(uname -m)
-case "${arch}" in
-aarch64) chisel_arch="arm64" ;;
-x86_64) chisel_arch="amd64" ;;
-*)
-  echo "Unsupported architecture: ${arch}"
-  exit 1
-  ;;
-esac
-
-rootfs="$(install-slices --arch "$chisel_arch" rust-src_src)"
+rootfs="$(install-slices rust-src_src)"
 
 # The unversioned symlink chain should resolve to the source tree
 # /usr/lib/rustlib/src/rust -> ../../rust-1.93/lib/rustlib/src/rust -> /usr/src/rustc-1.93.1


### PR DESCRIPTION
# Proposed changes

Add slice definitions for the Rust standard library and compiler source code, [`rust-src`](https://packages.ubuntu.com/resolute/rust-src).

The [`rust-src`](https://packages.ubuntu.com/resolute/rust-src) package on Ubuntu 26.04 is just a re-export of [`rust-1.93-src`](https://packages.ubuntu.com/resolute/rust-1.93-src), so this PR includes slice definitions for both.

The versioned `rust-1.93-src` package ships the full Rust source tree under `/usr/src/rustc-1.93.1/` plus two symlinks that make it discoverable. The unversioned rust-src package adds a third symlink at `/usr/lib/rustlib/src/rust` so that tools can find the source without hardcoding a version.

This is a prerequisite for `rust-miri` (which needs the stdlib source at runtime) and is also useful on its own for `cargo build -Z build-std`, IDE source navigation and `rust-analyzer` usage.

## Related issues/PRs

None.

### Forward porting

Ubuntu 26.04 is currently the latest release, so there are no forward ports to do.

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)