### PR TITLE
chore(25.10): ubuntu-25.10 EOL

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -27,7 +27,6 @@ env:
       {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
-      {"ref": "ubuntu-25.10", "chisel-versions": ["v1.2.0","v1.3.0","main"]},
       {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.2","main"]},
       {"ref": "ubuntu-26.10", "chisel-versions": ["v1.4.2","main"]}
     ]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   # chisel-releases branches to lint on. 
-  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-25.10","ubuntu-26.04","ubuntu-26.10"]') }}
+  RELEASES: ${{ toJson('["ubuntu-20.04","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04","ubuntu-26.10"]') }}
 
 jobs:
   prepare-lint:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the moment, the officially supported Chisel releases are:
 - [ubuntu-25.04](https://github.com/canonical/chisel-releases/tree/ubuntu-25.04)
 \- Plucky (EOL)
 - [ubuntu-25.10](https://github.com/canonical/chisel-releases/tree/ubuntu-25.10)
-\- Questing
+\- Questing (EOL)
 - [ubuntu-26.04](https://github.com/canonical/chisel-releases/tree/ubuntu-26.04)
 \- Resolute
 - [ubuntu-26.10](https://github.com/canonical/chisel-releases/tree/ubuntu-26.10)


### PR DESCRIPTION
# Proposed changes

25.10 is now EOL. this PR makes all the appropriate changes for that to be the case.

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)