### PR TITLE
feat: register ubuntu-26.10

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -28,8 +28,8 @@ env:
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","v1.3.0","main"]},
-      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.0","main"]},
-      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.4.0","main"]}
+      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.2","main"]},
+      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.4.2","main"]}
     ]
 
 jobs:

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -28,7 +28,8 @@ env:
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","v1.3.0","main"]},
-      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.0","main"]}
+      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.0","main"]},
+      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.4.0","main"]}
     ]
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   # chisel-releases branches to lint on. 
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-25.10","ubuntu-26.04"]') }}
+  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-25.10","ubuntu-26.04","ubuntu-26.10"]') }}
 
 jobs:
   prepare-lint:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ the moment, the officially supported Chisel releases are:
 \- Questing
 - [ubuntu-26.04](https://github.com/canonical/chisel-releases/tree/ubuntu-26.04)
 \- Resolute
+- [ubuntu-26.10](https://github.com/canonical/chisel-releases/tree/ubuntu-26.10)
+\- Stonking
 
 In each release branch, you'll find a `chisel.yaml` file that defines the Chisel
 release, plus a `slices` folder with all the Slice Definitions Files (SDFs) for


### PR DESCRIPTION
# Proposed changes

add ubuntu-26.10 (stonking) to the CI compatibility + lint release lists and the supported-releases README. 

## Related issues/PRs

- closes https://github.com/canonical/chisel-releases/issues/1036

### Forward porting
n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

opened here since it was a blocker for rockcraft developement
