### PR TITLE
fix: flocal extraction broken in pkg-deps

### DIFF
--- a/.github/scripts/pkg-deps/pkg-deps
+++ b/.github/scripts/pkg-deps/pkg-deps
@@ -40,7 +40,7 @@ for f in $@; do
   sort | uniq > "$fupstream"
 
   flocal="$(mktemp)"
-  yq '.slices.[].essential[]' "$f" | \
+  yq '.slices.[].essential | keys | .[]' "$f" | \
   sed "s/_.*//; /^$pkg$/d" | sort | uniq > "$flocal"
 
   fdiff="$(mktemp)"


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

`.github/scripts/pkg-deps/pkg-deps` computes `flocal` (the slice's locally
declared dependencies) with:

```bash
yq '.slices.[].essential[]' "$f"
```

`essential` blocks are YAML maps, not lists (e.g. `essential: { make_copyright: }`,
where the value is `null`) — confirmed by checking #1029's diff, which adds
`essential:\n  make_copyright:`. `[]` splats *values*, so this yields a list
of `null`s instead of the dependency names. `flocal` ends up empty on every
run, producing a spurious `-<dep>` line in the dependency diff comment on
every PR that touches a slice with `essential` deps.

Fix (`fix:`): read the map's keys instead of splatting its values:

```bash
yq '.slices.[].essential | keys | .[]' "$f"
```

## Related issues/PRs
<!-- If any -->

Fixes #1031. Related to #1030.

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

Not applicable — `.github/scripts/pkg-deps/pkg-deps` only exists on `main`
(checked ubuntu-22.04 through ubuntu-26.04 branches, none have this file).

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->

This is a one-line shell script fix, not a slice definition change — no
slices were added/modified, so the standard slice-testing steps in the
contributing guide don't really apply here; verified instead by tracing
the YAML structure against #1029's actual diff.
