### PR TITLE
feat(26.04): add libnl-cli-3-200 related slices

### DIFF
--- a/slices/libnl-cli-3-200.yaml
+++ b/slices/libnl-cli-3-200.yaml
@@ -1,0 +1,29 @@
+package: libnl-cli-3-200
+
+essential:
+  libnl-cli-3-200_copyright:
+
+slices:
+  cls:
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+      libnl-nf-3-200_libs:
+      libnl-route-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libnl-cli-3.so.200*:
+      /usr/lib/*-linux-*/libnl/cli/cls/*.so:
+
+  qdisc:
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+      libnl-nf-3-200_libs:
+      libnl-route-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libnl-cli-3.so.200*:
+      /usr/lib/*-linux-*/libnl/cli/qdisc/*.so*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-cli-3-200/copyright:

--- a/slices/libnl-genl-3-200.yaml
+++ b/slices/libnl-genl-3-200.yaml
@@ -1,0 +1,16 @@
+package: libnl-genl-3-200
+
+essential:
+  libnl-genl-3-200_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libnl-genl-3.so.200*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-genl-3-200/copyright:

--- a/slices/libnl-nf-3-200.yaml
+++ b/slices/libnl-nf-3-200.yaml
@@ -1,0 +1,17 @@
+package: libnl-nf-3-200
+
+essential:
+  libnl-nf-3-200_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+      libnl-route-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libnl-nf-3.so.200*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-nf-3-200/copyright:

--- a/slices/libnl-route-3-200.yaml
+++ b/slices/libnl-route-3-200.yaml
@@ -1,0 +1,16 @@
+package: libnl-route-3-200
+
+essential:
+  libnl-route-3-200_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libnl-route-3.so.200*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnl-route-3-200/copyright:


### PR DESCRIPTION
# Proposed changes
This PR add slices for libnl-cli-3-200 package and its dependencies: libnl-route-3-200、libnl-genl-3-200、libnl-nf-3-200、libnl-cli-3-200.

### Forward porting
#1088 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->