### PR TITLE
test(22.04): add bash coverage

### DIFF
--- a/tests/spread/integration/bash/task.yaml
+++ b/tests/spread/integration/bash/task.yaml
@@ -1,0 +1,3 @@
+summary: Integration tests for bash
+
+execute: bash -ex ./test_bash.sh

--- a/tests/spread/integration/bash/test_bash.sh
+++ b/tests/spread/integration/bash/test_bash.sh
@@ -1,0 +1,7 @@
+rootfs="$(install-slices bash_bins)"
+
+chroot "$rootfs" bash -c "echo Success > /test"
+
+test "$(cat "$rootfs/test")" == "Success"
+
+env --ignore-environment chroot "$rootfs" bash -c "[[ -n \$BASH_VERSION ]]"

--- a/tests/spread/integration/bash/test_bash.sh
+++ b/tests/spread/integration/bash/test_bash.sh
@@ -4,4 +4,4 @@ chroot "$rootfs" bash -c "echo Success > /test"
 
 test "$(cat "$rootfs/test")" == "Success"
 
-env --ignore-environment chroot "$rootfs" bash -c "[[ -n \$BASH_VERSION ]]"
+chroot "$rootfs" bash -c "[[ -n \$BASH_VERSION ]]"


### PR DESCRIPTION
Part of the Bash slice coverage work for #1010.

This PR applies the integration test to `ubuntu-22.04`. The project maintains each Ubuntu release on a separate branch, so the same change needs three linked PRs:

- #1072 — Ubuntu 20.04
- #1070 — Ubuntu 22.04
- #1069 — Ubuntu 24.04

The test installs the `bash_bins` slice in a clean root filesystem, runs Bash inside the chroot, and checks that Bash also starts with an empty environment.

Checked locally with `bash -n` and a YAML parse. The full Spread suite needs Linux with LXD and was not run locally. The Canonical contributor agreement is signed.