### PR TITLE
feat(26.04): add tomcat11 slices

### DIFF
--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -4,7 +4,7 @@ essential:
   libtomcat11-java_copyright:
 
 slices:
-  i18n-common:
+  i18n:
     contents:
       /usr/share/java/tomcat11-i18n-cs-10*.jar:
       /usr/share/java/tomcat11-i18n-cs.jar:

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -1,0 +1,87 @@
+package: libtomcat11-java
+
+essential:
+  - libtomcat11-java_copyright:
+
+slices:
+  i18n-common:
+    contents:
+      /usr/share/java/tomcat11-i18n-cs-10*.jar:
+      /usr/share/java/tomcat11-i18n-cs.jar:
+      /usr/share/java/tomcat11-i18n-de-10*.jar:
+      /usr/share/java/tomcat11-i18n-de.jar:
+      /usr/share/java/tomcat11-i18n-es-10*.jar:
+      /usr/share/java/tomcat11-i18n-es.jar:
+      /usr/share/java/tomcat11-i18n-fr-10*.jar:
+      /usr/share/java/tomcat11-i18n-fr.jar:
+      /usr/share/java/tomcat11-i18n-ja-10*.jar:
+      /usr/share/java/tomcat11-i18n-ja.jar:
+      /usr/share/java/tomcat11-i18n-ko-10*.jar:
+      /usr/share/java/tomcat11-i18n-ko.jar:
+      /usr/share/java/tomcat11-i18n-pt-BR-10*.jar:
+      /usr/share/java/tomcat11-i18n-pt-BR.jar:
+      /usr/share/java/tomcat11-i18n-ru-10*.jar:
+      /usr/share/java/tomcat11-i18n-ru.jar:
+      /usr/share/java/tomcat11-i18n-zh-CN-10*.jar:
+      /usr/share/java/tomcat11-i18n-zh-CN.jar:
+
+  libs:
+    essential:
+      - libeclipse-jdt-core-java_libs
+    contents:
+      /usr/share/java/tomcat11-annotations-api-10*.jar:
+      /usr/share/java/tomcat11-annotations-api.jar:
+      /usr/share/java/tomcat11-api-10*.jar:
+      /usr/share/java/tomcat11-api.jar:
+      /usr/share/java/tomcat11-catalina-10*.jar:
+      /usr/share/java/tomcat11-catalina-ha-10*.jar:
+      /usr/share/java/tomcat11-catalina-ha.jar:
+      /usr/share/java/tomcat11-catalina.jar:
+      /usr/share/java/tomcat11-coyote-10*.jar:
+      /usr/share/java/tomcat11-coyote.jar:
+      /usr/share/java/tomcat11-dbcp-10*.jar:
+      /usr/share/java/tomcat11-dbcp.jar:
+      /usr/share/java/tomcat11-el-api-10*.jar:
+      /usr/share/java/tomcat11-el-api.jar:
+      /usr/share/java/tomcat11-jasper-10*.jar:
+      /usr/share/java/tomcat11-jasper-el-10*.jar:
+      /usr/share/java/tomcat11-jasper-el.jar:
+      /usr/share/java/tomcat11-jasper.jar:
+      /usr/share/java/tomcat11-jaspic-api-10*.jar:
+      /usr/share/java/tomcat11-jaspic-api.jar:
+      /usr/share/java/tomcat11-jdbc-10*.jar:
+      /usr/share/java/tomcat11-jdbc.jar:
+      /usr/share/java/tomcat11-jni-10*.jar:
+      /usr/share/java/tomcat11-jni.jar:
+      /usr/share/java/tomcat11-jsp-api-10*.jar:
+      /usr/share/java/tomcat11-jsp-api.jar:
+      /usr/share/java/tomcat11-juli-10*.jar:
+      /usr/share/java/tomcat11-juli.jar:
+      /usr/share/java/tomcat11-servlet-api-10*.jar:
+      /usr/share/java/tomcat11-servlet-api.jar:
+      /usr/share/java/tomcat11-storeconfig-10*.jar:
+      /usr/share/java/tomcat11-storeconfig.jar:
+      /usr/share/java/tomcat11-tribes-10*.jar:
+      /usr/share/java/tomcat11-tribes.jar:
+      /usr/share/java/tomcat11-util-10*.jar:
+      /usr/share/java/tomcat11-util-scan-10*.jar:
+      /usr/share/java/tomcat11-util-scan.jar:
+      /usr/share/java/tomcat11-util.jar:
+      /usr/share/java/tomcat11-websocket-10*.jar:
+      /usr/share/java/tomcat11-websocket-api-10*.jar:
+      /usr/share/java/tomcat11-websocket-api.jar:
+      /usr/share/java/tomcat11-websocket-client-api-10*.jar:
+      /usr/share/java/tomcat11-websocket-client-api.jar:
+      /usr/share/java/tomcat11-websocket.jar:
+
+  copyright:
+    contents:
+      /usr/share/doc/libtomcat11-java/copyright:
+
+#  Will be needed for tomcat11-admin package slices
+#  ant:
+#    essential:
+#      libtomcat11-java_jars:
+#    contents:
+#      /usr/share/java/tomcat11-catalina-ant-10*.jar:
+#      /usr/share/java/tomcat11-catalina-ant.jar:

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -27,7 +27,7 @@ slices:
 
   libs:
     essential:
