### PR TITLE
fix(26.04): use `std::ffi::c_char` in rust tests

### DIFF
--- a/tests/spread/integration/rustc-1.93/testfiles/greeter.rs
+++ b/tests/spread/integration/rustc-1.93/testfiles/greeter.rs
@@ -1,16 +1,10 @@
 #[no_mangle]
 pub extern "C" fn greet(who: *const u8) -> *const u8 {
-    #[cfg(target_arch = "aarch64")]
-    let c_str = unsafe { std::ffi::CStr::from_ptr(who) };
-    #[cfg(not(target_arch = "aarch64"))]
-    let c_str = unsafe { std::ffi::CStr::from_ptr(who as *const i8) };
+    let c_str = unsafe { std::ffi::CStr::from_ptr(who as *const std::ffi::c_char) };
     
     let name = c_str.to_str().unwrap_or("stranger");
     let greeting = format!("Hello to {} from Rust static library!", name);
     let c_greeting = std::ffi::CString::new(greeting).unwrap();
     
-    #[cfg(target_arch = "aarch64")]
-    return c_greeting.into_raw();
-    #[cfg(not(target_arch = "aarch64"))]
     return c_greeting.into_raw() as *const u8;
 }

--- a/tests/spread/integration/rustc/testfiles/greeter.rs
+++ b/tests/spread/integration/rustc/testfiles/greeter.rs
@@ -1,16 +1,10 @@
 #[no_mangle]
 pub extern "C" fn greet(who: *const u8) -> *const u8 {
-    #[cfg(target_arch = "aarch64")]
-    let c_str = unsafe { std::ffi::CStr::from_ptr(who) };
-    #[cfg(not(target_arch = "aarch64"))]
-    let c_str = unsafe { std::ffi::CStr::from_ptr(who as *const i8) };
+    let c_str = unsafe { std::ffi::CStr::from_ptr(who as *const std::ffi::c_char) };
     
     let name = c_str.to_str().unwrap_or("stranger");
     let greeting = format!("Hello to {} from Rust static library!", name);
     let c_greeting = std::ffi::CString::new(greeting).unwrap();
     
-    #[cfg(target_arch = "aarch64")]
-    return c_greeting.into_raw();
-    #[cfg(not(target_arch = "aarch64"))]
     return c_greeting.into_raw() as *const u8;
 }


### PR DESCRIPTION
# Proposed changes

preemptive little fix to rust tests motivated by upcoming work on s390x and ppc

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/1098

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1100
- https://github.com/canonical/chisel-releases/pull/1099 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1098

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)