### PR TITLE
fix(ci): don't run automatic workflows in forks

### DIFF
--- a/.github/workflows/check-releases-archives.yaml
+++ b/.github/workflows/check-releases-archives.yaml
@@ -13,7 +13,6 @@ jobs:
     # By default don't run unattended in forks
     if: >-
       github.repository_owner == 'canonical'
-      || github.event_name == 'pull_request'
       || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.maintained-releases }}

--- a/.github/workflows/check-releases-archives.yaml
+++ b/.github/workflows/check-releases-archives.yaml
@@ -10,6 +10,11 @@ jobs:
   infer-releases:
     runs-on: ubuntu-latest
     name: "Infer releases to check"
+    # Don't run unattended in forks; see install-slices.yaml.
+    if: >-
+      github.repository_owner == 'canonical'
+      || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.maintained-releases }}
     steps:

--- a/.github/workflows/check-releases-archives.yaml
+++ b/.github/workflows/check-releases-archives.yaml
@@ -10,7 +10,7 @@ jobs:
   infer-releases:
     runs-on: ubuntu-latest
     name: "Infer releases to check"
-    # Don't run unattended in forks; see install-slices.yaml.
+    # By default don't run unattended in forks
     if: >-
       github.repository_owner == 'canonical'
       || github.event_name == 'pull_request'

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -35,6 +35,16 @@ jobs:
   prepare-install:
     runs-on: ubuntu-latest
     name: "Prepare to install"
+    # Forks inherit these triggers and run them unattended on the fork owner's
+    # Actions budget -- and every automatic one installs *all* slices (note a
+    # fork sync is a push to main). So outside canonical, only run when a human
+    # asked for it. Gating on the event and not just the owner matters here:
+    # `github.*` is the *caller's* context, so an owner-only check would
+    # disable PR CI for every fork. Dependent jobs skip via `needs`.
+    if: >-
+      github.repository_owner == 'canonical'
+      || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
     outputs:
       install-all: ${{ steps.set-output.outputs.install_all }}
       matrix: ${{ steps.set-output.outputs.matrix }}

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -35,12 +35,7 @@ jobs:
   prepare-install:
     runs-on: ubuntu-latest
     name: "Prepare to install"
-    # Forks inherit these triggers and run them unattended on the fork owner's
-    # Actions budget -- and every automatic one installs *all* slices (note a
-    # fork sync is a push to main). So outside canonical, only run when a human
-    # asked for it. Gating on the event and not just the owner matters here:
-    # `github.*` is the *caller's* context, so an owner-only check would
-    # disable PR CI for every fork. Dependent jobs skip via `needs`.
+    # Don't run unattended in forks
     if: >-
       github.repository_owner == 'canonical'
       || github.event_name == 'pull_request'

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -39,7 +39,6 @@ jobs:
     if: >-
       github.repository_owner == 'canonical'
       || github.event_name == 'pull_request'
-      || github.event_name == 'workflow_dispatch'
     outputs:
       install-all: ${{ steps.set-output.outputs.install_all }}
       matrix: ${{ steps.set-output.outputs.matrix }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,6 @@ jobs:
     if: >-
       github.repository_owner == 'canonical'
       || github.event_name == 'pull_request'
-      || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
       main-ref: ${{ steps.set-output.outputs.main_ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,11 @@ jobs:
   prepare-lint:
     runs-on: ubuntu-latest
     name: "Prepare to lint"
+    # Don't run unattended in forks; see install-slices.yaml.
+    if: >-
+      github.repository_owner == 'canonical'
+      || github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-output.outputs.matrix }}
       main-ref: ${{ steps.set-output.outputs.main_ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
   prepare-lint:
     runs-on: ubuntu-latest
     name: "Prepare to lint"
-    # Don't run unattended in forks; see install-slices.yaml.
+    # Don't run unattended in forks
     if: >-
       github.repository_owner == 'canonical'
       || github.event_name == 'pull_request'

--- a/.github/workflows/validate-hints.yaml
+++ b/.github/workflows/validate-hints.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     # Needs to be called, from a workflow triggered by a PR
     if: |
-      startswith(github.event_name, 'pull_request') &&
+      github.event_name == 'pull_request' &&
       startswith(github.base_ref, 'ubuntu-')
     outputs:
       changed-files: ${{ steps.changed-paths.outputs.slices_files }}


### PR DESCRIPTION
# Proposed changes

forks inherit the scheduled workflows on main, along with the push and create triggers reaching them, and run them unattended on the fork owner's Actions budget. the nightly "Install slices" run alone is ~2,700 runner-minutes per night in a fork carrying three release branches.

this PR adds a guard to each scheduled workflow so that outside canonical only human-initiated events run; dependent jobs skip via needs. ofc forks can change this themselves if needed. forward-port-missing.yaml and triage-prs.yaml were already guarded this way. 

driveby: narrow the event check in validate-hints.yaml, which is only ever reached by pull_request. pkg-deps.yaml keeps its startswith since ci-pr-target.yaml calls it via pull_request_target from older branches (future cleanup)

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

## Additional Context

i'm out of credits this month 😭 

_(no, i don't need to pay 400$ to gh. it just goes out of the free gh use)_

<img width="955" height="951" alt="Screenshot 2026-07-25 at 19 51 47" src="https://github.com/user-attachments/assets/97016e9c-8c49-4d4d-a9e2-8cf534a1d59a" />