-      libeclipse-jdt-core-java_libs:
+      libeclipse-jdt-core-java_jars
     contents:
       /usr/share/java/tomcat11-annotations-api-10*.jar:
       /usr/share/java/tomcat11-annotations-api.jar:

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -1,7 +1,7 @@
 package: libtomcat11-java
 
 essential:
-  - libtomcat11-java_copyright:
+  libtomcat11-java_copyright:
 
 slices:
   i18n-common:

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -6,71 +6,71 @@ essential:
 slices:
   i18n:
     contents:
-      /usr/share/java/tomcat11-i18n-cs-10*.jar:
+      /usr/share/java/tomcat11-i18n-cs-11*.jar:
       /usr/share/java/tomcat11-i18n-cs.jar:
-      /usr/share/java/tomcat11-i18n-de-10*.jar:
+      /usr/share/java/tomcat11-i18n-de-11*.jar:
       /usr/share/java/tomcat11-i18n-de.jar:
-      /usr/share/java/tomcat11-i18n-es-10*.jar:
+      /usr/share/java/tomcat11-i18n-es-11*.jar:
       /usr/share/java/tomcat11-i18n-es.jar:
-      /usr/share/java/tomcat11-i18n-fr-10*.jar:
+      /usr/share/java/tomcat11-i18n-fr-11*.jar:
       /usr/share/java/tomcat11-i18n-fr.jar:
-      /usr/share/java/tomcat11-i18n-ja-10*.jar:
+      /usr/share/java/tomcat11-i18n-ja-11*.jar:
       /usr/share/java/tomcat11-i18n-ja.jar:
-      /usr/share/java/tomcat11-i18n-ko-10*.jar:
+      /usr/share/java/tomcat11-i18n-ko-11*.jar:
       /usr/share/java/tomcat11-i18n-ko.jar:
-      /usr/share/java/tomcat11-i18n-pt-BR-10*.jar:
+      /usr/share/java/tomcat11-i18n-pt-BR-11*.jar:
       /usr/share/java/tomcat11-i18n-pt-BR.jar:
-      /usr/share/java/tomcat11-i18n-ru-10*.jar:
+      /usr/share/java/tomcat11-i18n-ru-11*.jar:
       /usr/share/java/tomcat11-i18n-ru.jar:
-      /usr/share/java/tomcat11-i18n-zh-CN-10*.jar:
+      /usr/share/java/tomcat11-i18n-zh-CN-11*.jar:
       /usr/share/java/tomcat11-i18n-zh-CN.jar:
 
   jars:
     essential:
       libeclipse-jdt-core-java_jars:
     contents:
-      /usr/share/java/tomcat11-annotations-api-10*.jar:
+      /usr/share/java/tomcat11-annotations-api-11*.jar:
       /usr/share/java/tomcat11-annotations-api.jar:
-      /usr/share/java/tomcat11-api-10*.jar:
+      /usr/share/java/tomcat11-api-11*.jar:
       /usr/share/java/tomcat11-api.jar:
-      /usr/share/java/tomcat11-catalina-10*.jar:
-      /usr/share/java/tomcat11-catalina-ha-10*.jar:
+      /usr/share/java/tomcat11-catalina-11*.jar:
+      /usr/share/java/tomcat11-catalina-ha-11*.jar:
       /usr/share/java/tomcat11-catalina-ha.jar:
       /usr/share/java/tomcat11-catalina.jar:
-      /usr/share/java/tomcat11-coyote-10*.jar:
+      /usr/share/java/tomcat11-coyote-11*.jar:
       /usr/share/java/tomcat11-coyote.jar:
-      /usr/share/java/tomcat11-dbcp-10*.jar:
+      /usr/share/java/tomcat11-dbcp-11*.jar:
       /usr/share/java/tomcat11-dbcp.jar:
-      /usr/share/java/tomcat11-el-api-10*.jar:
+      /usr/share/java/tomcat11-el-api-11*.jar:
       /usr/share/java/tomcat11-el-api.jar:
-      /usr/share/java/tomcat11-jasper-10*.jar:
-      /usr/share/java/tomcat11-jasper-el-10*.jar:
+      /usr/share/java/tomcat11-jasper-11*.jar:
+      /usr/share/java/tomcat11-jasper-el-11*.jar:
       /usr/share/java/tomcat11-jasper-el.jar:
       /usr/share/java/tomcat11-jasper.jar:
-      /usr/share/java/tomcat11-jaspic-api-10*.jar:
+      /usr/share/java/tomcat11-jaspic-api-11*.jar:
       /usr/share/java/tomcat11-jaspic-api.jar:
