### PR TITLE
fix(26.10): use default jdk instead of 21

### DIFF
--- a/slices/tomcat10-common.yaml
+++ b/slices/tomcat10-common.yaml
@@ -33,9 +33,9 @@ slices:
   jars:
     essential:
       libtomcat10-java_jars:
-      openjdk-21-jre-headless_jfr:
-      openjdk-21-jre-headless_management:
-      openjdk-21-jre-headless_security:
+      openjdk-25-jre-headless_jfr:
+      openjdk-25-jre-headless_management:
+      openjdk-25-jre-headless_security:
     contents:
       /usr/share/tomcat10/bin/bootstrap.jar:
       /usr/share/tomcat10/bin/tomcat-juli.jar:


### PR DESCRIPTION
# Proposed changes

Forward port of https://github.com/canonical/chisel-releases/pull/1061

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->