### PR TITLE
test(25.10): add bash coverage

### DIFF
--- a/tests/spread/integration/bash/task.yaml
+++ b/tests/spread/integration/bash/task.yaml
@@ -1,0 +1,3 @@
+summary: Integration tests for bash
+
+execute: bash -ex ./test_bash.sh

--- a/tests/spread/integration/bash/test_bash.sh
+++ b/tests/spread/integration/bash/test_bash.sh
@@ -1,0 +1,7 @@
+rootfs="$(install-slices bash_bins)"
+
+chroot "$rootfs" bash -c "echo Success > /test"
+
+test "$(cat "$rootfs/test")" == "Success"
+
+env --ignore-environment chroot "$rootfs" bash -c "[[ -n \$BASH_VERSION ]]"


### PR DESCRIPTION
# Proposed changes

Add a Spread integration test for the `bash_bins` slice. The test:

- installs the slice into a clean root filesystem;
- runs Bash inside the chroot and verifies file output;
- starts Bash with an empty environment and verifies `BASH_VERSION` is set.

This brings the older maintained release branches in line with the Bash
coverage already present on `ubuntu-26.04` and `ubuntu-26.10`.

## Related issues/PRs

Closes #1010

### Forward porting

Part of the required `20.04` -> `22.04` -> `24.04` -> `25.10` forward-port
chain. Links will be added after all four drafts exist. The newer `26.04` and
`26.10` branches already contain equivalent coverage.

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [ ] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [ ] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)

## Additional Context

Local validation:

- `bash -n tests/spread/integration/bash/test_bash.sh`
- parsed `tests/spread/integration/bash/task.yaml` with PyYAML
- `git diff --check`

The full Spread test requires Linux with LXD and is left to upstream CI.