-      /usr/share/java/tomcat11-jdbc-10*.jar:
+      /usr/share/java/tomcat11-jdbc-11*.jar:
       /usr/share/java/tomcat11-jdbc.jar:
-      /usr/share/java/tomcat11-jni-10*.jar:
+      /usr/share/java/tomcat11-jni-11*.jar:
       /usr/share/java/tomcat11-jni.jar:
-      /usr/share/java/tomcat11-jsp-api-10*.jar:
+      /usr/share/java/tomcat11-jsp-api-11*.jar:
       /usr/share/java/tomcat11-jsp-api.jar:
-      /usr/share/java/tomcat11-juli-10*.jar:
+      /usr/share/java/tomcat11-juli-11*.jar:
       /usr/share/java/tomcat11-juli.jar:
-      /usr/share/java/tomcat11-servlet-api-10*.jar:
+      /usr/share/java/tomcat11-servlet-api-11*.jar:
       /usr/share/java/tomcat11-servlet-api.jar:
-      /usr/share/java/tomcat11-storeconfig-10*.jar:
+      /usr/share/java/tomcat11-storeconfig-11*.jar:
       /usr/share/java/tomcat11-storeconfig.jar:
-      /usr/share/java/tomcat11-tribes-10*.jar:
+      /usr/share/java/tomcat11-tribes-11*.jar:
       /usr/share/java/tomcat11-tribes.jar:
-      /usr/share/java/tomcat11-util-10*.jar:
-      /usr/share/java/tomcat11-util-scan-10*.jar:
+      /usr/share/java/tomcat11-util-11*.jar:
+      /usr/share/java/tomcat11-util-scan-11*.jar:
       /usr/share/java/tomcat11-util-scan.jar:
       /usr/share/java/tomcat11-util.jar:
-      /usr/share/java/tomcat11-websocket-10*.jar:
-      /usr/share/java/tomcat11-websocket-api-10*.jar:
+      /usr/share/java/tomcat11-websocket-11*.jar:
+      /usr/share/java/tomcat11-websocket-api-11*.jar:
       /usr/share/java/tomcat11-websocket-api.jar:
-      /usr/share/java/tomcat11-websocket-client-api-10*.jar:
+      /usr/share/java/tomcat11-websocket-client-api-11*.jar:
       /usr/share/java/tomcat11-websocket-client-api.jar:
       /usr/share/java/tomcat11-websocket.jar:
 

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -27,7 +27,7 @@ slices:
 
   libs:
     essential:
-      - libeclipse-jdt-core-java_libs
+      libeclipse-jdt-core-java_libs:
     contents:
       /usr/share/java/tomcat11-annotations-api-10*.jar:
       /usr/share/java/tomcat11-annotations-api.jar:

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -25,9 +25,9 @@ slices:
       /usr/share/java/tomcat11-i18n-zh-CN-10*.jar:
       /usr/share/java/tomcat11-i18n-zh-CN.jar:
 
-  libs:
+  jars:
     essential:
-      libeclipse-jdt-core-java_jars
+      libeclipse-jdt-core-java_jars:
     contents:
       /usr/share/java/tomcat11-annotations-api-10*.jar:
       /usr/share/java/tomcat11-annotations-api.jar:

--- a/slices/libtomcat11-java.yaml
+++ b/slices/libtomcat11-java.yaml
@@ -83,5 +83,5 @@ slices:
 #    essential:
 #      libtomcat11-java_jars:
 #    contents:
-#      /usr/share/java/tomcat11-catalina-ant-10*.jar:
+#      /usr/share/java/tomcat11-catalina-ant-11*.jar:
 #      /usr/share/java/tomcat11-catalina-ant.jar:

