### PR TITLE
feat: bin slice builder

### DIFF
--- a/slice-builder/README.md
+++ b/slice-builder/README.md
@@ -1,7 +1,7 @@
 # slice-builder
 
 `slice-builder` generates [Chisel](https://canonical-chisel--72.com.readthedocs.build/72/)
-slice definition files (SDFs) for **superdistro bin** packages (`.tar.xz` archives produced by
+slice definition files (SDFs) for **bin** packages (`.tar.xz` archives produced by
 `bincraft pack`). Bin packages are not Debian debs, so the standard deb-slicing workflow does
 not apply; this tool wraps an `omp` (oh-my-pi) agent — guided by the `sdf-generation` skill — to
 classify archive paths into slices, resolve `essential` dependencies, and emit a validated SDF.

--- a/slice-builder/README.md
+++ b/slice-builder/README.md
@@ -1,0 +1,63 @@
+# slice-builder
+
+`slice-builder` generates [Chisel](https://canonical-chisel--72.com.readthedocs.build/72/)
+slice definition files (SDFs) for **superdistro bin** packages (`.tar.xz` archives produced by
+`bincraft pack`). Bin packages are not Debian debs, so the standard deb-slicing workflow does
+not apply; this tool wraps an `omp` (oh-my-pi) agent — guided by the `sdf-generation` skill — to
+classify archive paths into slices, resolve `essential` dependencies, and emit a validated SDF.
+
+## Install
+
+The tool is managed with [`uv`](https://docs.astral.sh/uv/). No install step is required; `uv`
+resolves dependencies from `pyproject.toml` into an ephemeral environment:
+
+```bash
+uv run slice-builder --help
+```
+
+## Usage
+
+```bash
+uv run slice-builder generate-sdf \
+  --bin-archive <path/to/bin.tar.xz> \
+  --base <base> \
+  --package <sd_name> \
+  --track <track> \
+  --dependencies <sd_name1>,<sd_name2>,... \
+  --sdf-lookup-dir <path/to/sdf-cache> \
+  --output <path/to/<sdf-dir>/<bare-name>.yaml>
+```
+
+| Parameter | Description |
+| --- | --- |
+| `--bin-archive` | `.tar.xz` archive from `bincraft pack`. |
+| `--base` | Ubuntu base (e.g. `26.04`). Derives branch `ubuntu-26.04`, fetched shallow. |
+| `--package` | Bin's SD name, bare (e.g. `curl`). |
+| `--track` | Bin's track (e.g. `v1.2.3`). Always YAML-quoted in output. |
+| `--dependencies` | Comma-separated `sd_name` values (may be empty). |
+| `--sdf-lookup-dir` | Read-only cache of already-generated bin SDFs, overlaid onto the checkout. |
+| `--output` | Full output path. |
+| `--omp` | (opt) Path to `omp` binary; default `omp` on PATH. |
+| `--omp-model` | (opt) Model selector for omp. |
+| `--retries` | (opt) Max agent retries on validation failure. Default 3. |
+
+## Exit codes
+
+- `0` success
+- `1` SDF generation failed (agent/ validation failure)
+- `2` input/config error (bad archive, missing dep SDF, bad args, `omp` not on PATH, output exists)
+
+## Development
+
+```bash
+just test          # unit tests
+just test-integration  # @slow, requires omp + LLM credentials
+just fmt           # format
+just lint          # ruff check
+```
+
+## Layout
+
+Everything lives under `slice-builder/` so the directory can be lifted into its own repository
+without rework. The `sdf-generation` skill (`skills/sdf-generation/SKILL.md`) evolves
+independently of the tool code.

--- a/slice-builder/justfile
+++ b/slice-builder/justfile
@@ -1,0 +1,23 @@
+# Run unit tests.
+test:
+    uv run pytest
+
+# Run integration tests (requires omp + LLM credentials).
+test-integration:
+    uv run pytest -m slow
+
+# Format code.
+fmt:
+    uv run --with ruff ruff format
+
+# Lint code.
+lint:
+    uv run --with ruff ruff check
+
+# Lint SDFs with the tool-owned yamllint config.
+lint-sdf:
+    uv run yamllint -c yamllint.yaml slices
+
+# Run the builder.
+run *args:
+    uv run slice-builder {{args}}

--- a/slice-builder/justfile
+++ b/slice-builder/justfile
@@ -14,10 +14,6 @@ fmt:
 lint:
     uv run --with ruff ruff check
 
-# Lint SDFs with the tool-owned yamllint config.
-lint-sdf:
-    uv run yamllint -c yamllint.yaml slices
-
 # Run the builder.
 run *args:
     uv run slice-builder {{args}}

--- a/slice-builder/plans/01-initial-plan.md
+++ b/slice-builder/plans/01-initial-plan.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Superdistro bin packages (.tar.xz packed by `bincraft pack`) are not Ubuntu debs, so the existing deb-slicing workflow (apt download → dpkg -c → design slices) does not apply. Yet these bins must be consumable by `chisel cut` alongside Ubuntu archive slices, so each bin needs an SDF in the new store: bin namespace. Authoring these by hand does not scale (sd-tools produces bins in bulk), so an automated SDF generator is needed.
+Bin packages (.tar.xz packed by `bincraft pack`) are not Ubuntu debs, so the existing deb-slicing workflow (apt download → dpkg -c → design slices) does not apply. Yet these bins must be consumable by `chisel cut` alongside Ubuntu archive slices, so each bin needs an SDF in the new store: bin namespace. Authoring these by hand does not scale (sd-tools produces bins in bulk), so an automated SDF generator is needed.
 
 ## Scope
 

--- a/slice-builder/plans/01-initial-plan.md
+++ b/slice-builder/plans/01-initial-plan.md
@@ -1,0 +1,423 @@
+# Slice Builder Tool — Implementation Plan
+
+## Problem
+
+Superdistro bin packages (.tar.xz packed by `bincraft pack`) are not Ubuntu debs, so the existing deb-slicing workflow (apt download → dpkg -c → design slices) does not apply. Yet these bins must be consumable by `chisel cut` alongside Ubuntu archive slices, so each bin needs an SDF in the new store: bin namespace. Authoring these by hand does not scale (sd-tools produces bins in bulk), so an automated SDF generator is needed.
+
+## Scope
+
+**In:** generate one SDF per bin archive; classify paths; resolve `essential`
+to dep slices; detect literal path conflicts and emit `prefer`; validate; emit
+final SDF.
+
+**Out:** hand-tuning (output is final); forward-porting (sd-tools orchestrates);
+glob conflict resolution (Chisel handles at cut time; unresolvable conflicts flag for human review).
+
+## Architecture
+
+The tool is a **Python CLI** (`slice-builder`) managed with **uv**, wrapping
+an **oh-my-pi (`omp`) agent**. The tool handles deterministic I/O; the agent
+handles judgment calls guided by the `sdf-generation` skill. All tool source,
+tests, prompts, and config live under a single top-level `slice-builder/`
+directory so the tool can be extracted to its own repository with no rework.
+
+```
+┌─ slice-builder (Python CLI, uv-managed) ──────────┐
+│ 1. Parse args (argparse)                            │
+│ 2. Shallow-clone chisel-releases ubuntu-<base>      │
+│ 3. Read chisel.yaml → format, default-prefix,       │
+│    bin SDF directory                                │
+│ 4. Overlay --sdf-lookup-dir SDFs onto checkout      │
+│ 5. Extract --bin-archive → enumerate paths          │
+│ 6. Invoke omp agent(paths, deps, dep-SDFs, skill)  │
+│ 7. Validate output (yamllint, sort, parse)          │
+│ 8. Write to --output                                │
+└─────────────────────────────────────────────────────┘
+         │
+┌─ oh-my-pi agent (consumes sdf-generation skill) ────┐
+│ - Classify paths → slices                           │
+│ - Analyze dep SDFs → pick essential slices          │
+│ - Detect literal path conflicts → prefer            │
+│ - Render SDF (sorted, map-format essential)         │
+└─────────────────────────────────────────────────────┘
+```
+
+**Design decision — agent+skill vs deterministic code:**
+- *Chosen (agent + skill):* heuristics evolve via skill edits without code
+  changes; handles ambiguous dep-slice selection flexibly. Trade-off:
+  non-deterministic, slower, requires LLM.
+- *Alternative (deterministic):* fast, testable, but requires code changes
+  when path→slice rules evolve.
+- *Future:* hybrid — deterministic for clear rules (path table, sort, render),
+  agent only for dep-slice selection.
+
+**Design decision — Python + uv:**
+- *Chosen:* matches the Canonical SD toolchain convention (slupgrader,
+  pydep_differ, sd-tools are all Python/uv). `uv run slice-builder ...`
+  resolves deps from `pyproject.toml` with no install step; `uv` is already
+  present in the workshop SDK. argparse CLI mirrors slupgrader's `cli.py` /
+  `__main__.py` split. `justfile` recipes mirror slupgrader's for
+  `test`/`fmt`/`lint`/`run`.
+- *Alternative (Go):* would match chisel itself, but the agent-orchestration
+  layer (subprocess, prompt assembly, retry loop) is lighter in Python and
+  the sibling tools are Python.
+
+**Design decision — oh-my-pi as agent:**
+- *Chosen:* `omp` is already in the workshop SDK (`workshop.yaml` lists
+  `omp`). It exposes a one-shot mode (`omp -p "<prompt>"`) and a persistent
+  RPC mode (`omp --mode rpc`, NDJSON over stdio). It auto-discovers skills
+  from disk (`.claude`, `.cursor`, `AGENTS.md`, `skills/`), so the
+  `sdf-generation` skill is picked up with no wiring. Its `read`/`write`/
+  `bash`/`search` tools let it inspect the checkout and dep SDFs directly.
+- *Integration mode:* **one-shot (`omp -p`)** per invocation. The builder
+  assembles a single prompt (paths, deps, dep-SDF summaries, skill pointer),
+  runs `omp -p` with `--tools read,write,search,bash` and a constrained
+  working directory, and parses the SDF from the agent's `write` output or
+  stdout. RPC mode is a future optimisation to amortise session startup
+  across a batch.
+- *Alternative (LangChain/LangGraph in-process):* slupgrader's approach. Heavier
+  dependency surface; omp is already installed and tuned.
+
+## Project layout
+
+Everything lives under `slice-builder/` so the directory can be lifted into
+its own git repository (e.g. `canonical/slice-builder`) without moving files.
+The `chisel-releases` repo gains only the `slice-builder/` subtree plus the
+`sdf-generation` skill; the SDF outputs go to the existing `slices/` (or
+`bin-slices/`) tree as today.
+
+```
+slice-builder/
+├── pyproject.toml          # uv project; [project.scripts] slice-builder=...
+├── README.md               # install + usage (mirrors slupgrader README shape)
+├── justfile                # test / fmt / lint / run recipes (uv run ...)
+├── ruff.toml               # line-length 100, match repo style
+├── yamllint.yaml           # tool-owned yamllint config (repo's is local-only)
+├── src/
+│   └── slice_builder/
+│       ├── __init__.py
+│       ├── __main__.py     # `python -m slice_builder` entry
+│       ├── cli.py          # argparse parser + main() (slupgrader-style)
+│       ├── config.py       # dataclasses: BuildConfig, DepRef, etc.
+│       ├── checkout.py     # shallow-clone chisel-releases ubuntu-<base>
+│       ├── release.py      # parse chisel.yaml → format, stores, prefix, dir
+│       ├── archive.py      # extract .tar.xz → sorted path list
+│       ├── overlay.py      # copy --sdf-lookup-dir onto checkout
+│       ├── deps.py         # locate + load dep SDFs (bin vs deb detection)
+│       ├── prefer.py       # literal-path conflict scan across checkout SDFs
+│       ├── agent.py        # omp invocation: prompt assembly + `omp -p` runner
+│       ├── render.py       # sort + emit SDF YAML (map essential, quoted track)
+│       ├── validate.py     # yamllint + sort-check + parse-check
+│       └── sdf.py          # SDF data model + YAML load/dump helpers
+├── prompts/
+│   └── system.md          # base system prompt for the omp agent
+├── skills/
+│   └── sdf-generation/
+│       └── SKILL.md       # the skill consumed by omp (see Skill section)
+└── tests/
+    ├── conftest.py
+    ├── unit/              # fast, no LLM (archive, release, render, validate)
+    └── integration/       # @slow, requires omp + LLM credentials
+```
+
+**`pyproject.toml` essentials** (slupgrader-aligned):
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "slice-builder"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "pyyaml>=6.0",     # SDF load/dump
+  "yamllint>=1.35",   # validation
+]
+
+[project.scripts]
+slice-builder = "slice_builder.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/slice_builder"]
+
+[tool.ruff]
+line-length = 100
+```
+
+Run without installing: `uv run slice-builder ...` (uv resolves deps from
+`pyproject.toml` into an ephemeral venv). Tests: `uv run pytest`. Lint:
+`uv run --with ruff ruff check && uv run --with ruff ruff format --check`.
+
+## Data flow
+
+```
+sd-tools ──invoke──▶ uv run slice-builder generate-sdf
+  │
+  ├─ 1. Derive branch: ubuntu-<base> (e.g. ubuntu-26.04)
+  ├─ 2. Shallow-clone → temp dir
+  ├─ 3. Read chisel.yaml → format (v3/v4), stores.bin.default-prefix, bin SDF dir
+  ├─ 4. Copy --sdf-lookup-dir/*.yaml → checkout bin SDF dir (overlay)
+  ├─ 5. Extract bin.tar.xz → path list
+  ├─ 6. For each dep: locate SDF in checkout → load
+  ├─ 7. omp -p (skill, paths, deps, dep-SDFs, checkout) → SDF YAML
+  ├─ 8. Validate: yamllint + sort-check + parse
+  └─ 9. Write to --output
+```
+
+**Checkout strategy:** per-invocation shallow clone to a temp dir (no state,
+no concurrency issues). Can optimize to a long-lived checkout with
+`git fetch + reset` if performance demands.
+
+**SDF lookup overlay:** `--sdf-lookup-dir` is read-only (populated by sd-tools,
+never overwritten). The builder copies its contents onto the checkout so the
+agent sees a unified tree (Ubuntu archive SDFs + previously generated bin
+SDFs). Within a batch, sd-tools adds each output to the cache, so subsequent
+invocations see prior outputs.
+
+**omp invocation detail:** the builder writes the assembled prompt to a temp
+file and runs `omp -p "$(cat prompt.txt)" --tools read,write,search,bash
+--cwd <checkout>` (one-shot). The agent is instructed to `write` the SDF to a
+known temp path inside the checkout; the builder reads that file back, then
+validates. On validation failure the builder re-runs `omp -p` with the
+validation errors appended (≤N retries). The `sdf-generation` skill is
+discovered by omp from `slice-builder/skills/` (omp auto-discovers on-disk
+skills); no `--skill` flag is needed. If omp exits 0 but writes no SDF file,
+treat it as a validation failure and retry (then Error, exit 1). The exact omp
+flags (`-p`, `--tools`, `--cwd`, model selector) must be verified against
+`omp --help` on the workshop SDK before wiring — the flags above are the
+intended interface, not confirmed.
+
+**chisel.yaml parsing:** the plan assumes `format: v3`/`v4` and a
+`stores.bin.default-prefix` key, but the only in-repo `chisel.yaml` example
+(in `.github/scripts/install-slices/test_install_slices.py`) is `format: v1`.
+The implementer must read the actual `chisel.yaml` from the cloned
+`ubuntu-<base>` branch and verify the real schema (format value, stores
+layout, default-prefix key name, bin SDF directory) before coding `release.py`
+— do not assume the v3/v4 specifics above are accurate.
+
+## Path→slice classification
+
+| Path pattern | Slice |
+|---|---|
+| `/usr/bin/**`, `/bin/**` | `bins` |
+| `/usr/lib/**`, `/lib/**` | `libs` |
+| `/etc/**` | `config` |
+| `/usr/share/doc/**/copyright` | `copyright` |
+| `/usr/share/gocode/src/**` | `src` |
+
+Rules:
+- Only emit slices with ≥1 path.
+- `copyright`: always expected; only created if the archive actually contains a
+  copyright file. If created, add `bin-<package>_copyright` to top-level
+  `essential`.
+- Unmatched paths: flag for human review; agent must not silently drop them.
+- Table is provisional; will be refined as more bins are processed.
+
+## Documentation
+
+Chisel and chisel-releases https://canonical-chisel--72.com.readthedocs.build/72/
+
+## Essential resolution
+
+For each dependency `sd_name` from `--dependencies`:
+
+1. **Locate dep SDF:** search `--sdf-lookup-dir` (bin SDFs from prev runs),
+   then the checkout (v3: `bin-slices/<sd_name>.yaml` or
+   `slices/<sd_name>.yaml`; v4: `slices/<sd_name>.yaml`).
+2. **Determine bin vs deb:** if SDF has `store: bin` → bin dep (slice refs use
+   `default-prefix`, e.g. `bin-<dep>_...`); otherwise → deb dep (bare name,
+   `<dep>_...`).
+3. **Analyze dep SDF → pick slice(s):** the agent reads the dep's slices and
+   contents, selects the slice(s) that provide what the current bin needs
+   (e.g. `libs` for a library, `bins` for a binary). This is a judgment call
+   guided by the skill.
+4. **Emit in v3/v4 map format:**
+   ```yaml
+   essential:
+     libc6_libs: {}
+     bin-go-github-some-dep_bins: {}
+   ```
+5. **Dep SDF not found:** error (cannot resolve essential). Do not emit
+   unresolved references.
+
+## Prefer detection
+
+1. Collect all **literal** (non-glob) paths from the bin's contents.
+2. Scan all SDFs in the checkout for literal paths.
+3. For each literal path in the bin that also appears in another package:
+   - **Bin vs deb:** emit `prefer: <deb-package-name>` on the bin's path. Deb
+     wins by default.
+   - **Bin vs bin:** flag for human review (no default resolution).
+4. **Glob paths:** `prefer` forbidden on globs (spec). Glob conflicts are
+   detected by Chisel at cut time; if Chisel errors, human review.
+5. `prefer` value = unique package identifier of the preferred package (bare
+   name for debs, `bin-<name>` for bins).
+
+## Invocation contract
+
+sd-tools invokes the slice builder as a subprocess. Because the tool is
+uv-managed, the command is `uv run slice-builder ...` (uv is on PATH in the
+workshop SDK). sd-tools locates the binary via PATH, mirroring how it locates
+`slupgrader`.
+
+```
+uv run slice-builder generate-sdf \
+  --bin-archive <path/to/bin.tar.xz> \
+  --base <base> \
+  --package <sd_name> \
+  --track <track> \
+  --dependencies <sd_name1>,<sd_name2>,... \
+  --sdf-lookup-dir <path/to/sdf-cache> \
+  --output <path/to/<sdf-dir>/<bare-name>.yaml>
+```
+
+| Parameter | Description |
+|---|---|
+| `--bin-archive` | `.tar.xz` from `bincraft pack`. Extracted to inspect contents. |
+| `--base` | Ubuntu base (e.g. `26.04`). Derives branch `ubuntu-26.04`, fetched shallow. |
+| `--package` | Bin's SD name, bare (e.g. `curl`). → `package:` field + output filename basename. |
+| `--track` | Bin's track (e.g. `v1.2.3`). → `default-track:` (always YAML-quoted to force string). |
+| `--dependencies` | Comma-separated `sd_name` values (may be empty). Bin-to-bin refs use prefixed name, no track. |
+| `--sdf-lookup-dir` | Read-only cache of already-generated bin SDFs (populated by sd-tools). Overlaid onto checkout. |
+| `--output` | Full output path. Dir determined by release format: v3→`bin-slices/`, v4→`slices/`. |
+| `--omp` | (opt) Path to `omp` binary; default `omp` on PATH. |
+| `--omp-model` | (opt) Model selector for omp (e.g. `gemini/gemini-flash-latest`). Default: omp's configured default. |
+| `--retries` | (opt) Max agent retries on validation failure. Default 3. |
+
+Exit 0 = success; non-zero = failure (sd-tools surfaces stderr). Exit codes
+follow slupgrader's convention: 0 success, 1 SDF generation failed, 2
+input/config error (bad archive, missing dep SDF, bad args).
+
+## Output shape
+
+```yaml
+package: go-github-some-package
+store: bin
+default-track: "v1.2.3"
+
+essential:
+  bin-go-github-some-package_copyright:
+
+slices:
+  bins:
+    essential:
+      libc6_libs:
+      bin-go-github-some-dep_bins:
+    contents:
+      /usr/bin/some-binary:
+
+  libs:
+    contents:
+      /usr/lib/go-github-some-package/**:
+
+  config:
+    contents:
+      /etc/some-package/config.yaml:
+
+  copyright:
+    contents:
+      /usr/share/doc/go-github-some-package/copyright:
+```
+
+**Key format rules:**
+- `essential` uses **v3/v4 map format** (a YAML mapping, not a v1/v2 list).
+  Emit each entry as `key:` (null value) to match the existing bin SDFs in the
+  repo (e.g. `slices/bins/curl.yaml`, `slices/foo.yaml`); the `key: {}` notation
+  denotes "map format", not a literal empty-dict value.
+- Slice refs use the **`bin-` prefix** for bin packages (read from
+  `stores.bin.default-prefix` in `chisel.yaml`, not hardcoded).
+- `default-track` **always quoted** (prevents YAML float parsing of `0.1` etc.).
+- `copyright` + top-level `essential` only if archive contains a copyright file.
+- **Output directory is sd-tools' responsibility** — the builder writes to the
+  exact `--output` path and does not compute or validate the directory. The
+  `v3→bin-slices/`, `v4→slices/` mapping is sd-tools' concern (note the
+  current dev branch uses `slices/bins/`).
+- **YAML emission:** use a custom PyYAML `Dumper` to force the repo style —
+  block style for maps, `default-track` as a quoted scalar, contents paths and
+  `essential` entries as null-valued keys (`/path:`). Do not emit flow style,
+  anchors, or `!!` tags.
+
+## Validation
+
+Builder validates before writing (sd-tools does no further processing):
+1. **yamllint** with the tool's own config (`slice-builder/yamllint.yaml`),
+   authored from scratch — the repo's root `yamllint.yaml` and `lint.sh` are
+   local-only and not committed, so the tool must not reference them. The
+   `yamllint` Python package is a declared dependency; invoke it as a
+   subprocess against the temp SDF. Start from `extends: default` and tighten
+   to match the SDF style (2-space indent, 100-char lines, no document-start
+   marker).
+2. **Sort-check** `contents` paths and `essential` entries in **byte order**
+   (`LC_COLLATE=C`), lexicographic. Builder implements its own check in
+   `validate.py` (no reusable repo linter exists).
+3. **Parse-check** required fields (`package`, `store`, `default-track`,
+   `slices`) via `sdf.py`.
+4. Validation fail → agent retries (≤`--retries`) or tool errors.
+
+## Failure modes
+
+| Condition | Behavior |
+|---|---|
+| Malformed archive | Error (exit 2) |
+| No paths match any rule | Error (exit 1) |
+| Unmatched paths | Warn; flag for review; don't drop |
+| Dep SDF not found | Error (exit 2) |
+| Glob conflict | Warn; Chisel handles at cut time |
+| Bin-vs-bin literal conflict | Warn; no default; flag for review |
+| Output exists | Error (exit 2); don't overwrite |
+| `omp` not on PATH | Error (exit 2) |
+| omp invocation fails / non-zero | Error (exit 1) |
+| Validation fails after N retries | Error (exit 1) |
+
+## Skill
+
+`slice-builder/skills/sdf-generation/SKILL.md` bundles:
+- SDF format reference (v3/v4 fields, map `essential`, `store`/`default-track`).
+- Path→slice table.
+- Essential resolution rules (analyze dep SDF → pick slices).
+- Prefer rules (literal only, deb preferred).
+- Validation rules (sort, yamllint).
+- Non-deb slicing methodology (Chisel how-to with deb steps stripped).
+
+Consumed by the **omp agent** inside slice-builder. omp auto-discovers skills
+from disk (it inherits `.claude`, `.cursor`, `AGENTS.md`, and `skills/`
+layouts), so placing the skill under `slice-builder/skills/sdf-generation/`
+and running omp with `--cwd slice-builder/` is sufficient — no `--skill` flag
+or in-process loader. sd-tools never loads the skill. It evolves
+independently of tool code.
+
+The builder's `agent.py` also emits a `prompts/system.md` base system prompt
+that points omp at the skill and constrains its tool surface to
+`read,write,search,bash` with the checkout as `--cwd`.
+
+## Testing
+
+Mirrors slupgrader's split:
+- **Unit tests** (`tests/unit/`, fast, no LLM, no omp): `archive.py` path
+  extraction, `release.py` chisel.yaml parsing, `render.py` sort + quote,
+  `validate.py` yamllint/sort/parse, `deps.py` bin-vs-deb detection,
+  `prefer.py` conflict scan. Run: `uv run pytest`.
+- **Integration tests** (`tests/integration/`, `@slow`, require omp + LLM
+  credentials): end-to-end `generate-sdf` against a fixture `.tar.xz` and a
+  fixture checkout, asserting the emitted SDF matches the expected shape.
+  Gated behind `has_omp()` / `has_llm_credentials()` skip guards, like
+  slupgrader's `@slow` marker. Run: `uv run pytest -m slow`.
+
+## Open / future
+
+1. **Path→slice table:** provisional. Needs rules for `/usr/share/man/**`,
+   `/usr/share/gocode/pkg/**`, `/usr/include/**`.
+2. **Bin-vs-bin prefer:** no default yet. Needs policy if common.
+3. **Store name:** hardcoded `bin`. Add `--store` if multiple stores introduced.
+4. **Determinism:** agent is non-deterministic. Hybrid approach if
+   reproducibility needed.
+5. **omp RPC mode:** switch from one-shot `omp -p` per invocation to a
+   persistent `omp --mode rpc` session reused across a sd-tools batch, to
+   amortise startup and model warm-up.
+6. **Extraction to dedicated repo:** if `slice-builder/` outgrows
+   `chisel-releases`, lift the directory to its own `canonical/slice-builder`
+   repo and have sd-tools clone/pin it (same pattern as `slupgrader` in
+   `sd-tools`' `dependencies.lock.yaml`).
+

--- a/slice-builder/prompts/system.md
+++ b/slice-builder/prompts/system.md
@@ -1,7 +1,6 @@
 # System prompt for the omp agent
 
-You are a Chisel slice definition generator. You generate valid SDF YAML for superdistro bin
-packages.
+You are a Chisel slice definition generator. You generate valid SDF YAML for bin packages.
 
 Follow the `sdf-generation` skill provided in this task strictly. It is the authoritative
 reference for the SDF format, the path-to-slice classification table, essential resolution, and

--- a/slice-builder/prompts/system.md
+++ b/slice-builder/prompts/system.md
@@ -1,0 +1,24 @@
+# System prompt for the omp agent
+
+You are a Chisel slice definition generator. You generate valid SDF YAML for superdistro bin
+packages.
+
+Follow the `sdf-generation` skill provided in this task strictly. It is the authoritative
+reference for the SDF format, the path-to-slice classification table, essential resolution, and
+validation rules.
+
+## Constraints
+
+- Only use the `read`, `write`, `search`, and `bash` tools.
+- Stay within the provided checkout directory (`--cwd`). Do not modify any existing SDFs.
+- Your only write must be the single output SDF at the exact path given in the task, using the
+  `write` tool. Then stop.
+
+## Output requirements
+
+- Emit `default-track` as a double-quoted string (e.g. `default-track: "0.1"`).
+- Use null-valued keys for bare content paths (`/path:`) and `essential` entries
+  (`bin-pkg_slice:`).
+- Use block YAML style only. No flow style, no anchors, no `!!` tags, no document-start `---`.
+- Sort `contents` paths and `essential` entries in byte order (lexicographic by UTF-8 bytes).
+- Never silently drop archive paths. Flag any unmatched paths in your text response.

--- a/slice-builder/pyproject.toml
+++ b/slice-builder/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "slice-builder"
+version = "0.1.0"
+description = "Generate Chisel slice definition files (SDFs) for superdistro bin packages."
+requires-python = ">=3.12"
+dependencies = [
+  "pyyaml>=6.0",
+  "yamllint>=1.35",
+]
+
+[project.scripts]
+slice-builder = "slice_builder.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/slice_builder"]

--- a/slice-builder/pyproject.toml
+++ b/slice-builder/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "slice-builder"
 version = "0.1.0"
-description = "Generate Chisel slice definition files (SDFs) for superdistro bin packages."
+description = "Generate Chisel slice definition files (SDFs) for bin packages."
 requires-python = ">=3.12"
 dependencies = [
   "pyyaml>=6.0",

--- a/slice-builder/ruff.toml
+++ b/slice-builder/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 100
+target-version = "py312"
+
+[lint]
+select = ["E", "F", "I", "W", "UP", "B"]

--- a/slice-builder/skills/sdf-generation/SKILL.md
+++ b/slice-builder/skills/sdf-generation/SKILL.md
@@ -1,0 +1,135 @@
+# SDF Generation Skill
+
+This skill guides an agent in generating a Chisel **Slice Definition File (SDF)** for a
+superdistro `bin` package, given a list of archive paths, dependency SDFs, and a release
+prefix.
+
+The agent focuses on **path classification** and **essential dependency resolution**. The
+`prefer` computation, sorting, and yamllint validation are handled deterministically by the
+`slice-builder` tool after the agent runs.
+
+## SDF format reference (v3/v4)
+
+### Top-level fields
+
+| Field          | Type   | Required | Notes |
+| -------------- | ------ | -------- | ----- |
+| `package`      | string | Required | Bare package name; must match the YAML file basename. For bin packages this is the bare SD name (e.g. `curl`), NOT the prefixed identifier. |
+| `store`        | string | Optional (>= v3) | For bin packages, set to `bin`. Mutually exclusive with `archive`. |
+| `default-track`| string | Required when `store` is set (>= v3) | The track (e.g. `v1.2.3`). MUST always be YAML double-quoted so values like `0.1` are not parsed as floats. |
+| `essential`    | object | Optional | A map of slice full-names to their essential-specific properties. Emit each entry as a null-valued key, e.g. `bin-curl_copyright:` (NOT `bin-curl_copyright: {}`). |
+| `slices`       | object | Required | Map of slice name -> slice object. |
+
+### Slice-level fields
+
+| Field                        | Type   | Required | Notes |
+| ---------------------------- | ------ | -------- | ----- |
+| `slices.<name>`              | object | -        | A slice object. Slice names: lowercase `a-z`, digits `0-9`, minus `-`; at least 3 chars; must start with a letter. |
+| `slices.<name>.essential`    | object | Optional (v3/v4) | Same map format as top-level `essential`; slice full-names (e.g. `libc6_libs`). |
+| `slices.<name>.contents`     | object | Optional | Map of absolute path -> path properties (or null for a bare path). Paths MUST be absolute (start with `/`). |
+| `slices.<name>.contents.<path>.prefer` | string | Optional (>= v2) | Resolves a path conflict across packages. Value must be the name of an existing package. CANNOT be used with glob paths. |
+
+### Path globs
+
+Paths may contain globs:
+
+- `?` matches any one character, except `/`.
+- `*` matches zero or more characters, except `/`.
+- `**` matches zero or more characters, including `/`.
+
+### Example SDF (bin package)
+
+```yaml
+package: curl
+store: bin
+default-track: "0.1"
+
+essential:
+  bin-curl_copyright:
+
+slices:
+  bins:
+    contents:
+      /usr/bin/curl-bin:
+
+  copyright:
+    contents:
+      /usr/share/doc/curl-bin/copyright:
+```
+
+## Path -> slice classification
+
+| Path pattern | Slice |
+| --- | --- |
+| `/usr/bin/**`, `/bin/**` | `bins` |
+| `/usr/lib/**`, `/lib/**` | `libs` |
+| `/etc/**` | `config` |
+| `/usr/share/doc/**/copyright` | `copyright` |
+| `/usr/share/gocode/src/**` | `src` |
+
+Rules:
+
+- Only emit slices that contain at least one path.
+- `copyright` slice: only created if the archive actually contains a copyright file. If created,
+  add `bin-<package>_copyright` to the top-level `essential` map.
+- Unmatched paths: the agent MUST NOT silently drop them. Flag them for human review (emit a
+  comment or a dedicated slice and note them in the response text).
+- The table is provisional; the agent may deviate with justification, but must never drop paths.
+
+## Essential resolution
+
+For each dependency:
+
+1. The dependency's SDF is provided in the prompt. Determine if it is a **bin dep** (its SDF has
+   `store: bin`) or a **deb dep** (no `store` field).
+2. For bin deps, slice references use the release's bin prefix (e.g. `bin-<dep>_<slice>`). For
+   deb deps, references use the bare name (`<dep>_<slice>`).
+3. Read the dep's slices and contents, and select the slice(s) that provide what the current bin
+   needs (e.g. `libs` for a library, `bins` for a binary). This is a judgment call.
+4. Emit selected refs in the v3/v4 map format under the appropriate slice's `essential` (usually
+   the `bins` slice's `essential`):
+
+   ```yaml
+   slices:
+     bins:
+       essential:
+         libc6_libs:
+         bin-go-github-some-dep_bins:
+   ```
+
+5. If a dependency SDF is missing, that is an error in the builder (not the agent's concern); the
+   builder will not invoke the agent with unresolved deps.
+
+## Prefer rules
+
+The `prefer` computation is performed **deterministically by the builder** after the agent runs;
+the agent does not need to compute `prefer` itself. The rules below describe what the builder
+does, for the agent's awareness:
+
+- Collect all LITERAL (non-glob) paths in the generated SDF's contents.
+- For each literal path that also appears in another package's SDF in the release checkout:
+  - **Bin vs deb conflict:** emit `prefer: <deb-package-name>` on the bin's path (deb wins by
+    default).
+  - **Bin vs bin conflict:** flag for human review; no default resolution.
+- `prefer` is FORBIDDEN on glob paths.
+- The `prefer` value is the unique package identifier of the preferred package (bare name for
+  debs, `bin-<name>` for bins).
+
+## Validation rules
+
+The builder enforces these; the agent should produce compliant output:
+
+- `contents` paths and `essential` entries MUST be sorted in byte order (`LC_COLLATE=C`,
+  lexicographic by UTF-8 bytes).
+- The SDF must pass yamllint (2-space indentation, 100-char line limit, no document-start `---`
+  marker, block style only, no flow style, no anchors/`!!` tags).
+- Required fields: `package`, `store`, `default-track`, `slices`.
+- All content paths must be absolute.
+- `default-track` must be quoted.
+
+## Non-deb slicing methodology
+
+Bin packages are not Debian debs, so there is no `dpkg -c` / apt download step. The archive
+(`.tar.xz`) is extracted directly and its member paths are classified into slices using the table
+above. Essential dependencies are resolved from previously-generated bin SDFs and Ubuntu archive
+(deb) SDFs in the checkout.

--- a/slice-builder/skills/sdf-generation/SKILL.md
+++ b/slice-builder/skills/sdf-generation/SKILL.md
@@ -1,7 +1,7 @@
 # SDF Generation Skill
 
 This skill guides an agent in generating a Chisel **Slice Definition File (SDF)** for a
-superdistro `bin` package, given a list of archive paths, dependency SDFs, and a release
+`bin` package, given a list of archive paths, dependency SDFs, and a release
 prefix.
 
 The agent focuses on **path classification** and **essential dependency resolution**. The
@@ -117,19 +117,36 @@ does, for the agent's awareness:
 
 ## Validation rules
 
-The builder enforces these; the agent should produce compliant output:
+The builder validates the SDF in two passes. The agent is only retried for **semantic** failures
+(pass 1); style and ordering are fixed deterministically by the builder (pass 2), so the agent
+need not optimise for them.
 
-- `contents` paths and `essential` entries MUST be sorted in byte order (`LC_COLLATE=C`,
-  lexicographic by UTF-8 bytes).
-- The SDF must pass yamllint (2-space indentation, 100-char line limit, no document-start `---`
-  marker, block style only, no flow style, no anchors/`!!` tags).
+**Pass 1 — semantic (agent is retried on failure):**
+
+- The SDF must be valid YAML that parses into the expected structure.
 - Required fields: `package`, `store`, `default-track`, `slices`.
-- All content paths must be absolute.
-- `default-track` must be quoted.
+- `store` must be `bin` for bin packages.
+- All content paths must be absolute (start with `/`).
+- Slice names: lowercase `a-z`, digits `0-9`, minus `-`; at least 3 chars; start with a letter.
+
+**Pass 2 — style (builder fixes via `render()`, agent is NOT retried):**
+
+- `contents` paths and `essential` entries are byte-sorted (`LC_COLLATE=C`, lexicographic by
+  UTF-8 bytes) by the builder.
+- The SDF is re-dumped to pass yamllint (2-space indentation, 100-char line limit, no
+  document-start `---` marker, block style only, no flow style, no anchors/`!!` tags).
+- `default-track` is re-quoted by the builder's dumper.
+
+The agent should still aim for compliant output, but it should focus its effort on correct
+path classification and essential resolution, not on YAML formatting.
 
 ## Non-deb slicing methodology
 
 Bin packages are not Debian debs, so there is no `dpkg -c` / apt download step. The archive
-(`.tar.xz`) is extracted directly and its member paths are classified into slices using the table
-above. Essential dependencies are resolved from previously-generated bin SDFs and Ubuntu archive
-(deb) SDFs in the checkout.
+(`.tar.xz`) is extracted to a directory by the builder and its member paths are classified into
+slices using the table above. The agent has access to the extracted directory (its path is given
+in the task) and should inspect file types and contents with its `read`/`bash` tools (e.g.
+`file`, `cat`) when the path name alone is ambiguous — for example, a `/usr/lib/` entry could be
+a shared library, a static archive, or data, and the correct slice depends on the file type.
+Essential dependencies are resolved from previously-generated bin SDFs and Ubuntu archive (deb)
+SDFs in the checkout.

--- a/slice-builder/src/slice_builder/__init__.py
+++ b/slice-builder/src/slice_builder/__init__.py
@@ -1,0 +1,3 @@
+"""slice-builder: generate Chisel slice definition files (SDFs) for bin packages."""
+
+__version__ = "0.1.0"

--- a/slice-builder/src/slice_builder/__main__.py
+++ b/slice-builder/src/slice_builder/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for `python -m slice_builder`."""
+
+import sys
+
+from slice_builder.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/slice-builder/src/slice_builder/agent.py
+++ b/slice-builder/src/slice_builder/agent.py
@@ -1,0 +1,177 @@
+"""omp (oh-my-pi) agent invocation: prompt assembly + one-shot `omp -p` runner.
+
+The builder assembles a single prompt (paths, deps, dep-SDF summaries, skill pointer), runs
+``omp -p`` with ``--tools read,write,search,bash`` and the checkout as ``--cwd``, and reads the
+SDF the agent writes to a known temp path inside the checkout. On validation failure the builder
+re-runs with the validation errors appended (up to ``--retries``).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from slice_builder.config import BuildConfig, DepRef
+
+# The agent writes its SDF here (inside the checkout so its `write` tool can reach it).
+AGENT_OUTPUT_NAME = ".slice-builder-agent-output.yaml"
+
+# Tools the agent is allowed to use.
+AGENT_TOOLS = "read,write,search,bash"
+
+
+@dataclass
+class AgentPaths:
+    """Paths derived from a checkout for agent I/O."""
+
+    checkout: Path
+    agent_output: Path
+    system_prompt: Path
+    skill: Path
+
+
+def agent_paths(checkout: str | Path) -> AgentPaths:
+    """Compute the agent's I/O paths for a checkout.
+
+    The system prompt and skill live under the slice-builder source tree (two levels up from
+    this module's parent package dir).
+    """
+
+    root = Path(__file__).resolve().parents[2]
+    checkout = Path(checkout)
+    return AgentPaths(
+        checkout=checkout,
+        agent_output=checkout / AGENT_OUTPUT_NAME,
+        system_prompt=root / "prompts" / "system.md",
+        skill=root / "skills" / "sdf-generation" / "SKILL.md",
+    )
+
+
+def _summarise_dep(dep: DepRef) -> str:
+    """Build a compact text summary of a dependency SDF for the agent prompt."""
+
+    sdf = dep.sdf
+    pkg = sdf.get("package", dep.sd_name)
+    store = sdf.get("store")
+    kind = "bin" if store == "bin" else "deb"
+    ref_prefix = dep.prefix
+    lines = [f"### Dependency: {dep.sd_name} ({kind})"]
+    lines.append(f"package: {pkg}")
+    if store:
+        lines.append(f"store: {store}")
+    slices = sdf.get("slices") or {}
+    lines.append("slices:")
+    for name, sl in slices.items():
+        full = f"{ref_prefix}{dep.sd_name}_{name}"
+        contents = (sl or {}).get("contents") or {}
+        paths = list(contents.keys())
+        lines.append(f"  - {name} (ref: {full}) paths: {paths}")
+    return "\n".join(lines)
+
+
+def build_prompt(
+    config: BuildConfig,
+    paths: list[str],
+    deps: list[DepRef],
+    ap: AgentPaths,
+    own_identifier: str,
+) -> str:
+    """Assemble the full agent prompt (system prompt + task)."""
+
+    sys_prompt = ap.system_prompt.read_text(encoding="utf-8") if ap.system_prompt.is_file() else ""
+    skill_text = ap.skill.read_text(encoding="utf-8") if ap.skill.is_file() else ""
+
+    sections: list[str] = []
+    if sys_prompt:
+        sections.append(sys_prompt)
+    if skill_text:
+        sections.append("# sdf-generation skill\n\n" + skill_text)
+
+    task_lines = [
+        "# Task",
+        "",
+        f"Generate an SDF for the bin package `{config.package}`.",
+        "- store: bin",
+        f"- default-track: {config.track} (emit double-quoted)",
+        f"- unique package identifier: {own_identifier}",
+        "",
+        "## Archive paths",
+        "",
+        "Classify each path into a slice using the skill's path table. Do not drop any path.",
+        "",
+        "```",
+    ]
+    task_lines.extend(paths)
+    task_lines.append("```")
+    sections.append("\n".join(task_lines))
+
+    if deps:
+        dep_block = ["## Dependencies", ""]
+        dep_block.append(
+            "Resolve essential slices for the `bins` slice (or other slices as appropriate). "
+            "Bin deps use the prefixed ref; deb deps use the bare ref."
+        )
+        dep_block.append("")
+        for dep in deps:
+            dep_block.append(_summarise_dep(dep))
+            dep_block.append("")
+        sections.append("\n".join(dep_block))
+
+    sections.append(
+        f"## Output\n\nWrite the final SDF to `{ap.agent_output}` using the `write` tool, "
+        "then stop. The builder will sort, apply `prefer`, and validate."
+    )
+
+    return "\n\n".join(s for s in sections if s)
+
+
+def run_omp(
+    prompt: str,
+    ap: AgentPaths,
+    config: BuildConfig,
+    extra_retry_note: str = "",
+) -> str:
+    """Run `omp -p` one-shot and return the agent's stdout.
+
+    Raises ``RuntimeError`` if omp is not on PATH or exits non-zero.
+    """
+
+    full_prompt = prompt
+    if extra_retry_note:
+        full_prompt = full_prompt + "\n\n" + extra_retry_note
+
+    cmd = [
+        config.omp,
+        "-p",
+        full_prompt,
+        "--tools",
+        AGENT_TOOLS,
+        "--cwd",
+        str(ap.checkout),
+        "--auto-approve",
+        "--no-session",
+    ]
+    if config.omp_model:
+        cmd.extend(["--model", config.omp_model])
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"omp not found on PATH: {config.omp}") from exc
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise RuntimeError(f"omp exited {proc.returncode}: {stderr}")
+    return proc.stdout
+
+
+def read_agent_output(ap: AgentPaths) -> str:
+    """Read the SDF the agent wrote to ``ap.agent_output``.
+
+    Raises ``RuntimeError`` if the file is missing (agent wrote nothing).
+    """
+
+    if not ap.agent_output.is_file():
+        raise RuntimeError(f"agent wrote no SDF at {ap.agent_output}")
+    return ap.agent_output.read_text(encoding="utf-8")

--- a/slice-builder/src/slice_builder/agent.py
+++ b/slice-builder/src/slice_builder/agent.py
@@ -73,11 +73,17 @@ def _summarise_dep(dep: DepRef) -> str:
 def build_prompt(
     config: BuildConfig,
     paths: list[str],
+    extracted_dir: Path,
     deps: list[DepRef],
     ap: AgentPaths,
     own_identifier: str,
 ) -> str:
-    """Assemble the full agent prompt (system prompt + task)."""
+    """Assemble the full agent prompt (system prompt + task).
+
+    ``extracted_dir`` is the directory the archive was extracted into; the agent can inspect file
+    types and contents there with its ``read``/``bash`` tools (e.g. ``file``, ``cat``) to make
+    better classification decisions than path names alone allow.
+    """
 
     sys_prompt = ap.system_prompt.read_text(encoding="utf-8") if ap.system_prompt.is_file() else ""
     skill_text = ap.skill.read_text(encoding="utf-8") if ap.skill.is_file() else ""
@@ -95,6 +101,13 @@ def build_prompt(
         "- store: bin",
         f"- default-track: {config.track} (emit double-quoted)",
         f"- unique package identifier: {own_identifier}",
+        "",
+        "## Extracted archive",
+        "",
+        f"The bin archive has been extracted to `{extracted_dir}`. Inspect file types and",
+        "contents there with your `read` and `bash` tools (e.g. `file`, `cat`) as needed to",
+        "classify paths correctly. The Chisel content paths in the SDF must be absolute",
+        "(leading `/`), matching the archive member paths listed below.",
         "",
         "## Archive paths",
         "",

--- a/slice-builder/src/slice_builder/archive.py
+++ b/slice-builder/src/slice_builder/archive.py
@@ -1,16 +1,68 @@
-"""Extract member paths from a `.tar.xz` bin archive."""
+"""Extract a `.tar.xz` bin archive to a directory and enumerate its paths.
+
+The agent needs access to the actual extracted files (not just their names) to classify paths
+correctly — file type (shared lib vs data), symlinks, and occasionally file content (e.g. a
+copyright file) inform slice grouping. The builder extracts the archive to a directory and hands
+that directory to the agent.
+"""
 
 from __future__ import annotations
 
+import os
 import tarfile
 from pathlib import Path
+
+
+def extract_archive(archive: str | Path, dest: str | Path) -> Path:
+    """Safely extract a `.tar.xz` archive into ``dest`` and return the destination path.
+
+    Extraction is guarded against path traversal (members resolving outside ``dest``) and
+    absolute member paths, which are unsafe in a tar. Member paths are extracted as-is (relative
+    to ``dest``); the leading-slash normalisation used for Chisel content paths is applied only
+    by :func:`extract_paths` for display.
+
+    Raises ``ValueError`` if the archive cannot be opened, is missing, or contains an unsafe
+    member path.
+    """
+
+    archive = Path(archive)
+    if not archive.is_file():
+        raise ValueError(f"archive not found: {archive}")
+
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    dest_resolved = dest.resolve()
+
+    try:
+        with tarfile.open(archive, "r:xz") as tar:
+            for member in tar.getmembers():
+                _ensure_safe_member(member, dest_resolved)
+            tar.extractall(dest, filter="data")
+    except (tarfile.TarError, OSError) as exc:
+        raise ValueError(f"cannot read archive {archive}: {exc}") from exc
+    return dest
+
+
+def _ensure_safe_member(member: tarfile.TarInfo, dest_resolved: Path) -> None:
+    """Reject members that would escape ``dest`` (path traversal / absolute paths)."""
+
+    name = member.name
+    if not name or name.startswith("/"):
+        raise ValueError(f"archive contains an unsafe (absolute) member path: {name!r}")
+    # Resolve the target and confirm it stays under dest. linkname is checked for symlinks by
+    # the 'data' filter at extraction time; this guards against '..' in the member name itself.
+    target = (dest_resolved / name).resolve()
+    if not str(target).startswith(str(dest_resolved) + os.sep) and target != dest_resolved:
+        raise ValueError(f"archive member escapes destination: {name!r}")
 
 
 def extract_paths(archive: str | Path) -> list[str]:
     """Return the sorted list of member paths in a `.tar.xz` archive.
 
     Each path is normalised to a forward-slash, leading-slash-relative form (the path inside the
-    archive, prefixed with `/`). Directories (members ending in ``/``) are kept as-is.
+    archive, prefixed with `/`). Directories (members ending in ``/``) are kept as-is. This is a
+    convenience for callers that only need the path list; for full file inspection use
+    :func:`extract_archive`.
 
     Raises ``ValueError`` if the archive cannot be opened or read.
     """

--- a/slice-builder/src/slice_builder/archive.py
+++ b/slice-builder/src/slice_builder/archive.py
@@ -1,0 +1,36 @@
+"""Extract member paths from a `.tar.xz` bin archive."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+
+def extract_paths(archive: str | Path) -> list[str]:
+    """Return the sorted list of member paths in a `.tar.xz` archive.
+
+    Each path is normalised to a forward-slash, leading-slash-relative form (the path inside the
+    archive, prefixed with `/`). Directories (members ending in ``/``) are kept as-is.
+
+    Raises ``ValueError`` if the archive cannot be opened or read.
+    """
+
+    archive = Path(archive)
+    if not archive.is_file():
+        raise ValueError(f"archive not found: {archive}")
+
+    paths: list[str] = []
+    try:
+        with tarfile.open(archive, "r:xz") as tar:
+            for member in tar.getmembers():
+                name = member.name
+                if not name:
+                    continue
+                # Normalise to an absolute-looking path (Chisel content paths are absolute).
+                if not name.startswith("/"):
+                    name = "/" + name
+                paths.append(name)
+    except (tarfile.TarError, OSError) as exc:
+        raise ValueError(f"cannot read archive {archive}: {exc}") from exc
+
+    return sorted(set(paths))

--- a/slice-builder/src/slice_builder/checkout.py
+++ b/slice-builder/src/slice_builder/checkout.py
@@ -1,0 +1,42 @@
+"""Shallow-clone a chisel-releases `ubuntu-<base>` branch to a temp directory."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REMOTE = "https://github.com/canonical/chisel-releases.git"
+
+
+def branch_for_base(base: str) -> str:
+    """Return the chisel-releases branch name for an Ubuntu base (e.g. ``26.04``)."""
+
+    return f"ubuntu-{base}"
+
+
+def shallow_clone(base: str, dest: str | Path) -> Path:
+    """Shallow-clone the `ubuntu-<base>` branch into ``dest`` and return the path.
+
+    Raises ``RuntimeError`` on git failure.
+    """
+
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    branch = branch_for_base(base)
+    cmd = [
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        branch,
+        REMOTE,
+        str(dest),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"git clone failed (exit {exc.returncode}): {exc.stderr.strip()}"
+        ) from exc
+    return dest

--- a/slice-builder/src/slice_builder/cli.py
+++ b/slice-builder/src/slice_builder/cli.py
@@ -20,7 +20,7 @@ from slice_builder.agent import (
     read_agent_output,
     run_omp,
 )
-from slice_builder.archive import extract_paths
+from slice_builder.archive import extract_archive, extract_paths
 from slice_builder.checkout import shallow_clone
 from slice_builder.config import BuildConfig
 from slice_builder.deps import resolve_deps
@@ -29,7 +29,7 @@ from slice_builder.prefer import apply_prefer, scan_prefer
 from slice_builder.release import parse_chisel_yaml
 from slice_builder.render import render
 from slice_builder.sdf import parse_sdf
-from slice_builder.validate import format_errors, validate
+from slice_builder.validate import format_errors, validate, validate_semantic
 
 # Exit codes.
 EXIT_OK = 0
@@ -68,9 +68,18 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _parse_config(args: argparse.Namespace) -> BuildConfig:
-    """Build a BuildConfig from parsed args, validating simple invariants."""
+def _parse_config(args: argparse.Namespace) -> BuildConfig | int:
+    """Build a BuildConfig from parsed args, validating simple invariants.
 
+    Returns a :class:`BuildConfig` on success, or an exit code (int) on a config error.
+    """
+
+    if args.retries < 1:
+        print(
+            f"slice-builder: error: --retries must be >= 1, got: {args.retries}",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG_ERROR
     deps = (
         [d.strip() for d in args.dependencies.split(",") if d.strip()] if args.dependencies else []
     )
@@ -109,7 +118,7 @@ def generate_sdf(config: BuildConfig) -> int:
             EXIT_CONFIG_ERROR,
         )
 
-    # --- extract archive paths ---
+    # --- extract archive paths (for early validation + the prompt path list) ---
     try:
         paths = extract_paths(config.bin_archive)
     except ValueError as exc:
@@ -144,8 +153,16 @@ def generate_sdf(config: BuildConfig) -> int:
         own_identifier = f"{release.bin_prefix}{config.package}"
         ap = agent_paths(checkout)
 
+        # --- extract the archive to a directory the agent can inspect ---
+        # The agent needs file types and contents (not just names) to classify paths correctly.
+        extracted_dir = checkout / ".bin-archive-extracted"
+        try:
+            extract_archive(config.bin_archive, extracted_dir)
+        except ValueError as exc:
+            return _fail(str(exc), EXIT_CONFIG_ERROR)
+
         # --- build prompt ---
-        prompt = build_prompt(config, paths, deps, ap, own_identifier)
+        prompt = build_prompt(config, paths, extracted_dir, deps, ap, own_identifier)
 
         # --- agent loop with retries ---
         sdf_text = ""
@@ -165,8 +182,10 @@ def generate_sdf(config: BuildConfig) -> int:
                 last_errors = [str(exc)]
                 continue
 
-            # --- validate ---
-            result = validate(sdf_text)
+            # --- validate (semantic only: parse + required + absolute paths) ---
+            # yamllint and byte-sort are skipped here because render() re-imposes them
+            # deterministically; retrying the agent for a style issue wastes a round-trip.
+            result = validate_semantic(sdf_text)
             if result.ok:
                 break
             last_errors = result.errors
@@ -206,6 +225,8 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     config = _parse_config(args)
+    if isinstance(config, int):
+        return config
     if args.command == "generate-sdf":
         return generate_sdf(config)
     return _fail(f"unknown command: {args.command}", EXIT_CONFIG_ERROR)

--- a/slice-builder/src/slice_builder/cli.py
+++ b/slice-builder/src/slice_builder/cli.py
@@ -1,0 +1,211 @@
+"""argparse CLI + main() orchestration for `slice-builder`.
+
+Mirrors slupgrader's `cli.py` / `__main__.py` split. Exit codes:
+- 0 success
+- 1 SDF generation failed (agent / validation failure)
+- 2 input/config error (bad archive, missing dep SDF, bad args, omp not on PATH, output exists)
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from slice_builder.agent import (
+    agent_paths,
+    build_prompt,
+    read_agent_output,
+    run_omp,
+)
+from slice_builder.archive import extract_paths
+from slice_builder.checkout import shallow_clone
+from slice_builder.config import BuildConfig
+from slice_builder.deps import resolve_deps
+from slice_builder.overlay import overlay
+from slice_builder.prefer import apply_prefer, scan_prefer
+from slice_builder.release import parse_chisel_yaml
+from slice_builder.render import render
+from slice_builder.sdf import parse_sdf
+from slice_builder.validate import format_errors, validate
+
+# Exit codes.
+EXIT_OK = 0
+EXIT_GEN_FAILED = 1
+EXIT_CONFIG_ERROR = 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the top-level argument parser."""
+
+    parser = argparse.ArgumentParser(
+        prog="slice-builder",
+        description="Generate Chisel slice definition files (SDFs) for bin packages.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gen = sub.add_parser("generate-sdf", help="Generate an SDF for a bin archive.")
+    gen.add_argument("--bin-archive", required=True, help="Path to the .tar.xz bin archive.")
+    gen.add_argument("--base", required=True, help="Ubuntu base (e.g. 26.04).")
+    gen.add_argument("--package", required=True, help="Bin's SD name, bare (e.g. curl).")
+    gen.add_argument("--track", required=True, help="Bin's track (e.g. v1.2.3).")
+    gen.add_argument(
+        "--dependencies",
+        default="",
+        help="Comma-separated sd_name values (may be empty).",
+    )
+    gen.add_argument(
+        "--sdf-lookup-dir",
+        default=None,
+        help="Read-only cache of already-generated bin SDFs.",
+    )
+    gen.add_argument("--output", required=True, help="Full output path for the SDF.")
+    gen.add_argument("--omp", default="omp", help="Path to omp binary; default 'omp' on PATH.")
+    gen.add_argument("--omp-model", default=None, help="Model selector for omp.")
+    gen.add_argument("--retries", type=int, default=3, help="Max agent retries on validation fail.")
+    return parser
+
+
+def _parse_config(args: argparse.Namespace) -> BuildConfig:
+    """Build a BuildConfig from parsed args, validating simple invariants."""
+
+    deps = (
+        [d.strip() for d in args.dependencies.split(",") if d.strip()] if args.dependencies else []
+    )
+    return BuildConfig(
+        bin_archive=args.bin_archive,
+        base=args.base,
+        package=args.package,
+        track=args.track,
+        dependencies=deps,
+        sdf_lookup_dir=args.sdf_lookup_dir,
+        output=args.output,
+        omp=args.omp,
+        omp_model=args.omp_model,
+        retries=args.retries,
+    )
+
+
+def _fail(msg: str, code: int) -> int:
+    """Print an error to stderr and return an exit code."""
+
+    print(f"slice-builder: error: {msg}", file=sys.stderr)
+    return code
+
+
+def generate_sdf(config: BuildConfig) -> int:
+    """Run the full generate-sdf pipeline. Returns an exit code."""
+
+    # --- input/config validation ---
+    if not Path(config.bin_archive).is_file():
+        return _fail(f"bin archive not found: {config.bin_archive}", EXIT_CONFIG_ERROR)
+    if shutil.which(config.omp) is None:
+        return _fail(f"omp not found on PATH: {config.omp}", EXIT_CONFIG_ERROR)
+    if Path(config.output).exists():
+        return _fail(
+            f"output already exists, refusing to overwrite: {config.output}",
+            EXIT_CONFIG_ERROR,
+        )
+
+    # --- extract archive paths ---
+    try:
+        paths = extract_paths(config.bin_archive)
+    except ValueError as exc:
+        return _fail(str(exc), EXIT_CONFIG_ERROR)
+    if not paths:
+        return _fail("archive contains no paths", EXIT_CONFIG_ERROR)
+
+    # --- shallow clone + parse chisel.yaml ---
+    with tempfile.TemporaryDirectory(prefix="slice-builder-") as tmp:
+        checkout = Path(tmp) / "checkout"
+        try:
+            shallow_clone(config.base, checkout)
+        except RuntimeError as exc:
+            return _fail(str(exc), EXIT_CONFIG_ERROR)
+
+        try:
+            release = parse_chisel_yaml(checkout)
+        except ValueError as exc:
+            return _fail(str(exc), EXIT_CONFIG_ERROR)
+
+        # --- overlay lookup SDFs ---
+        overlay(config.sdf_lookup_dir, checkout, release.bin_sdf_dir)
+
+        # --- resolve deps ---
+        try:
+            deps = resolve_deps(
+                config.dependencies, config.sdf_lookup_dir, checkout, release.bin_prefix
+            )
+        except ValueError as exc:
+            return _fail(str(exc), EXIT_CONFIG_ERROR)
+
+        own_identifier = f"{release.bin_prefix}{config.package}"
+        ap = agent_paths(checkout)
+
+        # --- build prompt ---
+        prompt = build_prompt(config, paths, deps, ap, own_identifier)
+
+        # --- agent loop with retries ---
+        sdf_text = ""
+        last_errors: list[str] = []
+        for attempt in range(1, config.retries + 1):
+            retry_note = format_errors(last_errors) if last_errors else ""
+            # Clean any stale agent output from a previous attempt.
+            ap.agent_output.unlink(missing_ok=True)
+            try:
+                run_omp(prompt, ap, config, retry_note)
+            except RuntimeError as exc:
+                return _fail(f"omp invocation failed (attempt {attempt}): {exc}", EXIT_GEN_FAILED)
+
+            try:
+                sdf_text = read_agent_output(ap)
+            except RuntimeError as exc:
+                last_errors = [str(exc)]
+                continue
+
+            # --- validate ---
+            result = validate(sdf_text)
+            if result.ok:
+                break
+            last_errors = result.errors
+        else:
+            return _fail(
+                f"validation failed after {config.retries} attempts: {'; '.join(last_errors)}",
+                EXIT_GEN_FAILED,
+            )
+
+        # --- post-process: parse, apply prefer, sort, render ---
+        import yaml
+
+        sdf = parse_sdf(yaml.safe_load(sdf_text))
+        prefer_result = scan_prefer(sdf, checkout, release.bin_prefix, own_identifier)
+        apply_prefer(sdf, prefer_result)
+        final_text = render(sdf)
+
+        # --- re-validate after post-processing ---
+        result = validate(final_text)
+        if not result.ok:
+            return _fail(
+                f"post-processing validation failed: {'; '.join(result.errors)}",
+                EXIT_GEN_FAILED,
+            )
+
+        # --- write output ---
+        out_path = Path(config.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(final_text, encoding="utf-8")
+
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an exit code."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = _parse_config(args)
+    if args.command == "generate-sdf":
+        return generate_sdf(config)
+    return _fail(f"unknown command: {args.command}", EXIT_CONFIG_ERROR)

--- a/slice-builder/src/slice_builder/config.py
+++ b/slice-builder/src/slice_builder/config.py
@@ -1,0 +1,39 @@
+"""Configuration dataclasses shared across the slice-builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DepRef:
+    """A resolved dependency reference.
+
+    Attributes:
+        sd_name: bare SD name (e.g. ``curl``).
+        is_bin: True if the dep SDF declares ``store: bin``.
+        prefix: the release bin prefix (e.g. ``bin-``) if the dep is a bin dep,
+            otherwise the empty string (deb deps use the bare name).
+        sdf: the loaded dep SDF as a plain dict.
+    """
+
+    sd_name: str
+    is_bin: bool
+    prefix: str
+    sdf: dict
+
+
+@dataclass
+class BuildConfig:
+    """Parsed CLI configuration for a single ``generate-sdf`` invocation."""
+
+    bin_archive: str
+    base: str
+    package: str
+    track: str
+    dependencies: list[str] = field(default_factory=list)
+    sdf_lookup_dir: str | None = None
+    output: str = ""
+    omp: str = "omp"
+    omp_model: str | None = None
+    retries: int = 3

--- a/slice-builder/src/slice_builder/deps.py
+++ b/slice-builder/src/slice_builder/deps.py
@@ -1,0 +1,75 @@
+"""Locate and load dependency SDFs (bin vs deb detection).
+
+For each dependency ``sd_name``:
+
+1. Search the SDF lookup dir (already-generated bin SDFs), then the checkout's bin SDF dir, then
+   the checkout's regular ``slices/`` dir (deb SDFs).
+2. Load the SDF; determine bin vs deb by the presence of ``store: bin``.
+3. Build a :class:`DepRef` with the appropriate prefix (release bin prefix for bin deps, empty
+   for deb deps).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from slice_builder.config import DepRef
+from slice_builder.sdf import load_sdf_dict
+
+
+def _find_sdf(sd_name: str, lookup_dir: str | Path | None, checkout: str | Path) -> Path | None:
+    """Locate ``<sd_name>.yaml`` in lookup dir, then checkout bin dir, then checkout slices."""
+
+    candidates: list[Path] = []
+    if lookup_dir is not None:
+        candidates.append(Path(lookup_dir) / f"{sd_name}.yaml")
+    # Checkout bin SDF dir (v3: bin-slices/, v4: slices/) and regular slices/ both covered.
+    for sub in ("bin-slices", "slices"):
+        candidates.append(Path(checkout) / sub / f"{sd_name}.yaml")
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+def resolve_deps(
+    dependencies: list[str],
+    lookup_dir: str | Path | None,
+    checkout: str | Path,
+    bin_prefix: str,
+) -> list[DepRef]:
+    """Resolve all dependency SDFs.
+
+    Raises ``ValueError`` listing every dependency whose SDF could not be found.
+    """
+
+    missing: list[str] = []
+    refs: list[DepRef] = []
+    for sd_name in dependencies:
+        path = _find_sdf(sd_name, lookup_dir, checkout)
+        if path is None:
+            missing.append(sd_name)
+            continue
+        sdf = load_sdf_dict(path)
+        is_bin = sdf.get("store") == "bin"
+        refs.append(
+            DepRef(
+                sd_name=sd_name,
+                is_bin=is_bin,
+                prefix=bin_prefix if is_bin else "",
+                sdf=sdf,
+            )
+        )
+    if missing:
+        raise ValueError(f"dependency SDF(s) not found: {', '.join(missing)}")
+    return refs
+
+
+def slice_ref(dep: DepRef, slice_name: str) -> str:
+    """Build a full slice reference for a dependency slice.
+
+    Bin deps use the prefixed identifier (``bin-<dep>_<slice>``); deb deps use the bare name
+    (``<dep>_<slice>``).
+    """
+
+    return f"{dep.prefix}{dep.sd_name}_{slice_name}"

--- a/slice-builder/src/slice_builder/overlay.py
+++ b/slice-builder/src/slice_builder/overlay.py
@@ -1,0 +1,30 @@
+"""Overlay a read-only SDF lookup directory onto a checkout's bin SDF directory."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def overlay(lookup_dir: str | Path | None, checkout: str | Path, bin_sdf_dir: str) -> None:
+    """Copy ``*.yaml`` files from ``lookup_dir`` into ``checkout/bin_sdf_dir``.
+
+    The lookup dir is read-only (populated by sd-tools, never overwritten). Existing files in
+    the checkout's bin SDF dir with the same name are overwritten by the overlay, mirroring the
+    "unified tree" intent: previously-generated bin SDFs take precedence over the checkout's
+    versions.
+
+    A missing or empty ``lookup_dir`` is a no-op.
+    """
+
+    if lookup_dir is None:
+        return
+    src = Path(lookup_dir)
+    if not src.is_dir():
+        return
+
+    dst = Path(checkout) / bin_sdf_dir
+    dst.mkdir(parents=True, exist_ok=True)
+
+    for yaml_file in sorted(src.glob("*.yaml")):
+        shutil.copy2(yaml_file, dst / yaml_file.name)

--- a/slice-builder/src/slice_builder/prefer.py
+++ b/slice-builder/src/slice_builder/prefer.py
@@ -1,0 +1,133 @@
+"""Literal-path conflict scan across checkout SDFs -> ``prefer``.
+
+The agent does not compute ``prefer``; the builder does it deterministically after the agent
+produces a draft SDF. For each LITERAL (non-glob) path in the generated bin SDF's contents that
+also appears in another package's SDF in the checkout:
+
+- Bin vs deb conflict: emit ``prefer: <deb-package-name>`` on the bin's path (deb wins).
+- Bin vs bin conflict: flag for human review (no default resolution).
+
+``prefer`` is forbidden on glob paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from slice_builder.sdf import SDF, load_sdf_dict
+
+GLOB_CHARS = ("*", "?", "**")
+
+
+def is_glob(path: str) -> bool:
+    """Return True if ``path`` contains any glob character."""
+
+    return any(ch in path for ch in GLOB_CHARS)
+
+
+@dataclass
+class PreferResult:
+    """Outcome of a prefer scan."""
+
+    # path -> prefer value (the package identifier to prefer).
+    prefers: dict[str, str] = field(default_factory=dict)
+    # path -> list of conflicting package identifiers (for human review).
+    bin_vs_bin_conflicts: dict[str, list[str]] = field(default_factory=dict)
+
+
+def _collect_literal_paths(sdf_dict: dict) -> set[str]:
+    """Return the set of literal (non-glob) content paths in an SDF dict."""
+
+    paths: set[str] = set()
+    for sl in (sdf_dict.get("slices") or {}).values():
+        if not isinstance(sl, dict):
+            continue
+        contents = sl.get("contents")
+        if not isinstance(contents, dict):
+            continue
+        for p in contents:
+            if isinstance(p, str) and not is_glob(p):
+                paths.add(p)
+    return paths
+
+
+def _package_identifier(sdf_dict: dict, bin_prefix: str) -> str:
+    """Return the unique package identifier for an SDF (prefixed for bins, bare for debs)."""
+
+    pkg = str(sdf_dict.get("package", ""))
+    if sdf_dict.get("store") == "bin":
+        return f"{bin_prefix}{pkg}"
+    return pkg
+
+
+def scan_prefer(
+    generated: SDF,
+    checkout: str | Path,
+    bin_prefix: str,
+    own_identifier: str,
+) -> PreferResult:
+    """Scan checkout SDFs for literal-path conflicts with ``generated``.
+
+    ``own_identifier`` is the generated package's unique identifier (e.g. ``bin-curl``), used to
+    skip self-conflicts.
+    """
+
+    result = PreferResult()
+    checkout = Path(checkout)
+
+    # Literal paths in the generated SDF, grouped by slice for later application.
+    own_literals: set[str] = set()
+    for sl in generated.slices.values():
+        for p in sl.contents:
+            if not is_glob(p):
+                own_literals.add(p)
+
+    if not own_literals:
+        return result
+
+    # Map: literal path -> list of (other_identifier, is_bin) that also declare it.
+    conflicts: dict[str, list[tuple[str, bool]]] = {}
+    for sdf_dir in ("bin-slices", "slices"):
+        d = checkout / sdf_dir
+        if not d.is_dir():
+            continue
+        for yaml_file in sorted(d.glob("*.yaml")):
+            try:
+                other = load_sdf_dict(yaml_file)
+            except (OSError, ValueError):
+                continue
+            other_id = _package_identifier(other, bin_prefix)
+            if other_id == own_identifier:
+                continue
+            other_is_bin = other.get("store") == "bin"
+            for p in _collect_literal_paths(other):
+                if p in own_literals:
+                    conflicts.setdefault(p, []).append((other_id, other_is_bin))
+
+    for path, others in conflicts.items():
+        deb_winners = [oid for oid, is_bin in others if not is_bin]
+        bin_winners = [oid for oid, is_bin in others if is_bin]
+        if deb_winners:
+            # Deb wins by default; prefer the first deb (deterministic).
+            result.prefers[path] = deb_winners[0]
+        elif bin_winners:
+            # Bin vs bin: no default; flag for human review.
+            result.bin_vs_bin_conflicts[path] = sorted(bin_winners)
+    return result
+
+
+def apply_prefer(sdf: SDF, result: PreferResult) -> None:
+    """Apply ``prefer`` values to the generated SDF's literal content paths in place.
+
+    Glob paths are never touched. Existing path properties are preserved; ``prefer`` is added.
+    """
+
+    for sl in sdf.slices.values():
+        for path, entry in list(sl.contents.items()):
+            if is_glob(path):
+                continue
+            if path in result.prefers:
+                new_entry: dict = dict(entry) if entry else {}
+                new_entry["prefer"] = result.prefers[path]
+                sl.contents[path] = new_entry

--- a/slice-builder/src/slice_builder/release.py
+++ b/slice-builder/src/slice_builder/release.py
@@ -1,0 +1,63 @@
+"""Parse `chisel.yaml` from a chisel-releases checkout.
+
+The schema is verified against the Chisel documentation (format v1-v4). Only the fields the
+slice-builder needs are extracted: ``format``, the bin store's ``default-prefix``, and the bin
+SDF directory implied by the format (``bin-slices/`` for v3, ``slices/`` for v4).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+# The store name for bin packages. Hardcoded per the plan's "Open / future" item #3.
+BIN_STORE = "bin"
+
+
+@dataclass
+class ReleaseInfo:
+    """The subset of `chisel.yaml` the slice-builder consumes."""
+
+    format: str
+    bin_prefix: str
+    bin_sdf_dir: str
+
+
+def parse_chisel_yaml(checkout: str | Path) -> ReleaseInfo:
+    """Parse `chisel.yaml` from the root of a checkout.
+
+    Raises ``ValueError`` if the file is missing, malformed, or lacks the bin store.
+    """
+
+    checkout = Path(checkout)
+    path = checkout / "chisel.yaml"
+    if not path.is_file():
+        raise ValueError(f"chisel.yaml not found at {path}")
+
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a YAML mapping")
+
+    fmt = str(data.get("format", "")).strip()
+    if fmt not in ("v1", "v2", "v3", "v4"):
+        raise ValueError(f"{path}: unsupported or missing format: {fmt!r}")
+
+    stores = data.get("stores")
+    if not isinstance(stores, dict) or BIN_STORE not in stores:
+        raise ValueError(f"{path}: missing stores.{BIN_STORE}")
+
+    bin_store = stores[BIN_STORE]
+    if not isinstance(bin_store, dict):
+        raise ValueError(f"{path}: stores.{BIN_STORE} is not a mapping")
+
+    prefix = bin_store.get("default-prefix")
+    if not isinstance(prefix, str) or not prefix:
+        raise ValueError(f"{path}: stores.{BIN_STORE}.default-prefix missing or invalid")
+
+    # v3: bin SDFs live in bin-slices/; v4+: bin SDFs live in slices/ alongside regular ones.
+    bin_sdf_dir = "bin-slices" if fmt == "v3" else "slices"
+
+    return ReleaseInfo(format=fmt, bin_prefix=prefix, bin_sdf_dir=bin_sdf_dir)

--- a/slice-builder/src/slice_builder/render.py
+++ b/slice-builder/src/slice_builder/render.py
@@ -1,0 +1,40 @@
+"""Sort and render an SDF to canonical YAML.
+
+Sorting is byte order (``LC_COLLATE=C``, lexicographic by UTF-8 bytes) for ``contents`` paths
+and ``essential`` entries, matching the validation rule. Slice order is preserved as the agent
+emitted it (the spec only mandates path/essential key order).
+"""
+
+from __future__ import annotations
+
+from slice_builder.sdf import SDF, byte_sorted, dump_sdf
+
+
+def sort_sdf(sdf: SDF) -> None:
+    """Sort ``contents`` paths and ``essential`` entries in byte order, in place."""
+
+    sdf.essential = {k: sdf.essential[k] for k in byte_sorted(sdf.essential)}
+    for sl in sdf.slices.values():
+        sl.essential = {k: sl.essential[k] for k in byte_sorted(sl.essential)}
+        sl.contents = {k: sl.contents[k] for k in byte_sorted(sl.contents)}
+
+
+def render(sdf: SDF) -> str:
+    """Sort and render an SDF to a canonical YAML string.
+
+    A blank line is inserted between top-level sections and between slices to match the
+    existing repo SDF style (e.g. ``slices/bins/curl.yaml``).
+    """
+
+    sort_sdf(sdf)
+    text = dump_sdf(sdf)
+    # Insert a blank line before each top-level key that starts at column 0 (no leading space),
+    # except the very first line. This mirrors the repo's section spacing.
+    lines = text.splitlines()
+    out: list[str] = []
+    for i, line in enumerate(lines):
+        if i > 0 and line and not line[0].isspace() and not line.startswith("-"):
+            if out and out[-1] != "":
+                out.append("")
+        out.append(line)
+    return "\n".join(out) + "\n"

--- a/slice-builder/src/slice_builder/render.py
+++ b/slice-builder/src/slice_builder/render.py
@@ -20,21 +20,33 @@ def sort_sdf(sdf: SDF) -> None:
 
 
 def render(sdf: SDF) -> str:
-    """Sort and render an SDF to a canonical YAML string.
-
-    A blank line is inserted between top-level sections and between slices to match the
-    existing repo SDF style (e.g. ``slices/bins/curl.yaml``).
-    """
+    """Sort and render an SDF to a canonical YAML string."""
 
     sort_sdf(sdf)
     text = dump_sdf(sdf)
-    # Insert a blank line before each top-level key that starts at column 0 (no leading space),
-    # except the very first line. This mirrors the repo's section spacing.
     lines = text.splitlines()
     out: list[str] = []
+    in_slices = False
+    first_slice_seen = False
     for i, line in enumerate(lines):
-        if i > 0 and line and not line[0].isspace() and not line.startswith("-"):
-            if out and out[-1] != "":
-                out.append("")
+        if line == "slices:":
+            in_slices = True
+            first_slice_seen = False
+        is_top_level = bool(line) and not line[0].isspace()
+        is_slice_name = (
+            in_slices
+            and line.startswith("  ")
+            and not line.startswith("   ")
+            and line.endswith(":")
+        )
+        insert_blank = False
+        if i > 0 and is_top_level:
+            insert_blank = True
+        elif is_slice_name and first_slice_seen:
+            insert_blank = True
+        if is_slice_name:
+            first_slice_seen = True
+        if insert_blank and out and out[-1] != "":
+            out.append("")
         out.append(line)
     return "\n".join(out) + "\n"

--- a/slice-builder/src/slice_builder/sdf.py
+++ b/slice-builder/src/slice_builder/sdf.py
@@ -1,0 +1,175 @@
+"""SDF data model plus YAML load/dump helpers.
+
+The model is intentionally small: it represents the subset of the Chisel slice definition
+format (v3/v4) that the generator produces and re-emits. Dependency SDFs are loaded as plain
+dicts (``load_sdf_dict``) for analysis; the generator's own output is round-tripped through the
+``SDF``/``Slice`` dataclasses and ``dump_sdf``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# A content entry is either ``None`` (a bare path, emitted as ``/path:``) or a dict of path
+# properties (e.g. ``{"prefer": "libc6"}``).
+ContentEntry = dict | None
+
+
+@dataclass
+class Slice:
+    """A single slice within an SDF."""
+
+    name: str
+    contents: dict[str, ContentEntry] = field(default_factory=dict)
+    essential: dict[str, dict] = field(default_factory=dict)
+    # Preserves unrecognised slice-level fields (mutate, hint, ...) when round-tripping.
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class SDF:
+    """A slice definition file."""
+
+    package: str
+    store: str | None = None
+    default_track: str | None = None
+    essential: dict[str, dict] = field(default_factory=dict)
+    slices: dict[str, Slice] = field(default_factory=dict)
+    # Preserves unrecognised top-level fields (archive, ...) when round-tripping.
+    extra: dict = field(default_factory=dict)
+
+
+def byte_sorted(items):
+    """Return ``items`` sorted in byte order (``LC_COLLATE=C``), lexicographic by UTF-8 bytes.
+
+    UTF-8 is designed so that byte-wise comparison preserves code-point order, so this matches
+    a C-locale sort for valid UTF-8 strings.
+    """
+
+    return sorted(items, key=lambda x: x.encode("utf-8"))
+
+
+def load_sdf_dict(path: str | Path) -> dict:
+    """Load an SDF file as a plain dict (for dependency analysis)."""
+
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"SDF {path} is not a YAML mapping")
+    return data
+
+
+def _coerce_essential(value) -> dict[str, dict]:
+    """Normalise an ``essential`` value (v3/v4 map or v1/v2 list) to a map of dicts."""
+
+    if isinstance(value, dict):
+        return {str(k): (v if isinstance(v, dict) else {}) for k, v in value.items()}
+    if isinstance(value, list):
+        return {str(k): {} for k in value}
+    return {}
+
+
+def _coerce_contents(value) -> dict[str, ContentEntry]:
+    """Normalise a ``contents`` value to a map of path -> entry."""
+
+    if not isinstance(value, dict):
+        return {}
+    return {str(k): (v if isinstance(v, dict) else None) for k, v in value.items()}
+
+
+def parse_sdf(data: dict) -> SDF:
+    """Parse and validate a plain dict into an :class:`SDF`.
+
+    Raises ``ValueError`` if required fields (``package``, ``slices``) are missing.
+    """
+
+    errors: list[str] = []
+    if "package" not in data:
+        errors.append("missing required field: package")
+    if not isinstance(data.get("slices"), dict):
+        errors.append("missing required field: slices")
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    sdf = SDF(package=str(data["package"]))
+    sdf.store = data.get("store")
+    sdf.default_track = data.get("default-track")
+    if sdf.default_track is not None:
+        sdf.default_track = str(sdf.default_track)
+    sdf.essential = _coerce_essential(data.get("essential"))
+
+    for name, sdata in data["slices"].items():
+        if not isinstance(sdata, dict):
+            continue
+        sl = Slice(name=str(name))
+        sl.contents = _coerce_contents(sdata.get("contents"))
+        sl.essential = _coerce_essential(sdata.get("essential"))
+        sl.extra = {k: v for k, v in sdata.items() if k not in ("contents", "essential")}
+        sdf.slices[str(name)] = sl
+
+    sdf.extra = {
+        k: v
+        for k, v in data.items()
+        if k not in ("package", "store", "default-track", "essential", "slices")
+    }
+    return sdf
+
+
+class _QuotedStr(str):
+    """A string subclass that is always emitted with double-quote style."""
+
+
+class SDFDumper(yaml.SafeDumper):
+    """Custom dumper forcing the repo SDF style: block style, null-valued bare keys."""
+
+
+def _represent_none(dumper, _):
+    # Emit ``None`` as an empty scalar so dict values render as ``key:`` (not ``key: null``).
+    return dumper.represent_scalar("tag:yaml.org,2002:null", "")
+
+
+def _represent_quoted_str(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data), style='"')
+
+
+SDFDumper.add_representer(type(None), _represent_none)
+SDFDumper.add_representer(_QuotedStr, _represent_quoted_str)
+
+
+def _sdf_to_dict(sdf: SDF) -> dict:
+    out: dict = {"package": sdf.package}
+    if sdf.store is not None:
+        out["store"] = sdf.store
+    if sdf.default_track is not None:
+        out["default-track"] = _QuotedStr(sdf.default_track)
+    if sdf.essential:
+        out["essential"] = {k: (v if v else None) for k, v in sdf.essential.items()}
+    slices_out: dict = {}
+    for name, sl in sdf.slices.items():
+        sd: dict = {}
+        if sl.essential:
+            sd["essential"] = {k: (v if v else None) for k, v in sl.essential.items()}
+        if sl.contents:
+            sd["contents"] = dict(sl.contents)
+        sd.update(sl.extra)
+        slices_out[name] = sd
+    out["slices"] = slices_out
+    out.update(sdf.extra)
+    return out
+
+
+def dump_sdf(sdf: SDF) -> str:
+    """Render an :class:`SDF` to a canonical YAML string (block style, sorted by caller).."""
+
+    data = _sdf_to_dict(sdf)
+    return yaml.dump(
+        data,
+        Dumper=SDFDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+        width=100,
+    )

--- a/slice-builder/src/slice_builder/sdf.py
+++ b/slice-builder/src/slice_builder/sdf.py
@@ -141,10 +141,10 @@ SDFDumper.add_representer(_QuotedStr, _represent_quoted_str)
 
 def _sdf_to_dict(sdf: SDF) -> dict:
     out: dict = {"package": sdf.package}
-    if sdf.store is not None:
-        out["store"] = sdf.store
     if sdf.default_track is not None:
         out["default-track"] = _QuotedStr(sdf.default_track)
+    if sdf.store is not None:
+        out["store"] = sdf.store
     if sdf.essential:
         out["essential"] = {k: (v if v else None) for k, v in sdf.essential.items()}
     slices_out: dict = {}

--- a/slice-builder/src/slice_builder/validate.py
+++ b/slice-builder/src/slice_builder/validate.py
@@ -1,0 +1,141 @@
+"""Validation: yamllint + sort-check + parse-check.
+
+Run before writing the final SDF. On failure, the agent is retried (up to ``--retries``).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from slice_builder.sdf import SDF, byte_sorted, parse_sdf
+
+# Path to the tool-owned yamllint config, next to this package's source tree.
+_YAMLLINT_CONFIG = Path(__file__).resolve().parents[2] / "yamllint.yaml"
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of validating a draft SDF."""
+
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+
+    def add(self, msg: str) -> None:
+        self.errors.append(msg)
+        self.ok = False
+
+
+def _run_yamllint(sdf_text: str) -> list[str]:
+    """Run yamllint (as a subprocess) against ``sdf_text`` using the tool-owned config.
+
+    Returns a list of human-readable error strings (empty if clean).
+    """
+
+    if not _YAMLLINT_CONFIG.is_file():
+        return [f"yamllint config not found: {_YAMLLINT_CONFIG}"]
+
+    try:
+        proc = subprocess.run(
+            ["yamllint", "-c", str(_YAMLLINT_CONFIG), "-"],
+            input=sdf_text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return ["yamllint not installed (run: uv run yamllint ...)"]
+
+    if proc.returncode == 0:
+        return []
+    # yamllint prints "file:line:col: message" — strip the leading "-:" filename.
+    lines = [ln for ln in (proc.stdout + proc.stderr).splitlines() if ln.strip()]
+    cleaned: list[str] = []
+    for ln in lines:
+        if ln.startswith("-:"):
+            ln = ln[2:]
+        cleaned.append(ln.strip())
+    return cleaned or ["yamllint reported errors"]
+
+
+def _check_sorted(sdf: SDF) -> list[str]:
+    """Verify ``contents`` and ``essential`` keys are in byte order."""
+
+    errors: list[str] = []
+    keys = list(sdf.essential)
+    if keys != byte_sorted(keys):
+        errors.append("top-level essential entries are not byte-sorted")
+    for name, sl in sdf.slices.items():
+        keys = list(sl.essential)
+        if keys != byte_sorted(keys):
+            errors.append(f"slices.{name}.essential entries are not byte-sorted")
+        keys = list(sl.contents)
+        if keys != byte_sorted(keys):
+            errors.append(f"slices.{name}.contents paths are not byte-sorted")
+    return errors
+
+
+def _check_required(sdf: SDF) -> list[str]:
+    """Verify required fields and basic invariants."""
+
+    errors: list[str] = []
+    if not sdf.package:
+        errors.append("missing required field: package")
+    if sdf.store is None:
+        errors.append("missing required field: store")
+    if sdf.default_track is None:
+        errors.append("missing required field: default-track")
+    if not sdf.slices:
+        errors.append("missing required field: slices (or empty)")
+    for name, sl in sdf.slices.items():
+        for p in sl.contents:
+            if not p.startswith("/"):
+                errors.append(f"slices.{name}.contents path is not absolute: {p!r}")
+    return errors
+
+
+def validate(sdf_text: str) -> ValidationResult:
+    """Validate a draft SDF string: yamllint + parse + sort + required-fields."""
+
+    result = ValidationResult(ok=True)
+
+    # 1. yamllint (config: 2-space indent, 100-char lines, no document-start marker).
+    result.errors.extend(_run_yamllint(sdf_text))
+    if result.errors:
+        result.ok = False
+
+    # 2. parse + required fields.
+    import yaml
+
+    try:
+        data = yaml.safe_load(sdf_text)
+    except yaml.YAMLError as exc:
+        result.add(f"YAML parse error: {exc}")
+        return result
+
+    try:
+        sdf = parse_sdf(data)
+    except ValueError as exc:
+        result.add(f"parse error: {exc}")
+        return result
+
+    result.errors.extend(_check_required(sdf))
+    if result.errors:
+        result.ok = False
+
+    # 3. sort check.
+    result.errors.extend(_check_sorted(sdf))
+    if result.errors:
+        result.ok = False
+
+    return result
+
+
+def format_errors(errors: list[str]) -> str:
+    """Format validation errors for inclusion in an agent retry prompt."""
+
+    if not errors:
+        return ""
+    body = "\n".join(f"  - {e}" for e in errors)
+    return f"Validation errors:\n{body}\n\nFix these and regenerate the SDF."

--- a/slice-builder/src/slice_builder/validate.py
+++ b/slice-builder/src/slice_builder/validate.py
@@ -5,6 +5,7 @@ Run before writing the final SDF. On failure, the agent is retried (up to ``--re
 
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +14,10 @@ from slice_builder.sdf import SDF, byte_sorted, parse_sdf
 
 # Path to the tool-owned yamllint config, next to this package's source tree.
 _YAMLLINT_CONFIG = Path(__file__).resolve().parents[2] / "yamllint.yaml"
+
+# Slice names: lowercase a-z, digits 0-9, minus; at least 3 chars; must start with a letter.
+# Matches the rule documented in skills/sdf-generation/SKILL.md.
+_SLICE_NAME_RE = re.compile(r"[a-z][a-z0-9-]{2,}")
 
 
 @dataclass
@@ -49,13 +54,20 @@ def _run_yamllint(sdf_text: str) -> list[str]:
 
     if proc.returncode == 0:
         return []
-    # yamllint prints "file:line:col: message" — strip the leading "-:" filename.
-    lines = [ln for ln in (proc.stdout + proc.stderr).splitlines() if ln.strip()]
+    # yamllint prints "file:line:col: message". When invoked with "-" (stdin) it uses "stdin"
+    # as the filename header on its own line, followed by "<line>:<col>  <level>  <msg>" lines.
+    # Drop the bare filename header and any leading "-:" prefix so only the messages survive.
     cleaned: list[str] = []
-    for ln in lines:
+    for ln in (proc.stdout + proc.stderr).splitlines():
+        ln = ln.strip()
+        if not ln or ln in ("-", "stdin"):
+            continue
         if ln.startswith("-:"):
-            ln = ln[2:]
-        cleaned.append(ln.strip())
+            ln = ln[2:].strip()
+        elif ln.startswith("stdin:"):
+            ln = ln[len("stdin:") :].strip()
+        if ln:
+            cleaned.append(ln)
     return cleaned or ["yamllint reported errors"]
 
 
@@ -84,19 +96,73 @@ def _check_required(sdf: SDF) -> list[str]:
         errors.append("missing required field: package")
     if sdf.store is None:
         errors.append("missing required field: store")
+    elif sdf.store != "bin":
+        # This tool exists solely to generate bin SDFs; the store must be "bin".
+        errors.append(f"store must be 'bin' for bin packages, got: {sdf.store!r}")
     if sdf.default_track is None:
         errors.append("missing required field: default-track")
     if not sdf.slices:
         errors.append("missing required field: slices (or empty)")
     for name, sl in sdf.slices.items():
+        if not _SLICE_NAME_RE.fullmatch(name):
+            errors.append(
+                f"invalid slice name {name!r}: must be lowercase a-z/0-9/-, >=3 chars, "
+                "start with a letter"
+            )
         for p in sl.contents:
             if not p.startswith("/"):
                 errors.append(f"slices.{name}.contents path is not absolute: {p!r}")
     return errors
 
 
+def _parse_and_check_semantic(sdf_text: str) -> tuple[ValidationResult, SDF | None]:
+    """Parse ``sdf_text`` and run the semantic checks (parse + required + absolute paths).
+
+    Returns the result and the parsed SDF (None on parse failure). Does NOT run yamllint or the
+    sort check — those are style concerns the builder's own ``render()`` re-imposes, so they
+    should not trigger an agent retry.
+    """
+
+    result = ValidationResult(ok=True)
+
+    import yaml
+
+    try:
+        data = yaml.safe_load(sdf_text)
+    except yaml.YAMLError as exc:
+        result.add(f"YAML parse error: {exc}")
+        return result, None
+
+    try:
+        sdf = parse_sdf(data)
+    except ValueError as exc:
+        result.add(f"parse error: {exc}")
+        return result, None
+
+    result.errors.extend(_check_required(sdf))
+    if result.errors:
+        result.ok = False
+    return result, sdf
+
+
+def validate_semantic(sdf_text: str) -> ValidationResult:
+    """Validate only what the agent is responsible for: parse + required fields + absolute paths.
+
+    Used in the agent retry loop. yamllint and byte-sort are skipped because ``render()``
+    re-imposes them deterministically after the agent runs; retrying the agent for a style or
+    ordering issue it was about to have fixed would waste an LLM round-trip.
+    """
+
+    result, _ = _parse_and_check_semantic(sdf_text)
+    return result
+
+
 def validate(sdf_text: str) -> ValidationResult:
-    """Validate a draft SDF string: yamllint + parse + sort + required-fields."""
+    """Validate a draft SDF string: yamllint + parse + sort + required-fields.
+
+    The full check, run on the final rendered text after ``render()`` has re-imposed style and
+    ordering. For the agent retry loop prefer :func:`validate_semantic`.
+    """
 
     result = ValidationResult(ok=True)
 
@@ -105,24 +171,26 @@ def validate(sdf_text: str) -> ValidationResult:
     if result.errors:
         result.ok = False
 
-    # 2. parse + required fields.
+    # 2. parse + required fields + absolute paths.
+    sem, _ = _parse_and_check_semantic(sdf_text)
+    if not sem.ok:
+        # Preserve yamllint errors already collected, then add semantic ones.
+        result.errors.extend(sem.errors)
+        result.ok = False
+        # If parsing failed there is nothing more to check.
+        if not any("parse" in e for e in sem.errors):
+            pass
+        else:
+            return result
+
+    # Re-parse to run the sort check (cheap, and _parse_and_check already validated structure).
     import yaml
 
     try:
-        data = yaml.safe_load(sdf_text)
-    except yaml.YAMLError as exc:
-        result.add(f"YAML parse error: {exc}")
+        sdf = parse_sdf(yaml.safe_load(sdf_text))
+    except (yaml.YAMLError, ValueError):
+        # Already reported above; nothing more to do.
         return result
-
-    try:
-        sdf = parse_sdf(data)
-    except ValueError as exc:
-        result.add(f"parse error: {exc}")
-        return result
-
-    result.errors.extend(_check_required(sdf))
-    if result.errors:
-        result.ok = False
 
     # 3. sort check.
     result.errors.extend(_check_sorted(sdf))

--- a/slice-builder/tests/conftest.py
+++ b/slice-builder/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared pytest fixtures and markers."""
+
+import shutil
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: requires omp + LLM credentials")
+
+
+def has_omp() -> bool:
+    return shutil.which("omp") is not None
+
+
+def has_llm_credentials() -> bool:
+    import os
+
+    # omp reads keys from env; treat any common API-key env var as "credentials present".
+    return any(
+        os.environ.get(k)
+        for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY")
+    )
+
+
+@pytest.fixture
+def tmp_checkout(tmp_path):
+    """A bare chisel-releases checkout skeleton with a chisel.yaml."""
+
+    (tmp_path / "chisel.yaml").write_text(
+        "format: v3\n"
+        "archives:\n  ubuntu:\n    default: true\n    version: 26.04\n"
+        "    components: [main]\n    suites: [noble]\n"
+        "    public-keys: [k]\n"
+        "stores:\n  bin:\n    kind: bin\n    version: 26.04\n    default-prefix: 'bin-'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "slices").mkdir()
+    (tmp_path / "bin-slices").mkdir()
+    return tmp_path

--- a/slice-builder/tests/integration/test_generate_sdf.py
+++ b/slice-builder/tests/integration/test_generate_sdf.py
@@ -1,0 +1,68 @@
+"""Integration tests for the full generate-sdf pipeline.
+
+Gated behind @slow: require omp on PATH and LLM credentials. These hit the network (git clone)
+and a real LLM, so they are skipped by default.
+"""
+
+import tarfile
+from io import BytesIO
+
+import pytest
+
+from slice_builder.cli import main
+from tests.conftest import has_llm_credentials, has_omp
+
+slow = pytest.mark.skipif(
+    not (has_omp() and has_llm_credentials()),
+    reason="requires omp on PATH and LLM credentials",
+)
+
+
+def _make_bin_archive(path, members):
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:xz") as tar:
+        for name, content in members.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, BytesIO(data))
+    path.write_bytes(buf.getvalue())
+
+
+@slow
+@pytest.mark.slow
+def test_generate_sdf_end_to_end(tmp_path):
+    archive = tmp_path / "curl.tar.xz"
+    _make_bin_archive(
+        archive,
+        {
+            "usr/bin/curl-bin": "#!/bin/sh\n",
+            "usr/share/doc/curl-bin/copyright": "copyright\n",
+        },
+    )
+    output = tmp_path / "out" / "curl.yaml"
+    rc = main(
+        [
+            "generate-sdf",
+            "--bin-archive",
+            str(archive),
+            "--base",
+            "26.04",
+            "--package",
+            "curl",
+            "--track",
+            "0.1",
+            "--dependencies",
+            "",
+            "--sdf-lookup-dir",
+            str(tmp_path / "lookup"),
+            "--output",
+            str(output),
+        ]
+    )
+    assert rc == 0
+    assert output.is_file()
+    text = output.read_text()
+    assert "package: curl" in text
+    assert "store: bin" in text
+    assert 'default-track: "0.1"' in text

--- a/slice-builder/tests/unit/test_archive.py
+++ b/slice-builder/tests/unit/test_archive.py
@@ -3,7 +3,9 @@
 import tarfile
 from io import BytesIO
 
-from slice_builder.archive import extract_paths
+import pytest
+
+from slice_builder.archive import extract_archive, extract_paths
 
 
 def _make_tarxz(members: dict[str, bytes]) -> bytes:
@@ -42,16 +44,67 @@ def test_extract_paths_dedupes(tmp_path):
 
 
 def test_extract_paths_missing_archive_raises(tmp_path):
-    import pytest
-
     with pytest.raises(ValueError, match="archive not found"):
         extract_paths(tmp_path / "nope.tar.xz")
 
 
 def test_extract_paths_bad_archive_raises(tmp_path):
-    import pytest
-
     archive = tmp_path / "bad.tar.xz"
     archive.write_bytes(b"not a tar")
     with pytest.raises(ValueError, match="cannot read archive"):
         extract_paths(archive)
+
+
+# --- extract_archive ---
+
+
+def test_extract_archive_writes_files(tmp_path):
+    archive = tmp_path / "bin.tar.xz"
+    archive.write_bytes(
+        _make_tarxz(
+            {
+                "usr/bin/curl": b"#!/bin/sh\n",
+                "usr/share/doc/curl/copyright": b"copyright\n",
+            }
+        )
+    )
+    dest = tmp_path / "extracted"
+    extract_archive(archive, dest)
+    assert (dest / "usr/bin/curl").read_bytes() == b"#!/bin/sh\n"
+    assert (dest / "usr/share/doc/curl/copyright").read_bytes() == b"copyright\n"
+
+
+def test_extract_archive_missing_archive_raises(tmp_path):
+    with pytest.raises(ValueError, match="archive not found"):
+        extract_archive(tmp_path / "nope.tar.xz", tmp_path / "out")
+
+
+def test_extract_archive_bad_archive_raises(tmp_path):
+    archive = tmp_path / "bad.tar.xz"
+    archive.write_bytes(b"not a tar")
+    with pytest.raises(ValueError, match="cannot read archive"):
+        extract_archive(archive, tmp_path / "out")
+
+
+def test_extract_archive_rejects_absolute_member(tmp_path):
+    archive = tmp_path / "evil.tar.xz"
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:xz") as tar:
+        info = tarfile.TarInfo(name="/etc/passwd")
+        info.size = 1
+        tar.addfile(info, BytesIO(b"x"))
+    archive.write_bytes(buf.getvalue())
+    with pytest.raises(ValueError, match="unsafe.*absolute"):
+        extract_archive(archive, tmp_path / "out")
+
+
+def test_extract_archive_rejects_traversal_member(tmp_path):
+    archive = tmp_path / "evil.tar.xz"
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:xz") as tar:
+        info = tarfile.TarInfo(name="../escape")
+        info.size = 1
+        tar.addfile(info, BytesIO(b"x"))
+    archive.write_bytes(buf.getvalue())
+    with pytest.raises(ValueError, match="escapes destination"):
+        extract_archive(archive, tmp_path / "out")

--- a/slice-builder/tests/unit/test_archive.py
+++ b/slice-builder/tests/unit/test_archive.py
@@ -1,0 +1,57 @@
+"""Unit tests for archive.py."""
+
+import tarfile
+from io import BytesIO
+
+from slice_builder.archive import extract_paths
+
+
+def _make_tarxz(members: dict[str, bytes]) -> bytes:
+    """Build an in-memory .tar.xz with the given member name -> content mapping."""
+
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:xz") as tar:
+        for name, content in members.items():
+            data = content.encode() if isinstance(content, str) else content
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, BytesIO(data))
+    return buf.getvalue()
+
+
+def test_extract_paths_returns_sorted_absolute(tmp_path):
+    archive = tmp_path / "bin.tar.xz"
+    archive.write_bytes(
+        _make_tarxz(
+            {
+                "usr/bin/curl": b"#!/bin/sh\n",
+                "usr/share/doc/curl/copyright": b"copyright\n",
+                "etc/curl/config": b"cfg\n",
+            }
+        )
+    )
+    paths = extract_paths(archive)
+    assert paths == sorted(["/etc/curl/config", "/usr/bin/curl", "/usr/share/doc/curl/copyright"])
+
+
+def test_extract_paths_dedupes(tmp_path):
+    archive = tmp_path / "bin.tar.xz"
+    # tarfile dedupes members by name on read; ensure no duplicates surface.
+    archive.write_bytes(_make_tarxz({"usr/bin/x": b""}))
+    assert extract_paths(archive) == ["/usr/bin/x"]
+
+
+def test_extract_paths_missing_archive_raises(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="archive not found"):
+        extract_paths(tmp_path / "nope.tar.xz")
+
+
+def test_extract_paths_bad_archive_raises(tmp_path):
+    import pytest
+
+    archive = tmp_path / "bad.tar.xz"
+    archive.write_bytes(b"not a tar")
+    with pytest.raises(ValueError, match="cannot read archive"):
+        extract_paths(archive)

--- a/slice-builder/tests/unit/test_cli.py
+++ b/slice-builder/tests/unit/test_cli.py
@@ -1,0 +1,69 @@
+"""Unit tests for cli.py config parsing."""
+
+from slice_builder.cli import EXIT_CONFIG_ERROR, _parse_config, build_parser
+
+
+def _parse(args):
+    return _parse_config(build_parser().parse_args(args))
+
+
+def test_retries_zero_rejected():
+    r = _parse(
+        [
+            "generate-sdf",
+            "--bin-archive",
+            "a",
+            "--base",
+            "26.04",
+            "--package",
+            "curl",
+            "--track",
+            "v1",
+            "--output",
+            "o",
+            "--retries",
+            "0",
+        ]
+    )
+    assert r == EXIT_CONFIG_ERROR
+
+
+def test_retries_negative_rejected():
+    r = _parse(
+        [
+            "generate-sdf",
+            "--bin-archive",
+            "a",
+            "--base",
+            "26.04",
+            "--package",
+            "curl",
+            "--track",
+            "v1",
+            "--output",
+            "o",
+            "--retries",
+            "-1",
+        ]
+    )
+    assert r == EXIT_CONFIG_ERROR
+
+
+def test_retries_default_accepted():
+    r = _parse(
+        [
+            "generate-sdf",
+            "--bin-archive",
+            "a",
+            "--base",
+            "26.04",
+            "--package",
+            "curl",
+            "--track",
+            "v1",
+            "--output",
+            "o",
+        ]
+    )
+    assert hasattr(r, "retries")
+    assert r.retries == 3

--- a/slice-builder/tests/unit/test_deps.py
+++ b/slice-builder/tests/unit/test_deps.py
@@ -1,0 +1,60 @@
+"""Unit tests for deps.py."""
+
+import pytest
+
+from slice_builder.config import DepRef
+from slice_builder.deps import resolve_deps, slice_ref
+
+
+def _write_sdf(path, store=None, package="x", slices=None):
+    lines = [f"package: {package}"]
+    if store:
+        lines.append(f"store: {store}")
+    lines.append("slices:")
+    for name, paths in (slices or {}).items():
+        lines.append(f"  {name}:")
+        lines.append("    contents:")
+        for p in paths:
+            lines.append(f"      {p}:")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_resolve_deps_finds_bin_in_lookup(tmp_path):
+    lookup = tmp_path / "lookup"
+    lookup.mkdir()
+    _write_sdf(
+        lookup / "dep1.yaml",
+        store="bin",
+        package="dep1",
+        slices={"bins": ["/usr/bin/dep1"]},
+    )
+    refs = resolve_deps(["dep1"], lookup, tmp_path, "bin-")
+    assert len(refs) == 1
+    assert refs[0].is_bin is True
+    assert refs[0].prefix == "bin-"
+
+
+def test_resolve_deps_finds_deb_in_checkout_slices(tmp_checkout):
+    _write_sdf(
+        tmp_checkout / "slices" / "libc6.yaml",
+        package="libc6",
+        slices={"libs": ["/usr/lib/libc.so"]},
+    )
+    refs = resolve_deps(["libc6"], None, tmp_checkout, "bin-")
+    assert refs[0].is_bin is False
+    assert refs[0].prefix == ""
+
+
+def test_resolve_deps_missing_raises(tmp_checkout):
+    with pytest.raises(ValueError, match="dependency SDF.*not found"):
+        resolve_deps(["nope"], None, tmp_checkout, "bin-")
+
+
+def test_slice_ref_bin_uses_prefix():
+    dep = DepRef(sd_name="dep", is_bin=True, prefix="bin-", sdf={})
+    assert slice_ref(dep, "bins") == "bin-dep_bins"
+
+
+def test_slice_ref_deb_bare():
+    dep = DepRef(sd_name="libc6", is_bin=False, prefix="", sdf={})
+    assert slice_ref(dep, "libs") == "libc6_libs"

--- a/slice-builder/tests/unit/test_overlay.py
+++ b/slice-builder/tests/unit/test_overlay.py
@@ -1,0 +1,42 @@
+"""Unit tests for overlay.py."""
+
+from slice_builder.overlay import overlay
+
+
+def test_overlay_copies_yaml_files(tmp_path):
+    lookup = tmp_path / "lookup"
+    lookup.mkdir()
+    (lookup / "a.yaml").write_text("package: a\n", encoding="utf-8")
+    (lookup / "b.yaml").write_text("package: b\n", encoding="utf-8")
+    (lookup / "ignore.txt").write_text("nope", encoding="utf-8")
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    overlay(lookup, checkout, "bin-slices")
+    assert (checkout / "bin-slices" / "a.yaml").is_file()
+    assert (checkout / "bin-slices" / "b.yaml").is_file()
+    assert not (checkout / "bin-slices" / "ignore.txt").exists()
+
+
+def test_overlay_missing_dir_is_noop(tmp_path):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    overlay(tmp_path / "nope", checkout, "bin-slices")
+    assert not (checkout / "bin-slices").exists()
+
+
+def test_overlay_none_is_noop(tmp_path):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    overlay(None, checkout, "bin-slices")
+    assert not (checkout / "bin-slices").exists()
+
+
+def test_overlay_overwrites_existing(tmp_path):
+    lookup = tmp_path / "lookup"
+    lookup.mkdir()
+    (lookup / "a.yaml").write_text("package: new\n", encoding="utf-8")
+    checkout = tmp_path / "checkout"
+    (checkout / "bin-slices").mkdir(parents=True)
+    (checkout / "bin-slices" / "a.yaml").write_text("package: old\n", encoding="utf-8")
+    overlay(lookup, checkout, "bin-slices")
+    assert (checkout / "bin-slices" / "a.yaml").read_text() == "package: new\n"

--- a/slice-builder/tests/unit/test_prefer.py
+++ b/slice-builder/tests/unit/test_prefer.py
@@ -1,0 +1,102 @@
+"""Unit tests for prefer.py."""
+
+from slice_builder.prefer import apply_prefer, is_glob, scan_prefer
+from slice_builder.sdf import SDF, Slice
+
+
+def _make_sdf_with_paths(paths) -> SDF:
+    sdf = SDF(package="curl", store="bin", default_track="0.1")
+    sdf.slices["bins"] = Slice(name="bins", contents={p: None for p in paths})
+    return sdf
+
+
+def _write_other(path, package, store, contents):
+    lines = [f"package: {package}"]
+    if store:
+        lines.append(f"store: {store}")
+    lines.append("slices:")
+    lines.append("  bins:")
+    lines.append("    contents:")
+    for p in contents:
+        lines.append(f"      {p}:")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_is_glob_detects_wildcards():
+    assert is_glob("/usr/bin/*")
+    assert is_glob("/usr/lib/**")
+    assert is_glob("/usr/?")
+    assert not is_glob("/usr/bin/curl")
+
+
+def test_scan_prefer_bin_vs_deb_prefers_deb(tmp_checkout):
+    sdf = _make_sdf_with_paths(["/usr/bin/curl"])
+    _write_other(
+        tmp_checkout / "slices" / "libc6.yaml",
+        "libc6",
+        None,
+        ["/usr/bin/curl"],
+    )
+    result = scan_prefer(sdf, tmp_checkout, "bin-", "bin-curl")
+    assert result.prefers == {"/usr/bin/curl": "libc6"}
+    assert result.bin_vs_bin_conflicts == {}
+
+
+def test_scan_prefer_bin_vs_bin_flags_conflict(tmp_checkout):
+    sdf = _make_sdf_with_paths(["/usr/bin/curl"])
+    _write_other(
+        tmp_checkout / "bin-slices" / "other.yaml",
+        "other",
+        "bin",
+        ["/usr/bin/curl"],
+    )
+    result = scan_prefer(sdf, tmp_checkout, "bin-", "bin-curl")
+    assert result.prefers == {}
+    assert "/usr/bin/curl" in result.bin_vs_bin_conflicts
+    assert "bin-other" in result.bin_vs_bin_conflicts["/usr/bin/curl"]
+
+
+def test_scan_prefer_ignores_glob_paths(tmp_checkout):
+    sdf = _make_sdf_with_paths(["/usr/bin/*"])
+    _write_other(
+        tmp_checkout / "slices" / "libc6.yaml",
+        "libc6",
+        None,
+        ["/usr/bin/*"],
+    )
+    result = scan_prefer(sdf, tmp_checkout, "bin-", "bin-curl")
+    assert result.prefers == {}
+
+
+def test_scan_prefer_skips_self(tmp_checkout):
+    sdf = _make_sdf_with_paths(["/usr/bin/curl"])
+    _write_other(
+        tmp_checkout / "bin-slices" / "curl.yaml",
+        "curl",
+        "bin",
+        ["/usr/bin/curl"],
+    )
+    result = scan_prefer(sdf, tmp_checkout, "bin-", "bin-curl")
+    assert result.prefers == {}
+    assert result.bin_vs_bin_conflicts == {}
+
+
+def test_apply_prefer_adds_prefer_to_literal_path():
+    sdf = _make_sdf_with_paths(["/usr/bin/curl", "/usr/bin/*"])
+    from slice_builder.prefer import PreferResult
+
+    result = PreferResult(prefers={"/usr/bin/curl": "libc6"})
+    apply_prefer(sdf, result)
+    assert sdf.slices["bins"].contents["/usr/bin/curl"] == {"prefer": "libc6"}
+    # Glob path untouched.
+    assert sdf.slices["bins"].contents["/usr/bin/*"] is None
+
+
+def test_apply_prefer_preserves_existing_entry():
+    sdf = _make_sdf_with_paths(["/usr/bin/curl"])
+    sdf.slices["bins"].contents["/usr/bin/curl"] = {"mode": 0o755}
+    from slice_builder.prefer import PreferResult
+
+    result = PreferResult(prefers={"/usr/bin/curl": "libc6"})
+    apply_prefer(sdf, result)
+    assert sdf.slices["bins"].contents["/usr/bin/curl"] == {"mode": 0o755, "prefer": "libc6"}

--- a/slice-builder/tests/unit/test_release.py
+++ b/slice-builder/tests/unit/test_release.py
@@ -1,0 +1,57 @@
+"""Unit tests for release.py."""
+
+import pytest
+
+from slice_builder.release import parse_chisel_yaml
+
+
+def test_parse_v3_bin_prefix_and_dir(tmp_checkout):
+    info = parse_chisel_yaml(tmp_checkout)
+    assert info.format == "v3"
+    assert info.bin_prefix == "bin-"
+    assert info.bin_sdf_dir == "bin-slices"
+
+
+def test_parse_v4_uses_slices_dir(tmp_path):
+    (tmp_path / "chisel.yaml").write_text(
+        "format: v4\n"
+        "archives:\n  ubuntu:\n    default: true\n    version: 26.10\n"
+        "    components: [main]\n    suites: [noble]\n    public-keys: [k]\n"
+        "stores:\n  bin:\n    kind: bin\n    version: 26.10\n    default-prefix: 'bin-'\n",
+        encoding="utf-8",
+    )
+    info = parse_chisel_yaml(tmp_path)
+    assert info.format == "v4"
+    assert info.bin_sdf_dir == "slices"
+
+
+def test_parse_missing_file_raises(tmp_path):
+    with pytest.raises(ValueError, match="chisel.yaml not found"):
+        parse_chisel_yaml(tmp_path)
+
+
+def test_parse_missing_bin_store_raises(tmp_path):
+    (tmp_path / "chisel.yaml").write_text(
+        "format: v3\narchives:\n  ubuntu:\n    default: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing stores.bin"):
+        parse_chisel_yaml(tmp_path)
+
+
+def test_parse_bad_format_raises(tmp_path):
+    (tmp_path / "chisel.yaml").write_text(
+        "format: v9\nstores:\n  bin:\n    kind: bin\n    default-prefix: 'bin-'\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unsupported or missing format"):
+        parse_chisel_yaml(tmp_path)
+
+
+def test_parse_missing_prefix_raises(tmp_path):
+    (tmp_path / "chisel.yaml").write_text(
+        "format: v3\nstores:\n  bin:\n    kind: bin\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="default-prefix"):
+        parse_chisel_yaml(tmp_path)

--- a/slice-builder/tests/unit/test_sdf_render.py
+++ b/slice-builder/tests/unit/test_sdf_render.py
@@ -92,3 +92,66 @@ def test_render_sorts_then_dumps():
     sdf.slices["bins"].contents = {"/usr/bin/z": None, "/usr/bin/a": None}
     text = render(sdf)
     assert text.index("/usr/bin/a:") < text.index("/usr/bin/z:")
+
+
+def test_render_matches_canonical_curl_sdf():
+    """Rendered output must be byte-for-byte identical to slices/bins/curl.yaml."""
+
+    # Build an SDF matching the canonical curl.yaml exactly (no slice-level essential).
+    sdf = SDF(
+        package="curl",
+        store="bin",
+        default_track="0.1",
+        essential={"bin-curl_copyright": {}},
+        slices={
+            "bins": Slice(name="bins", contents={"/usr/bin/curl-bin": None}),
+            "copyright": Slice(
+                name="copyright",
+                contents={"/usr/share/doc/curl-bin/copyright": None},
+            ),
+        },
+    )
+    text = render(sdf)
+    expected = (
+        "package: curl\n"
+        "\n"
+        'default-track: "0.1"\n'
+        "\n"
+        "store: bin\n"
+        "\n"
+        "essential:\n"
+        "  bin-curl_copyright:\n"
+        "\n"
+        "slices:\n"
+        "  bins:\n"
+        "    contents:\n"
+        "      /usr/bin/curl-bin:\n"
+        "\n"
+        "  copyright:\n"
+        "    contents:\n"
+        "      /usr/share/doc/curl-bin/copyright:\n"
+    )
+    assert text == expected
+
+
+def test_render_inserts_blank_line_between_slices():
+    """A blank line must separate each slice block under ``slices:``."""
+
+    text = render(_make_sdf())
+    # No blank line right after the ``slices:`` header (first slice follows immediately)...
+    assert "slices:\n  bins:\n" in text
+    # ...but a blank line separates the first and second slice blocks.
+    assert "      /usr/bin/curl-bin:\n\n  copyright:\n" in text
+
+
+def test_render_no_blank_after_slices_header():
+    """The first slice must follow ``slices:`` with no intervening blank line."""
+
+    text = render(_make_sdf())
+    assert "slices:\n\n  bins:" not in text
+
+
+def test_render_ends_with_single_newline_no_trailing_blank():
+    text = render(_make_sdf())
+    assert text.endswith("copyright:\n")
+    assert not text.endswith("\n\n")

--- a/slice-builder/tests/unit/test_sdf_render.py
+++ b/slice-builder/tests/unit/test_sdf_render.py
@@ -1,0 +1,94 @@
+"""Unit tests for sdf.py + render.py."""
+
+import pytest
+import yaml
+
+from slice_builder.render import render, sort_sdf
+from slice_builder.sdf import SDF, Slice, byte_sorted, dump_sdf, parse_sdf
+
+
+def _make_sdf() -> SDF:
+    return SDF(
+        package="curl",
+        store="bin",
+        default_track="0.1",
+        essential={"bin-curl_copyright": {}},
+        slices={
+            "bins": Slice(
+                name="bins",
+                contents={"/usr/bin/curl-bin": None},
+                essential={"libc6_libs": {}},
+            ),
+            "copyright": Slice(
+                name="copyright",
+                contents={"/usr/share/doc/curl-bin/copyright": None},
+            ),
+        },
+    )
+
+
+def test_byte_sorted_matches_utf8_order():
+    items = ["/b", "/a", "/c", "/A"]
+    assert byte_sorted(items) == ["/A", "/a", "/b", "/c"]
+
+
+def test_parse_sdf_roundtrip():
+    text = (
+        "package: curl\nstore: bin\ndefault-track: '0.1'\n"
+        "essential:\n  bin-curl_copyright:\n"
+        "slices:\n  bins:\n    contents:\n      /usr/bin/curl-bin:\n"
+    )
+    sdf = parse_sdf(yaml.safe_load(text))
+    assert sdf.package == "curl"
+    assert sdf.store == "bin"
+    assert sdf.default_track == "0.1"
+    assert "bins" in sdf.slices
+    assert sdf.slices["bins"].contents == {"/usr/bin/curl-bin": None}
+
+
+def test_parse_sdf_missing_required_raises():
+    with pytest.raises(ValueError, match="missing required field"):
+        parse_sdf({"package": "x"})
+
+
+def test_parse_sdf_coerces_v1_list_essential():
+    sdf = parse_sdf({"package": "x", "slices": {}, "essential": ["x_copyright"]})
+    assert sdf.essential == {"x_copyright": {}}
+
+
+def test_dump_sdf_quotes_default_track():
+    text = dump_sdf(_make_sdf())
+    assert 'default-track: "0.1"' in text
+
+
+def test_dump_sdf_null_valued_keys():
+    text = dump_sdf(_make_sdf())
+    # Bare content paths and essential entries render as `key:` (not `key: null`).
+    assert "/usr/bin/curl-bin:" in text
+    assert "bin-curl_copyright:" in text
+    assert "null" not in text
+
+
+def test_dump_sdf_block_style_no_flow():
+    text = dump_sdf(_make_sdf())
+    assert "{" not in text
+    assert "[" not in text
+    assert "---" not in text
+
+
+def test_sort_sdf_byte_orders_contents_and_essential():
+    sdf = _make_sdf()
+    sdf.slices["bins"].contents = {"/usr/bin/z": None, "/usr/bin/a": None}
+    sdf.slices["bins"].essential = {"z_libs": {}, "a_libs": {}}
+    sdf.essential = {"bin-curl_z": {}, "bin-curl_a": {}}
+    sort_sdf(sdf)
+    assert list(sdf.slices["bins"].contents) == ["/usr/bin/a", "/usr/bin/z"]
+    assert list(sdf.slices["bins"].essential) == ["a_libs", "z_libs"]
+    assert list(sdf.essential) == ["bin-curl_a", "bin-curl_z"]
+
+
+def test_render_sorts_then_dumps():
+    sdf = _make_sdf()
+    sdf.slices["bins"].contents = {"/usr/bin/z": None, "/usr/bin/a": None}
+    text = render(sdf)
+    assert text.index("/usr/bin/a:") < text.index("/usr/bin/z:")

--- a/slice-builder/tests/unit/test_validate.py
+++ b/slice-builder/tests/unit/test_validate.py
@@ -1,0 +1,64 @@
+"""Unit tests for validate.py."""
+
+from slice_builder.validate import format_errors, validate
+
+GOOD_SDF = (
+    "package: curl\n"
+    "store: bin\n"
+    'default-track: "0.1"\n'
+    "essential:\n"
+    "  bin-curl_copyright:\n"
+    "slices:\n"
+    "  bins:\n"
+    "    contents:\n"
+    "      /usr/bin/curl-bin:\n"
+    "  copyright:\n"
+    "    contents:\n"
+    "      /usr/share/doc/curl-bin/copyright:\n"
+)
+
+
+def test_validate_good_sdf_passes():
+    result = validate(GOOD_SDF)
+    assert result.ok, result.errors
+
+
+def test_validate_missing_required_field_fails():
+    bad = GOOD_SDF.replace("store: bin\n", "")
+    result = validate(bad)
+    assert not result.ok
+    assert any("store" in e for e in result.errors)
+
+
+def test_validate_unsorted_contents_fails():
+    bad = GOOD_SDF.replace(
+        "      /usr/bin/curl-bin:\n",
+        "      /usr/bin/curl-bin:\n      /usr/bin/a-bin:\n",
+    )
+    result = validate(bad)
+    assert not result.ok
+    assert any("not byte-sorted" in e for e in result.errors)
+
+
+def test_validate_non_absolute_path_fails():
+    bad = GOOD_SDF.replace("/usr/bin/curl-bin:", "relative/path:")
+    result = validate(bad)
+    assert not result.ok
+    assert any("not absolute" in e for e in result.errors)
+
+
+def test_validate_yaml_parse_error_fails():
+    result = validate("package: curl\n  bad: : :")
+    assert not result.ok
+    assert any("parse error" in e or "YAML parse" in e for e in result.errors)
+
+
+def test_format_errors_returns_empty_for_no_errors():
+    assert format_errors([]) == ""
+
+
+def test_format_errors_includes_messages():
+    out = format_errors(["bad thing", "worse thing"])
+    assert "bad thing" in out
+    assert "worse thing" in out
+    assert "Fix these" in out

--- a/slice-builder/tests/unit/test_validate.py
+++ b/slice-builder/tests/unit/test_validate.py
@@ -1,6 +1,6 @@
 """Unit tests for validate.py."""
 
-from slice_builder.validate import format_errors, validate
+from slice_builder.validate import format_errors, validate, validate_semantic
 
 GOOD_SDF = (
     "package: curl\n"
@@ -62,3 +62,105 @@ def test_format_errors_includes_messages():
     assert "bad thing" in out
     assert "worse thing" in out
     assert "Fix these" in out
+
+
+# --- validate_semantic: the agent-loop check (no yamllint, no sort) ---
+
+
+def test_validate_semantic_good_sdf_passes():
+    assert validate_semantic(GOOD_SDF).ok
+
+
+def test_validate_semantic_missing_required_field_fails():
+    bad = GOOD_SDF.replace("store: bin\n", "")
+    result = validate_semantic(bad)
+    assert not result.ok
+    assert any("store" in e for e in result.errors)
+
+
+def test_validate_semantic_non_absolute_path_fails():
+    bad = GOOD_SDF.replace("/usr/bin/curl-bin:", "relative/path:")
+    result = validate_semantic(bad)
+    assert not result.ok
+    assert any("not absolute" in e for e in result.errors)
+
+
+def test_validate_semantic_yaml_parse_error_fails():
+    result = validate_semantic("package: curl\n  bad: : :")
+    assert not result.ok
+    assert any("parse error" in e or "YAML parse" in e for e in result.errors)
+
+
+def test_validate_semantic_ignores_unsorted_contents():
+    """The agent loop must NOT retry for a sort issue render() will fix."""
+    bad = GOOD_SDF.replace(
+        "      /usr/bin/curl-bin:\n",
+        "      /usr/bin/curl-bin:\n      /usr/bin/a-bin:\n",
+    )
+    result = validate_semantic(bad)
+    assert result.ok, result.errors
+
+
+def test_validate_semantic_ignores_yamllint_style_issues():
+    """The agent loop must NOT retry for a style issue render() will fix.
+
+    A document-start marker (---) is a yamllint error but not a semantic one.
+    """
+    bad = "---\n" + GOOD_SDF
+    result = validate_semantic(bad)
+    assert result.ok, result.errors
+
+
+def test_full_validate_still_catches_what_semantic_skips():
+    """The final-pass validate() must still catch sort + yamllint issues."""
+    unsorted = GOOD_SDF.replace(
+        "      /usr/bin/curl-bin:\n",
+        "      /usr/bin/curl-bin:\n      /usr/bin/a-bin:\n",
+    )
+    assert not validate(unsorted).ok
+    assert not validate("---\n" + GOOD_SDF).ok
+
+
+def test_validate_rejects_store_not_bin():
+    bad = GOOD_SDF.replace("store: bin\n", "store: deb\n")
+    result = validate(bad)
+    assert not result.ok
+    assert any("store must be 'bin'" in e for e in result.errors)
+
+
+def test_validate_rejects_empty_store():
+    bad = GOOD_SDF.replace("store: bin\n", "store: ''\n")
+    result = validate(bad)
+    assert not result.ok
+    assert any("store must be 'bin'" in e for e in result.errors)
+
+
+def test_validate_rejects_uppercase_slice_name():
+    bad = GOOD_SDF.replace("  bins:\n", "  Bins:\n")
+    result = validate(bad)
+    assert not result.ok
+    assert any("invalid slice name 'Bins'" in e for e in result.errors)
+
+
+def test_validate_rejects_short_slice_name():
+    bad = GOOD_SDF.replace("  bins:\n", "  ab:\n")
+    result = validate(bad)
+    assert not result.ok
+    assert any("invalid slice name 'ab'" in e for e in result.errors)
+
+
+def test_validate_rejects_digit_leading_slice_name():
+    bad = GOOD_SDF.replace("  bins:\n", "  123:\n")
+    result = validate(bad)
+    assert not result.ok
+    assert any("invalid slice name '123'" in e for e in result.errors)
+
+
+def test_validate_yamllint_stdin_filename_not_leaked():
+    # Trailing spaces trigger a yamllint error; the bare "stdin" filename header must not
+    # appear as a spurious error entry.
+    bad = GOOD_SDF.replace("package: curl\n", "package: curl   \n")
+    result = validate(bad)
+    assert not result.ok
+    assert "stdin" not in result.errors
+    assert any("trailing spaces" in e for e in result.errors)

--- a/slice-builder/uv.lock
+++ b/slice-builder/uv.lock
@@ -1,0 +1,155 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "slice-builder"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "yamllint" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "yamllint", specifier = ">=1.35" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "yamllint"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathspec" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a0/8fc2d68e132cf918f18273fdc8a1b8432b60d75ac12fdae4b0ef5c9d2e8d/yamllint-1.38.0.tar.gz", hash = "sha256:09e5f29531daab93366bb061e76019d5e91691ef0a40328f04c927387d1d364d", size = 142446, upload-time = "2026-01-13T07:47:53.276Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl", hash = "sha256:fc394a5b3be980a4062607b8fdddc0843f4fa394152b6da21722f5d59013c220", size = 68940, upload-time = "2026-01-13T07:47:51.343Z" },
+]

--- a/slice-builder/yamllint.yaml
+++ b/slice-builder/yamllint.yaml
@@ -1,4 +1,34 @@
+# yamllint configurations.
+# Ref: https://yamllint.readthedocs.io/en/stable/configuration.html
+
 extends: default
+
+# Ref: https://yamllint.readthedocs.io/en/stable/rules.html
 rules:
-  document-start: disable
-  line-length: {max: 100}
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  brackets:
+    forbid: false
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  comments:
+    level: error
+  comments-indentation:
+    level: error
+  document-end:
+    present: false
+  document-start:
+    present: false
+    level: error
+  empty-lines:
+    max: 1
+  indentation:
+    spaces: 2
+  line-length:
+    max: 100

--- a/slice-builder/yamllint.yaml
+++ b/slice-builder/yamllint.yaml
@@ -1,0 +1,4 @@
+extends: default
+rules:
+  document-start: disable
+  line-length: {max: 100}


### PR DESCRIPTION
# Proposed changes

Bin packages (.tar.xz from `bincraft pack`) are not Debian debs, so the existing deb-slicing workflow cannot author their Chisel slice definitions, and sd-tools produces them in bulk — hand-authoring does not scale. This adds `slice-builder`, a uv-managed Python CLI that generates one SDF per bin archive by wrapping an `omp` agent guided by an `sdf-generation` skill.

The split of responsibilities is the crux: the agent only makes judgment calls (path→slice classification, picking dependency slices for `essential`), while the builder owns everything deterministic — path-traversal-safe extraction, byte-order sorting, literal-path `prefer` conflict detection, and a custom PyYAML dumper that reproduces the repo's SDF style. Consequently validation is two-pass: the agent is retried only on semantic failures, since style and ordering are re-imposed by `render()` and retrying for them would waste LLM round-trips.

Two things worth knowing for review: the agent is handed the *extracted* archive directory rather than a path list, because file type and content are often needed to classify correctly (a `/usr/lib/` entry may be a shared library, a static archive, or data); and the whole tool is a self-contained `slice-builder/` subtree so it can be lifted to its own repository without rework. Non-determinism is accepted for now — the path table and dep-slice selection are expected to evolve via skill edits rather than code changes.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->