### PR TITLE
fix(26.10): use 'latest' endpoint

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -128,14 +128,26 @@ prepare: |
   arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/g' -e 's/ppc64el/ppc64le/g')"
 
   apt install -y curl wget
-  curl -s https://api.github.com/repos/canonical/chisel/releases/latest \
-    | awk "/browser_download_url/ && /chisel_v/ && /_$arch\./" \
-    | cut -d : -f 2,3 \
-    | tr -d \" \
-    | xargs wget
 
-  sha384sum -c chisel_v*sha384
-  tar -xf chisel_v*tar.gz -C /usr/local/bin
+  # Resolve the latest chisel release without calling api.github.com, whose
+  # unauthenticated REST quota (60 req/hr, shared per source IP) the CI runners
+  # routinely exhaust. An exhausted quota returns no asset URL, and the old
+  # `curl ... | xargs wget` pipeline then died with a cryptic `wget: missing URL`.
+  # The github.com web endpoint 302-redirects to the tagged release and is not
+  # subject to that quota, so we read the tag from the redirect target. See #752.
+  tag="$(curl -fsS -o /dev/null -w '%{redirect_url}' \
+    https://github.com/canonical/chisel/releases/latest | sed 's#.*/tag/##')"
+  if [ -z "$tag" ]; then
+    echo "FATAL: could not resolve latest chisel release tag (github.com unreachable?)" >&2
+    exit 1
+  fi
+
+  base="https://github.com/canonical/chisel/releases/download/$tag"
+  tarball="chisel_${tag}_linux_${arch}.tar.gz"
+  wget "$base/$tarball" "$base/$tarball.sha384"
+
+  sha384sum -c "$tarball.sha384"
+  tar -xf "$tarball" -C /usr/local/bin
 
 prepare-each: chisel version
 


### PR DESCRIPTION
# Proposed changes

fixes https://github.com/canonical/chisel-releases/issues/752

this was stalled for awhile since i used to think we'll have to thread the GITHUB_TOKEN into the lxd setup, which would bring security implications (not impossible, but much more fiddly). i've had another crack at this since it started to come up again in https://github.com/canonical/chisel-releases/pull/1021, and found a solution. turns out we can grab the latest tag "for free" from the redirect of https://github.com/canonical/chisel/releases/latest. the reason we need a version tag first, and can't just grab the artefact is because the tarball name includes a version in its filename and we can only download from https://github.com/canonical/chisel/releases/latest if we already know the asset name (and we don't, since we don't at the time know what's `latest`)

## Related issues/PRs

- https://github.com/canonical/chisel-releases/issues/752
- tested here: https://github.com/canonical/chisel-releases/pull/1056

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1048 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1038
- https://github.com/canonical/chisel-releases/pull/1039
- https://github.com/canonical/chisel-releases/pull/1040
- https://github.com/canonical/chisel-releases/pull/1041
- https://github.com/canonical/chisel-releases/pull/1042

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional information

proof:

```bash
$ curl -fsS -D - https://github.com/canonical/chisel/releases/latest | sed -n '/content-security-policy:/d;/set-cookie:/d;p'
HTTP/2 302
date: Sun, 05 Jul 2026 15:08:14 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With, Sec-Fetch-Site,Accept-Encoding, Accept, X-Requested-With
location: https://github.com/canonical/chisel/releases/tag/v1.4.1
cache-control: no-cache
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: no-referrer-when-downgrade
server: github.com
content-length: 0
x-github-request-id: FFCD:1A2C2D:F66BC5:129F58D:6A4A7381
```

no `x-ratelimit-limit` headers and tag in `location:` (i've dropped `two v long fields with sed). in contrast:

```bash
$ curl -fsS -D - -o /dev/null https://api.github.com/repos/canonical/chisel/releases/latest
HTTP/2 200
date: Sun, 05 Jul 2026 15:12:34 GMT
content-type: application/json; charset=utf-8
...
server: github.com
accept-ranges: bytes
x-ratelimit-limit: 60
x-ratelimit-remaining: 54
x-ratelimit-used: 6
x-ratelimit-resource: core
x-ratelimit-reset: 1783267230
content-length: 25391
x-github-request-id: C02F:384F98:C7C5DA:F1D1BF:6A4A7462
```