--- a/slices/tomcat11-common.yaml
+++ b/slices/tomcat11-common.yaml
@@ -1,0 +1,108 @@
+package: tomcat11-common
+
+essential:
+  tomcat11-common_copyright:
+
+# NOTE: all the jar files in are symlinks
+# to their corresponding jars from libtomcat11-java except
+# /usr/share/tomcat11/bin/bootstrap.jar
+
+slices:
+  scripts:
+    essential:
+      coreutils_delaying:
+      coreutils_directory-listing:
+      coreutils_dirname:
+      coreutils_echo:
+      coreutils_expr:
+      coreutils_output-of-entire-files:
+      coreutils_rm-bin:
+      coreutils_special-file-types:
+      coreutils_system-context:
+      coreutils_touch:
+      coreutils_working-context:
+      dash_bins:
+      debianutils_which:
+      grep_bins:
+      procps_bins:
+      tomcat11-common_jars:
+    contents:
+      /usr/share/tomcat11/bin/catalina.sh:
+      /usr/share/tomcat11/bin/setclasspath.sh:
+
+  jars:
+    essential:
+      libtomcat11-java_jars:
+      openjdk-21-jre-headless_jfr:
+      openjdk-21-jre-headless_management:
+      openjdk-21-jre-headless_security:
+    contents:
+      /usr/share/tomcat11/bin/bootstrap.jar:
+      /usr/share/tomcat11/bin/tomcat-juli.jar:
+      /usr/share/tomcat11/lib/annotations-api.jar:
+      /usr/share/tomcat11/lib/catalina-ha.jar:
+      /usr/share/tomcat11/lib/catalina-storeconfig.jar:
+      /usr/share/tomcat11/lib/catalina-tribes.jar:
+      /usr/share/tomcat11/lib/catalina.jar:
+      /usr/share/tomcat11/lib/el-api.jar:
+      /usr/share/tomcat11/lib/jasper-el.jar:
+      /usr/share/tomcat11/lib/jasper.jar:
+      /usr/share/tomcat11/lib/jaspic-api.jar:
+      /usr/share/tomcat11/lib/jsp-api.jar:
+      /usr/share/tomcat11/lib/servlet-api.jar:
+      /usr/share/tomcat11/lib/tomcat-api.jar:
+      /usr/share/tomcat11/lib/tomcat-coyote.jar:
+      /usr/share/tomcat11/lib/tomcat-dbcp.jar:
+      /usr/share/tomcat11/lib/tomcat-jdbc.jar:
+      /usr/share/tomcat11/lib/tomcat-jni.jar:
+      /usr/share/tomcat11/lib/tomcat-util-scan.jar:
+      /usr/share/tomcat11/lib/tomcat-util.jar:
+      /usr/share/tomcat11/lib/tomcat-websocket.jar:
+      /usr/share/tomcat11/lib/websocket-api.jar:
+      /usr/share/tomcat11/lib/websocket-client-api.jar:
+
+  i18n:
+    essential:
+      libtomcat11-java_i18n:
+      tomcat11-common_jars:
+    contents:
+      /usr/share/tomcat11/lib/tomcat-i18n-es.jar:
+      /usr/share/tomcat11/lib/tomcat-i18n-fr.jar:
+      /usr/share/tomcat11/lib/tomcat-i18n-ja.jar:
+      /usr/share/tomcat11/lib/tomcat-i18n-ru.jar:
+
+  # additional shell scripts
+  extra-scripts:
+    essential:
+      tomcat11-common_scripts:
+    contents:
+      /usr/share/tomcat11/bin/ciphers.sh:
+      /usr/share/tomcat11/bin/configtest.sh:
+      # needs jsvc - also contains bug hardcodes
+      # /usr/share/tomcat11/bin/jsvc: not found
+      # /usr/share/tomcat11/bin/daemon.sh:
+      /usr/share/tomcat11/bin/digest.sh:
+      /usr/share/tomcat11/bin/makebase.sh:
+      # java.lang.ClassNotFoundException:
+      # org.apache.tomcat.jakartaee.MigrationCLI
+      # packaging error, do not install
+      # /usr/share/tomcat11/bin/migrate.sh:
+      /usr/share/tomcat11/bin/shutdown.sh:
+      /usr/share/tomcat11/bin/startup.sh:
+      # used by other tools such as digest.sh, makebase.sh
+      /usr/share/tomcat11/bin/tool-wrapper.sh:
+      /usr/share/tomcat11/bin/version.sh:
+
+  copyright:
+    contents:
+      /usr/share/doc/tomcat11-common/copyright:
+
+#  Will be needed if tomcat11-admin is sliced
+#  ant:
+#    essential:
+#      - tomcat11-common_jars
+#      tomcat11-common_jars:
+#      libtomcat11-java_ant:
+#    contents:
+#      /usr/share/tomcat11/bin/catalina-tasks.xml:
+#      /usr/share/tomcat11/lib/catalina-ant.jar:

--- a/slices/tomcat11-common.yaml
+++ b/slices/tomcat11-common.yaml
@@ -33,9 +33,9 @@ slices:
   jars:
     essential:
       libtomcat11-java_jars:
-      openjdk-21-jre-headless_jfr:
-      openjdk-21-jre-headless_management:
-      openjdk-21-jre-headless_security:
+      openjdk-25-jre-headless_jfr:
+      openjdk-25-jre-headless_management:
+      openjdk-25-jre-headless_security:
     contents:
       /usr/share/tomcat11/bin/bootstrap.jar:
       /usr/share/tomcat11/bin/tomcat-juli.jar:

--- a/slices/tomcat11-common.yaml
+++ b/slices/tomcat11-common.yaml
@@ -8,7 +8,7 @@ essential:
 # /usr/share/tomcat11/bin/bootstrap.jar
 
 slices:
-  scripts:
+  catalina:
     essential:
       coreutils_delaying:
       coreutils_directory-listing:
@@ -26,8 +26,17 @@ slices:
       grep_bins:
       procps_bins:
       tomcat11-common_jars:
+      tomcat11-common_setclasspath:
     contents:
       /usr/share/tomcat11/bin/catalina.sh:
