### PR TITLE
fix(ci): handle list and map essential in pkg-deps

### DIFF
--- a/.github/scripts/pkg-deps/pkg-deps
+++ b/.github/scripts/pkg-deps/pkg-deps
@@ -40,7 +40,7 @@ for f in $@; do
   sort | uniq > "$fupstream"
 
   flocal="$(mktemp)"
-  yq '.slices.[].essential[]' "$f" | \
+  yq '.slices.[].essential | ( (select(tag == "!!seq") | .[]), (select(tag == "!!map") | keys | .[]) )' "$f" | \
   sed "s/_.*//; /^$pkg$/d" | sort | uniq > "$flocal"
 
   fdiff="$(mktemp)"


### PR DESCRIPTION
# Proposed changes

The pkg-deps script builds the list of a slice's dependencies with `yq '.slices.[].essential[]'`. The trailing `[]` returns a node's values, which only works when `essential` is a YAML list. 
On ubuntu-26.04 the `essential` blocks are written as maps instead, so the values are null and the list ends up empty. 
The bot then reports a dependency that isn't really missing (e.g. `-libc6` / `+`).

### slice difference across releases

ubuntu-24.04:
```yaml
core:
  essential:
    - golang-go_core
```

ubuntu-26.04:
```yaml
core:
  essential:
    golang-go_core:
```


`keys` fixes the map case but then breaks the list case (and errors on slices that have no essential at all). 
So the fix checks the node type and reads list items or map keys accordingly:

```
yq '.slices.[].essential | ( (select(tag == "!!seq") | .[]), (select(tag == "!!map") | keys | .[]) )' "$f"
```


### Forward porting

n/a, the script lives only on main.

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Tested locally with the same yq version CI uses.