### PR TITLE
feat(26.04): add rsyslog related slices 

### DIFF
--- a/slices/libestr0.yaml
+++ b/slices/libestr0.yaml
@@ -1,0 +1,16 @@
+package: libestr0
+
+essential:
+  libestr0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libestr.so.0:
+      /usr/lib/*-linux-*/libestr.so.0.0.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libestr0/copyright:

--- a/slices/libfastjson4.yaml
+++ b/slices/libfastjson4.yaml
@@ -1,0 +1,16 @@
+package: libfastjson4
+
+essential:
+  libfastjson4_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libfastjson.so.4:
+      /usr/lib/*-linux-*/libfastjson.so.4.3.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfastjson4/copyright:

--- a/slices/rsyslog.yaml
+++ b/slices/rsyslog.yaml
@@ -1,0 +1,48 @@
+package: rsyslog
+
+essential:
+  rsyslog_copyright:
+
+slices:
+  bins:
+    essential:
+      libc6_libs:
+      libestr0_libs:
+      libfastjson4_libs:
+      libsystemd0_libs:
+      libuuid1_libs:
+      rsyslog_config:
+      rsyslog_data:
+      zlib1g_libs:
+    contents:
+      /usr/sbin/rsyslogd:
+
+  data:
+    contents:
+      /var/spool/rsyslog/:
+
+  config:
+    essential:
+      rsyslog_libs:
+    contents:
+      /etc/logcheck/ignore.d.server/rsyslog:
+      /etc/logrotate.d/rsyslog:
+      /etc/rsyslog.conf:
+      /etc/rsyslog.d/50-default.conf:
+        copy: /usr/share/rsyslog/50-default.conf
+      /etc/systemd/system/multi-user.target.wants/rsyslog.service:
+        symlink: /usr/lib/systemd/system/rsyslog.service
+
+  libs:
+    essential:
+      libc6_libs:
+      libfastjson4_libs:
+      libsystemd0_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/lib/*-linux-*/rsyslog/*.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/rsyslog/copyright:

--- a/tests/spread/integration/libestr0/task.yaml
+++ b/tests/spread/integration/libestr0/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libestr0
+
+execute: |
+  rootfs="$(install-slices libestr0_libs)"
+
+  for f in "${rootfs}"/usr/lib/*/libestr.so.0 "${rootfs}"/usr/lib/*/libestr.so.0.0.0; do
+    test -f "$f"
+    head -c4 "$f" | grep -Fiq "ELF"
+  done

--- a/tests/spread/integration/libfastjson4/task.yaml
+++ b/tests/spread/integration/libfastjson4/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libfastjson4
+
+execute: |
+  rootfs="$(install-slices libfastjson4_libs)"
+
+  for f in "${rootfs}"/usr/lib/*/libfastjson.so.4 "${rootfs}"/usr/lib/*/libfastjson.so.4.3.0; do
+    test -f "$f"
+    head -c4 "$f" | grep -Fiq "ELF"
+  done

--- a/tests/spread/integration/rsyslog/task.yaml
+++ b/tests/spread/integration/rsyslog/task.yaml
@@ -1,0 +1,23 @@
+summary: Integration tests for rsyslog
+
+execute: |
+
+  # rsyslog_bins
+  rootfs="$(install-slices rsyslog_bins)"
+  chroot "$rootfs" rsyslogd --version 2>&1 | grep -Fiq "rsyslogd"
+
+  # rsyslog_libs
+  rootfs_libs="$(install-slices rsyslog_libs)"
+
+  for f in "${rootfs_libs}"/usr/lib/*/rsyslog/imuxsock.so "${rootfs_libs}"/usr/lib/*/rsyslog/imtcp.so; do
+    test -f "$f"
+    head -c4 "$f" | grep -Fiq "ELF"
+  done
+
+  # rsyslog_config
+  rootfs_config="$(install-slices rsyslog_config)"
+
+  test -f "${rootfs_config}/etc/rsyslog.conf"
+  test -f "${rootfs_config}/etc/rsyslog.d/50-default.conf"
+  test -f "${rootfs_config}/etc/logrotate.d/rsyslog"
+  test -L "${rootfs_config}/etc/systemd/system/multi-user.target.wants/rsyslog.service"

--- a/tests/spread/integration/rsyslog/task.yaml
+++ b/tests/spread/integration/rsyslog/task.yaml
@@ -3,8 +3,13 @@ summary: Integration tests for rsyslog
 execute: |
 
   # rsyslog_bins
-  rootfs="$(install-slices rsyslog_bins)"
-  chroot "$rootfs" rsyslogd --version 2>&1 | grep -Fiq "rsyslogd"
+  rootfs="$(install-slices base-passwd_data base-files_base rsyslog_bins)"
+  sed -i 's/^\($FileOwner[[:space:]]\+\)syslog/\1root/' "${rootfs}/etc/rsyslog.conf"
+  sed -i 's/^\($PrivDropToUser[[:space:]]\+\)syslog/\1root/' "${rootfs}/etc/rsyslog.conf"
+  sed -i 's/^\($PrivDropToGroup[[:space:]]\+\)syslog/\1root/' "${rootfs}/etc/rsyslog.conf"
+
+  chroot ${rootfs} /usr/sbin/rsyslogd
+  pkill rsyslogd
 
   # rsyslog_libs
   rootfs_libs="$(install-slices rsyslog_libs)"


### PR DESCRIPTION
# Proposed changes

This PR add slices for rsyslog package and its dependencies: libestr0, libfastjson4.

### Forward porting
#1086 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->