+
+  setclasspath:
+    essential:
+      coreutils_dirname:
+      dash_bins:
+      debianutils_which:
+      openjdk-25-jre-headless_core:
+    contents:
       /usr/share/tomcat11/bin/setclasspath.sh:
 
   jars:
@@ -72,9 +81,10 @@ slices:
       /usr/share/tomcat11/lib/tomcat-i18n-ru.jar:
 
   # additional shell scripts
-  extra-scripts:
+  scripts:
     essential:
-      tomcat11-common_scripts:
+      tomcat11-common_catalina:
+      tomcat11-common_setclasspath:
     contents:
       /usr/share/tomcat11/bin/ciphers.sh:
       /usr/share/tomcat11/bin/configtest.sh:

--- a/slices/tomcat11-common.yaml
+++ b/slices/tomcat11-common.yaml
@@ -85,6 +85,11 @@ slices:
     essential:
       tomcat11-common_catalina:
       tomcat11-common_setclasspath:
+
+  extra-scripts:
+    essential:
+      tomcat11-common_catalina:
+      tomcat11-common_setclasspath:
     contents:
       /usr/share/tomcat11/bin/ciphers.sh:
       /usr/share/tomcat11/bin/configtest.sh:

--- a/slices/tomcat11.yaml
+++ b/slices/tomcat11.yaml
@@ -17,11 +17,6 @@ slices:
         copy: /usr/share/tomcat11/etc/jaspic-providers.xml
       /etc/tomcat11/logging.properties:
         copy: /usr/share/tomcat11/etc/logging.properties
-      /etc/tomcat11/policy.d/01system.policy:
-      /etc/tomcat11/policy.d/02debian.policy:
-      /etc/tomcat11/policy.d/03catalina.policy:
-      /etc/tomcat11/policy.d/04webapps.policy:
-      /etc/tomcat11/policy.d/50local.policy:
       /etc/tomcat11/server.xml:
         copy: /usr/share/tomcat11/etc/server.xml
       /etc/tomcat11/tomcat-users.xml:

--- a/slices/tomcat11.yaml
+++ b/slices/tomcat11.yaml
@@ -1,0 +1,52 @@
+package: tomcat11
+
+essential:
+  tomcat11_copyright:
+
+slices:
+  core:
+    essential:
+      tomcat11-common_scripts:
+    contents:
+      /etc/tomcat11/Catalina/:
+      /etc/tomcat11/catalina.properties:
+        copy: /usr/share/tomcat11/etc/catalina.properties
+      /etc/tomcat11/context.xml:
+        copy: /usr/share/tomcat11/etc/context.xml
+      /etc/tomcat11/jaspic-providers.xml:
+        copy: /usr/share/tomcat11/etc/jaspic-providers.xml
+      /etc/tomcat11/logging.properties:
+        copy: /usr/share/tomcat11/etc/logging.properties
+      /etc/tomcat11/policy.d/01system.policy:
+      /etc/tomcat11/policy.d/02debian.policy:
+      /etc/tomcat11/policy.d/03catalina.policy:
+      /etc/tomcat11/policy.d/04webapps.policy:
+      /etc/tomcat11/policy.d/50local.policy:
+      /etc/tomcat11/server.xml:
+        copy: /usr/share/tomcat11/etc/server.xml
+      /etc/tomcat11/tomcat-users.xml:
+        copy: /usr/share/tomcat11/etc/tomcat-users.xml
+      /etc/tomcat11/web.xml:
+        copy: /usr/share/tomcat11/etc/web.xml
+      /var/cache/tomcat11/:
+        make: true
+      /var/lib/tomcat11/conf:
+      /var/lib/tomcat11/lib/:
+      /var/lib/tomcat11/logs:
+      /var/lib/tomcat11/webapps/:
+      /var/lib/tomcat11/work:
+      /var/log/tomcat11/:
+
+  standard:
+    essential:
+      tomcat11-common_i18n:
+      tomcat11_core:
+
+  dev:
+    essential:
+      tomcat11-common_extra-scripts:
+      tomcat11_standard:
+
+  copyright:
+    content:
+      /usr/share/doc/tomcat11/copyright:

--- a/slices/tomcat11.yaml
+++ b/slices/tomcat11.yaml
@@ -6,7 +6,7 @@ essential:
 slices:
   core:
     essential:
-      tomcat11-common_scripts:
+      tomcat11-common_catalina:
     contents:
       /etc/tomcat11/Catalina/:
       /etc/tomcat11/catalina.properties:
@@ -39,7 +39,7 @@ slices:
 
   dev:
     essential:
-      tomcat11-common_extra-scripts:
+      tomcat11-common_scripts:
       tomcat11_standard:
 
   copyright:

--- a/slices/tomcat11.yaml
+++ b/slices/tomcat11.yaml
@@ -43,5 +43,5 @@ slices:
       tomcat11_standard:
 
   copyright:
-    content:
+    contents:
       /usr/share/doc/tomcat11/copyright:

--- a/slices/tomcat11.yaml
+++ b/slices/tomcat11.yaml
@@ -39,7 +39,7 @@ slices:
 
   dev:
     essential:
-      tomcat11-common_scripts:
+      tomcat11-common_extra-scripts:
       tomcat11_standard:
 
   copyright:

--- a/tests/spread/integration/tomcat11-common/task.yaml
+++ b/tests/spread/integration/tomcat11-common/task.yaml
@@ -1,0 +1,16 @@
+summary: Integration tests for tomcat11-common
+
+execute: |
+  # tomcat needs an openjdk and shell
+  rootfs="$(install-slices tomcat11-common_core base-files_base coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
+  cd ${rootfs}
+  mkdir -p proc sys tmp dev
+  mount --bind /proc proc
+  mount --bind /sys sys
+  mount --bind /tmp tmp
+  mount --bind /dev dev
+  for java in `find usr/lib/jvm -name java`; do
+    export JAVA_HOME="/$(dirname $(dirname ${java}))"
+    export CATALINA_BASE="/var/lib/tomcat11"
+    chroot . /usr/share/tomcat11/bin/catalina.sh version
+  done

--- a/tests/spread/integration/tomcat11-common/task.yaml
+++ b/tests/spread/integration/tomcat11-common/task.yaml
@@ -24,17 +24,17 @@ execute: |
 
   case ${SLICE} in
     extra-scripts)
-      chroot "$rootfs" /usr/share/tomcat10/bin/ciphers.sh \
+      chroot "$rootfs" /usr/share/tomcat11/bin/ciphers.sh \
         | grep -q TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      chroot "$rootfs" /usr/share/tomcat10/bin/digest.sh foo \
+      chroot "$rootfs" /usr/share/tomcat11/bin/digest.sh foo \
         | grep -q "foo"
-      chroot "$rootfs" /usr/share/tomcat10/bin/makebase.sh foo \
+      chroot "$rootfs" /usr/share/tomcat11/bin/makebase.sh foo \
         | grep -q "Created CATALINA_BASE directory at foo"
-      chroot "$rootfs" /usr/share/tomcat10/bin/version.sh \
+      chroot "$rootfs" /usr/share/tomcat11/bin/version.sh \
         | grep -q "Apache Tomcat"
     ;;
     scripts)
-      chroot "$rootfs" /usr/share/tomcat10/bin/catalina.sh version \
+      chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh version \
         | grep -q "Apache Tomcat/11"
     ;;
   esac

--- a/tests/spread/integration/tomcat11-common/task.yaml
+++ b/tests/spread/integration/tomcat11-common/task.yaml
@@ -1,16 +1,40 @@
 summary: Integration tests for tomcat11-common
 
+environment:
+  SLICE/scripts: "scripts"
+  SLICE/extrascripts: "extra-scripts"
+
+restore: |
+  killall java || true
+
 execute: |
-  # tomcat needs an openjdk and shell
-  rootfs="$(install-slices tomcat11-common_core base-files_base coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
-  cd ${rootfs}
-  mkdir -p proc sys tmp dev
-  mount --bind /proc proc
-  mount --bind /sys sys
-  mount --bind /tmp tmp
-  mount --bind /dev dev
-  for java in `find usr/lib/jvm -name java`; do
-    export JAVA_HOME="/$(dirname $(dirname ${java}))"
-    export CATALINA_BASE="/var/lib/tomcat11"
-    chroot . /usr/share/tomcat11/bin/catalina.sh version
-  done
+  rootfs="$(install-slices tomcat11-common_${SLICE})"
+  java=$(find "$rootfs" -name java -type f -printf '%P\n' -quit 2>/dev/null)
+
+  # Make fake /dev/null and mount /proc
+  mkdir -p "$rootfs/dev"
+  touch "$rootfs/dev/null"
+  chmod +x "$rootfs/dev/null"
+  mkdir -p "$rootfs/proc"
+  sudo mount --bind /proc "$rootfs/proc"
+  trap 'sudo umount "$rootfs/proc"' EXIT
+
+  export JAVA_HOME="/$(dirname $(dirname ${java}))"
+  export CATALINA_BASE="/var/lib/tomcat11"
+
+  case ${SLICE} in
+    extra-scripts)
+      chroot "$rootfs" /usr/share/tomcat10/bin/ciphers.sh \
+        | grep -q TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      chroot "$rootfs" /usr/share/tomcat10/bin/digest.sh foo \
+        | grep -q "foo"
+      chroot "$rootfs" /usr/share/tomcat10/bin/makebase.sh foo \
+        | grep -q "Created CATALINA_BASE directory at foo"
+      chroot "$rootfs" /usr/share/tomcat10/bin/version.sh \
+        | grep -q "Apache Tomcat"
+    ;;
+    scripts)
+      chroot "$rootfs" /usr/share/tomcat10/bin/catalina.sh version \
+        | grep -q "Apache Tomcat/11"
+    ;;
+  esac

--- a/tests/spread/integration/tomcat11-common/task.yaml
+++ b/tests/spread/integration/tomcat11-common/task.yaml
@@ -1,8 +1,9 @@
 summary: Integration tests for tomcat11-common
 
 environment:
+  SLICE/catalina: "catalina"
+  SLICE/setclasspath: "setclasspath"
   SLICE/scripts: "scripts"
-  SLICE/extrascripts: "extra-scripts"
 
 restore: |
   killall java || true
@@ -23,7 +24,18 @@ execute: |
   export CATALINA_BASE="/var/lib/tomcat11"
 
   case ${SLICE} in
-    extra-scripts)
+    catalina)
+      chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh version \
+        | grep -q "Apache Tomcat/11"
+    ;;
+    setclasspath)
+      # no output here, script succeeds
+      chroot "$rootfs" /usr/share/tomcat11/bin/setclasspath.sh
+      unset JAVA_HOME
+      chroot "$rootfs" /usr/share/tomcat11/bin/setclasspath.sh \
+       | grep -q "Neither the JAVA_HOME nor the JRE_HOME environment variable is defined"
+    ;;
+    scripts)
       chroot "$rootfs" /usr/share/tomcat11/bin/ciphers.sh \
         | grep -q TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       chroot "$rootfs" /usr/share/tomcat11/bin/digest.sh foo \
@@ -32,9 +44,5 @@ execute: |
         | grep -q "Created CATALINA_BASE directory at foo"
       chroot "$rootfs" /usr/share/tomcat11/bin/version.sh \
         | grep -q "Apache Tomcat"
-    ;;
-    scripts)
-      chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh version \
-        | grep -q "Apache Tomcat/11"
     ;;
   esac

--- a/tests/spread/integration/tomcat11-common/task.yaml
+++ b/tests/spread/integration/tomcat11-common/task.yaml
@@ -35,7 +35,7 @@ execute: |
       chroot "$rootfs" /usr/share/tomcat11/bin/setclasspath.sh \
        | grep -q "Neither the JAVA_HOME nor the JRE_HOME environment variable is defined"
     ;;
-    extrascripts)
+    extra-scripts)
       chroot "$rootfs" /usr/share/tomcat11/bin/ciphers.sh \
         | grep -q TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       chroot "$rootfs" /usr/share/tomcat11/bin/digest.sh foo \

--- a/tests/spread/integration/tomcat11-common/task.yaml
+++ b/tests/spread/integration/tomcat11-common/task.yaml
@@ -3,7 +3,7 @@ summary: Integration tests for tomcat11-common
 environment:
   SLICE/catalina: "catalina"
   SLICE/setclasspath: "setclasspath"
-  SLICE/scripts: "scripts"
+  SLICE/extrascripts: "extra-scripts"
 
 restore: |
   killall java || true
@@ -35,7 +35,7 @@ execute: |
       chroot "$rootfs" /usr/share/tomcat11/bin/setclasspath.sh \
        | grep -q "Neither the JAVA_HOME nor the JRE_HOME environment variable is defined"
     ;;
-    scripts)
+    extrascripts)
       chroot "$rootfs" /usr/share/tomcat11/bin/ciphers.sh \
         | grep -q TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       chroot "$rootfs" /usr/share/tomcat11/bin/digest.sh foo \

--- a/tests/spread/integration/tomcat11/task.yaml
+++ b/tests/spread/integration/tomcat11/task.yaml
@@ -1,0 +1,16 @@
+summary: Integration tests for tomcat11
+
+execute: |
+  # tomcat needs an openjdk and shell
+  rootfs="$(install-slices tomcat11_core base-files_base coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
+  cd ${rootfs}
+  mkdir -p proc sys tmp dev
+  mount --bind /proc proc
+  mount --bind /sys sys
+  mount --bind /tmp tmp
+  mount --bind /dev dev
+  for java in `find usr/lib/jvm -name java`; do
+    export JAVA_HOME="/$(dirname $(dirname ${java}))"
+    export CATALINA_BASE="/var/lib/tomcat11"
+    chroot . /usr/share/tomcat11/bin/catalina.sh configtest
+  done

--- a/tests/spread/integration/tomcat11/task.yaml
+++ b/tests/spread/integration/tomcat11/task.yaml
@@ -1,16 +1,56 @@
 summary: Integration tests for tomcat11
 
+environment:
+  SLICE/core: "core"
+  SLICE/standard: "standard"
+# no change in tests over tomcat11-common_extra-scripts
+#  SLICE/dev: "dev"
+
+restore: |
+  killall java || true
+
 execute: |
-  # tomcat needs an openjdk and shell
-  rootfs="$(install-slices tomcat11_core base-files_base coreutils_bins dash_bins openjdk-21-jdk-headless_standard)"
-  cd ${rootfs}
-  mkdir -p proc sys tmp dev
-  mount --bind /proc proc
-  mount --bind /sys sys
-  mount --bind /tmp tmp
-  mount --bind /dev dev
-  for java in `find usr/lib/jvm -name java`; do
-    export JAVA_HOME="/$(dirname $(dirname ${java}))"
-    export CATALINA_BASE="/var/lib/tomcat11"
-    chroot . /usr/share/tomcat11/bin/catalina.sh configtest
-  done
+  rootfs="$(install-slices tomcat11_${SLICE})"
+  java=$(find "$rootfs" -name java -type f -printf '%P\n' -quit 2>/dev/null)
+
+  # Make fake /dev/null and mount /proc
+  mkdir -p "$rootfs/dev"
+  touch "$rootfs/dev/null"
+  chmod +x "$rootfs/dev/null"
+  mkdir -p "$rootfs/proc"
+  sudo mount --bind /proc "$rootfs/proc"
+  trap 'sudo umount "$rootfs/proc"' EXIT
+
+  export JAVA_HOME="/$(dirname $(dirname ${java}))"
+  export CATALINA_BASE="/var/lib/tomcat11"
+  chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh configtest 2>&1 \
+    | grep -q "Server initialization in"
+
+  case ${SLICE} in
+    standard)
+      apt-get update
+      apt-get install -y retry
+      chroot "$rootfs" /bin/sh -c \
+        "JAVA_OPTS=-Duser.language=ru /usr/share/tomcat11/bin/catalina.sh start"
+      retry --times=3 --delay 5 -- grep -q "org.apache.catalina.startup.Catalina.start" "$rootfs/var/lib/tomcat10/logs/catalina.out"
+      chroot "$rootfs" /bin/sh -c \
+        "JAVA_OPTS=-Duser.language=ru /usr/share/tomcat11/bin/catalina.sh stop"
+      grep "Инициализация" $rootfs/var/lib/tomcat10/logs/*.log
+    ;;
+    core)
+      chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh version \
+        | grep -q "Apache Tomcat/11"
+
+      apt-get update
+      apt-get install -y maven default-jdk retry
+      mvn archetype:generate -DgroupId=com.example \
+        -DartifactId=hello-world-war \
+        -DarchetypeArtifactId=maven-archetype-webapp \
+        -DarchetypeVersion=1.4  -DinteractiveMode=false
+      (cd hello-world-war && mvn package)
+      cp hello-world-war/target/*.war "$rootfs/var/lib/tomcat10/webapps"
+      chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh start
+      (retry --times=10 --delay 2 -- curl http://localhost:8080/hello-world-war/) | grep -q "Hello World!"
+      chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh stop
+    ;;
+  esac

--- a/tests/spread/integration/tomcat11/task.yaml
+++ b/tests/spread/integration/tomcat11/task.yaml
@@ -32,10 +32,10 @@ execute: |
       apt-get install -y retry
       chroot "$rootfs" /bin/sh -c \
         "JAVA_OPTS=-Duser.language=ru /usr/share/tomcat11/bin/catalina.sh start"
-      retry --times=3 --delay 5 -- grep -q "org.apache.catalina.startup.Catalina.start" "$rootfs/var/lib/tomcat10/logs/catalina.out"
+      retry --times=3 --delay 5 -- grep -q "org.apache.catalina.startup.Catalina.start" "$rootfs/var/lib/tomcat11/logs/catalina.out"
       chroot "$rootfs" /bin/sh -c \
         "JAVA_OPTS=-Duser.language=ru /usr/share/tomcat11/bin/catalina.sh stop"
-      grep "Инициализация" $rootfs/var/lib/tomcat10/logs/*.log
+      grep "Инициализация" $rootfs/var/lib/tomcat11/logs/*.log
     ;;
     core)
       chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh version \
@@ -48,7 +48,7 @@ execute: |
         -DarchetypeArtifactId=maven-archetype-webapp \
         -DarchetypeVersion=1.4  -DinteractiveMode=false
       (cd hello-world-war && mvn package)
-      cp hello-world-war/target/*.war "$rootfs/var/lib/tomcat10/webapps"
+      cp hello-world-war/target/*.war "$rootfs/var/lib/tomcat11/webapps"
       chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh start
       (retry --times=10 --delay 2 -- curl http://localhost:8080/hello-world-war/) | grep -q "Hello World!"
       chroot "$rootfs" /usr/share/tomcat11/bin/catalina.sh stop


### PR DESCRIPTION
Tomcat11 package layout is the same as tomcat10.

Copy the tomcat10 slices.

# Proposed changes
Tomcat11 package layout is the same as tomcat10.
Copy the tomcat10 slices.

Added refactoring to improve slice naming:
 - scripts renamed to catalina
 - setclasspath split into separate slice
 - extra-scripts renamed to scripts


## Related issues/PRs

Migrate tomcat10 in 26.10 to the new slice structure https://github.com/canonical/chisel-releases/pull/1141

### Forward porting
https://github.com/canonical/chisel-releases/pull/1052

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->