### PR TITLE
feat(26.04): add rsyslog and rsyslog-relp slices

### DIFF
--- a/slices/libestr0.yaml
+++ b/slices/libestr0.yaml
@@ -1,0 +1,16 @@
+package: libestr0
+
+essential:
+  libestr0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libestr.so.0:
+      /usr/lib/*-linux-*/libestr.so.0.0.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libestr0/copyright:

--- a/slices/libfastjson4.yaml
+++ b/slices/libfastjson4.yaml
@@ -1,0 +1,16 @@
+package: libfastjson4
+
+essential:
+  libfastjson4_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libfastjson.so.4:
+      /usr/lib/*-linux-*/libfastjson.so.4.3.0:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfastjson4/copyright:

--- a/slices/librelp0.yaml
+++ b/slices/librelp0.yaml
@@ -1,0 +1,18 @@
+package: librelp0
+
+essential:
+  librelp0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libgnutls30t64_libs:
+      libssl3t64_libs:
+    contents:
+      /usr/lib/*-linux-*/librelp.so.0:
+      /usr/lib/*-linux-*/librelp.so.0.5.1:
+
+  copyright:
+    contents:
+      /usr/share/doc/librelp0/copyright:

--- a/slices/rsyslog-relp.yaml
+++ b/slices/rsyslog-relp.yaml
@@ -1,0 +1,17 @@
+package: rsyslog-relp
+
+essential:
+  rsyslog-relp_copyright:
+
+slices:
+  modules:
+    essential:
+      libc6_libs:
+      librelp0_libs:
+    contents:
+      /usr/lib/*-linux-*/rsyslog/imrelp.so:
+      /usr/lib/*-linux-*/rsyslog/omrelp.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/rsyslog-relp/copyright:

--- a/slices/rsyslog.yaml
+++ b/slices/rsyslog.yaml
@@ -1,0 +1,84 @@
+package: rsyslog
+
+essential:
+  rsyslog_copyright:
+
+slices:
+  bins:
+    essential:
+      libc6_libs:
+      libestr0_libs:
+      libfastjson4_libs:
+      libsystemd0_libs:
+      libuuid1_libs:
+      rsyslog_config:
+      rsyslog_modules:
+      zlib1g_libs:
+    contents:
+      /usr/sbin/rsyslogd:
+
+  data:
+    contents:
+      /var/spool/rsyslog/:
+
+  config:
+    essential:
+      rsyslog_modules:
+    contents:
+      /etc/logcheck/ignore.d.server/rsyslog:
+      /etc/logrotate.d/rsyslog:
+      /etc/rsyslog.conf:
+      /etc/rsyslog.d/50-default.conf:
+        copy: /usr/share/rsyslog/50-default.conf
+      /etc/systemd/system/multi-user.target.wants/rsyslog.service:
+        symlink: /usr/lib/systemd/system/rsyslog.service
+
+  modules:
+    essential:
+      libc6_libs:
+      libfastjson4_libs:
+      libsystemd0_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/lib/*-linux-*/rsyslog/fmhash.so:
+      /usr/lib/*-linux-*/rsyslog/imfile.so:
+      /usr/lib/*-linux-*/rsyslog/imjournal.so:
+      /usr/lib/*-linux-*/rsyslog/imklog.so:
+      /usr/lib/*-linux-*/rsyslog/imkmsg.so:
+      /usr/lib/*-linux-*/rsyslog/immark.so:
+      /usr/lib/*-linux-*/rsyslog/impstats.so:
+      /usr/lib/*-linux-*/rsyslog/imptcp.so:
+      /usr/lib/*-linux-*/rsyslog/imtcp.so:
+      /usr/lib/*-linux-*/rsyslog/imudp.so:
+      /usr/lib/*-linux-*/rsyslog/imuxsock.so:
+      /usr/lib/*-linux-*/rsyslog/lmnet.so:
+      /usr/lib/*-linux-*/rsyslog/lmnetstrms.so:
+      /usr/lib/*-linux-*/rsyslog/lmnsd_ptcp.so:
+      /usr/lib/*-linux-*/rsyslog/lmregexp.so:
+      /usr/lib/*-linux-*/rsyslog/lmtcpclt.so:
+      /usr/lib/*-linux-*/rsyslog/lmtcpsrv.so:
+      /usr/lib/*-linux-*/rsyslog/lmzlibw.so:
+      /usr/lib/*-linux-*/rsyslog/lmzstdw.so:
+      /usr/lib/*-linux-*/rsyslog/mmanon.so:
+      /usr/lib/*-linux-*/rsyslog/mmexternal.so:
+      /usr/lib/*-linux-*/rsyslog/mmfields.so:
+      /usr/lib/*-linux-*/rsyslog/mmjsonparse.so:
+      /usr/lib/*-linux-*/rsyslog/mmleefparse.so:
+      /usr/lib/*-linux-*/rsyslog/mmpstrucdata.so:
+      /usr/lib/*-linux-*/rsyslog/mmrm1stspace.so:
+      /usr/lib/*-linux-*/rsyslog/mmsequence.so:
+      /usr/lib/*-linux-*/rsyslog/mmutf8fix.so:
+      /usr/lib/*-linux-*/rsyslog/omjournal.so:
+      /usr/lib/*-linux-*/rsyslog/ommail.so:
+      /usr/lib/*-linux-*/rsyslog/omprog.so:
+      /usr/lib/*-linux-*/rsyslog/omuxsock.so:
+      /usr/lib/*-linux-*/rsyslog/pmaixforwardedfrom.so:
+      /usr/lib/*-linux-*/rsyslog/pmciscoios.so:
+      /usr/lib/*-linux-*/rsyslog/pmcisconames.so:
+      /usr/lib/*-linux-*/rsyslog/pmlastmsg.so:
+      /usr/lib/*-linux-*/rsyslog/pmsnare.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/rsyslog/copyright:

--- a/tests/spread/integration/libestr0/task.yaml
+++ b/tests/spread/integration/libestr0/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libestr0
+
+execute: |
+  rootfs="$(install-slices libestr0_libs)"
+
+  for f in "${rootfs}"/usr/lib/*/libestr.so.0 "${rootfs}"/usr/lib/*/libestr.so.0.0.0; do
+    test -f "$f"
+    head -c4 "$f" | grep -Fiq "ELF"
+  done

--- a/tests/spread/integration/libfastjson4/task.yaml
+++ b/tests/spread/integration/libfastjson4/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for libfastjson4
+
+execute: |
+  rootfs="$(install-slices libfastjson4_libs)"
+
+  for f in "${rootfs}"/usr/lib/*/libfastjson.so.4 "${rootfs}"/usr/lib/*/libfastjson.so.4.3.0; do
+    test -f "$f"
+    head -c4 "$f" | grep -Fiq "ELF"
+  done

--- a/tests/spread/integration/librelp0/task.yaml
+++ b/tests/spread/integration/librelp0/task.yaml
@@ -1,0 +1,9 @@
+summary: Integration tests for librelp0
+
+execute: |
+  rootfs="$(install-slices librelp0_libs)"
+
+  for f in "${rootfs}"/usr/lib/*/librelp.so.0 "${rootfs}"/usr/lib/*/librelp.so.0.5.1; do
+    test -f "$f"
+    head -c4 "$f" | grep -Fiq "ELF"
+  done

--- a/tests/spread/integration/rsyslog-relp/relp.conf
+++ b/tests/spread/integration/rsyslog-relp/relp.conf
@@ -1,0 +1,25 @@
+# A message enters on a plain TCP listener, leaves through omrelp, comes back
+# in through imrelp and is written to a file. That puts both modules this
+# package ships on the path of a single message, inside one rsyslogd.
+
+module(load="imptcp")
+module(load="imrelp")
+module(load="omrelp")
+
+input(type="imptcp" port="10515" ruleset="relp-send")
+input(type="imrelp" port="10514" ruleset="relp-receive")
+
+# %rawmsg% keeps the message verbatim, so the marker the test greps for cannot
+# be split up by the syslog parser.
+template(name="relp-raw" type="string" string="%rawmsg%\n")
+
+ruleset(name="relp-send") {
+    # Both listeners come up at about the same time, so the first connect may
+    # still lose the race. Retry every second instead of the default 30.
+    action(type="omrelp" target="127.0.0.1" port="10514"
+           action.resumeInterval="1" action.resumeRetryCount="-1")
+}
+
+ruleset(name="relp-receive") {
+    action(type="omfile" file="/tmp/rsyslog-relp-test.log" template="relp-raw")
+}

--- a/tests/spread/integration/rsyslog-relp/task.yaml
+++ b/tests/spread/integration/rsyslog-relp/task.yaml
@@ -1,56 +1,39 @@
 summary: Integration tests for rsyslog-relp
 
 execute: |
-  # Start rsyslogd with imrelp listening on a TCP port, send a log message 
-  # via the RELP protocol, and verify it is written to a log file.
-  rootfs="$(install-slices rsyslog_bins rsyslog_data base-passwd_data rsyslog-relp_modules)"
+  # imrelp.so and omrelp.so are dlopen'ed by rsyslogd, so the only meaningful
+  # check is a message actually travelling over RELP. relp.conf wires a plain
+  # TCP listener to omrelp and imrelp to a file, both in one rsyslogd.
+  rootfs="$(install-slices base-files_tmp rsyslog-relp_modules rsyslog_bins)"
 
-  # Create syslog user/group (normally done by postinst via adduser)
-  echo "syslog:x:100:101::/nonexistent:/usr/sbin/nologin" >> "${rootfs}/etc/passwd"
-  echo "syslog:x:101:" >> "${rootfs}/etc/group"
+  logfile="${rootfs}/tmp/rsyslog-relp-test.log"
+  cp relp.conf "${rootfs}/tmp/relp.conf"
 
-  # Set up /var/log permissions (normally done by postinst)
-  chgrp syslog "${rootfs}/var/log"
-  chmod g+w "${rootfs}/var/log"
-
-  # Bind-mount host /dev so rsyslogd has /dev/null
+  # rsyslogd points its standard streams at /dev/null when it daemonises
   mkdir -p "${rootfs}/dev"
   mount --bind /dev "${rootfs}/dev"
-  trap "pkill -x rsyslogd; umount ${rootfs}/dev || true" EXIT
+  trap 'pkill -x rsyslogd || true; umount "${rootfs}/dev" || true' EXIT
 
-  # Config: load imrelp, listen on port 10514, write all messages to a file
-  cat >"${rootfs}/tmp/test-relp.conf" <<'CONF'
-module(load="imrelp")
-input(type="imrelp" port="10514")
-$PrivDropToUser root
-$PrivDropToGroup root
-$WorkDirectory /var/spool/rsyslog
-*.* /tmp/rsyslog-relp-test.log
-CONF
+  chroot "${rootfs}" /usr/sbin/rsyslogd -iNONE -f /tmp/relp.conf
 
-  # Start daemon
-  chroot "$rootfs" /usr/sbin/rsyslogd -iNONE -f /tmp/test-relp.conf
-  sleep 1
+  # chroot does not isolate the network, so the listener shows up on the host.
+  # The retried write doubles as the readiness probe: it fails until imptcp
+  # binds the port. A complete RFC 3164 header keeps the parser from having to
+  # guess where the hostname ends and the tag begins.
+  for _ in $(seq 30); do
+    if printf '<34>Jan  1 00:00:00 chisel-host relp-test: hello-over-relp\n' \
+        2>/dev/null >/dev/tcp/127.0.0.1/10515; then
+      break
+    fi
+    sleep 1
+  done
 
-  # Send a log message via the RELP protocol using Python.
-  # RELP frame format: "<txnr> <command> <datalen> <data>\n"
-  python3 -c "
-import socket, time
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(3)
-s.connect(('127.0.0.1', 10514))
-# RELP open
-s.sendall(b'1 open 6 relp1\n')
-time.sleep(0.5)
-# RELP syslog
-msg = '<34>chisel-relp: hello from chisel\n'
-frame = '2 syslog ' + str(len(msg)) + ' ' + msg
-s.sendall(frame.encode())
-time.sleep(1)
-s.close()
-"
-  sleep 1
-  pkill -x rsyslogd
+  # omrelp opens the RELP session and delivers off the main thread
+  for _ in $(seq 60); do
+    if [ -s "$logfile" ]; then
+      break
+    fi
+    sleep 1
+  done
 
-  # Verify the message was logged
-  grep -Fq "chisel-relp: hello from chisel" "${rootfs}/tmp/rsyslog-relp-test.log"
+  grep -Fq "hello-over-relp" "$logfile"

--- a/tests/spread/integration/rsyslog-relp/task.yaml
+++ b/tests/spread/integration/rsyslog-relp/task.yaml
@@ -1,0 +1,56 @@
+summary: Integration tests for rsyslog-relp
+
+execute: |
+  # Start rsyslogd with imrelp listening on a TCP port, send a log message 
+  # via the RELP protocol, and verify it is written to a log file.
+  rootfs="$(install-slices rsyslog_bins rsyslog_data base-passwd_data rsyslog-relp_modules)"
+
+  # Create syslog user/group (normally done by postinst via adduser)
+  echo "syslog:x:100:101::/nonexistent:/usr/sbin/nologin" >> "${rootfs}/etc/passwd"
+  echo "syslog:x:101:" >> "${rootfs}/etc/group"
+
+  # Set up /var/log permissions (normally done by postinst)
+  chgrp syslog "${rootfs}/var/log"
+  chmod g+w "${rootfs}/var/log"
+
+  # Bind-mount host /dev so rsyslogd has /dev/null
+  mkdir -p "${rootfs}/dev"
+  mount --bind /dev "${rootfs}/dev"
+  trap "pkill -x rsyslogd; umount ${rootfs}/dev || true" EXIT
+
+  # Config: load imrelp, listen on port 10514, write all messages to a file
+  cat >"${rootfs}/tmp/test-relp.conf" <<'CONF'
+module(load="imrelp")
+input(type="imrelp" port="10514")
+$PrivDropToUser root
+$PrivDropToGroup root
+$WorkDirectory /var/spool/rsyslog
+*.* /tmp/rsyslog-relp-test.log
+CONF
+
+  # Start daemon
+  chroot "$rootfs" /usr/sbin/rsyslogd -iNONE -f /tmp/test-relp.conf
+  sleep 1
+
+  # Send a log message via the RELP protocol using Python.
+  # RELP frame format: "<txnr> <command> <datalen> <data>\n"
+  python3 -c "
+import socket, time
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(3)
+s.connect(('127.0.0.1', 10514))
+# RELP open
+s.sendall(b'1 open 6 relp1\n')
+time.sleep(0.5)
+# RELP syslog
+msg = '<34>chisel-relp: hello from chisel\n'
+frame = '2 syslog ' + str(len(msg)) + ' ' + msg
+s.sendall(frame.encode())
+time.sleep(1)
+s.close()
+"
+  sleep 1
+  pkill -x rsyslogd
+
+  # Verify the message was logged
+  grep -Fq "chisel-relp: hello from chisel" "${rootfs}/tmp/rsyslog-relp-test.log"

--- a/tests/spread/integration/rsyslog/task.yaml
+++ b/tests/spread/integration/rsyslog/task.yaml
@@ -1,0 +1,32 @@
+summary: Integration tests for rsyslog
+
+execute: |
+
+  # rsyslog daemon: start with the default config, send a log message via
+  # /dev/log, and verify it is written to /var/log/syslog.
+  rootfs="$(install-slices rsyslog_bins rsyslog_data base-passwd_data)"
+
+  # Create syslog user/group (normally done by postinst via adduser)
+  echo "syslog:x:100:101::/nonexistent:/usr/sbin/nologin" >> "${rootfs}/etc/passwd"
+  echo "syslog:x:101:" >> "${rootfs}/etc/group"
+
+  # Set up /var/log permissions (normally done by postinst)
+  chgrp syslog "${rootfs}/var/log"
+  chmod g+w "${rootfs}/var/log"
+
+  # Bind-mount host /dev so rsyslogd has /dev/null and can create /dev/log
+  mkdir -p "${rootfs}/dev"
+  mount --bind /dev "${rootfs}/dev"
+  trap "pkill -x rsyslogd; umount ${rootfs}/dev || true" EXIT
+
+  # Start daemon with the default config
+  chroot "$rootfs" /usr/sbin/rsyslogd -iNONE
+  sleep 1
+
+  # Send a syslog message via the /dev/log Unix socket
+  logger -u "${rootfs}/dev/log" "chisel-test: hello from chisel"
+  sleep 1
+  pkill -x rsyslogd
+
+  # Verify the message was logged
+  grep -Fq "chisel-test: hello from chisel" "${rootfs}/var/log/syslog"

--- a/tests/spread/integration/rsyslog/task.yaml
+++ b/tests/spread/integration/rsyslog/task.yaml
@@ -1,32 +1,44 @@
 summary: Integration tests for rsyslog
 
 execute: |
+  rootfs="$(install-slices base-files_tmp base-passwd_data rsyslog_bins rsyslog_data)"
 
-  # rsyslog daemon: start with the default config, send a log message via
-  # /dev/log, and verify it is written to /var/log/syslog.
-  rootfs="$(install-slices rsyslog_bins rsyslog_data base-passwd_data)"
+  chroot "${rootfs}" /usr/sbin/rsyslogd -v | grep -q "^rsyslogd"
 
-  # Create syslog user/group (normally done by postinst via adduser)
+  # /etc/rsyslog.conf drops privileges to syslog:syslog and creates its files
+  # as syslog:adm. adduser gives the package that account from postinst, which
+  # a chiselled rootfs never runs.
   echo "syslog:x:100:101::/nonexistent:/usr/sbin/nologin" >> "${rootfs}/etc/passwd"
   echo "syslog:x:101:" >> "${rootfs}/etc/group"
 
-  # Set up /var/log permissions (normally done by postinst)
-  chgrp syslog "${rootfs}/var/log"
-  chmod g+w "${rootfs}/var/log"
-
-  # Bind-mount host /dev so rsyslogd has /dev/null and can create /dev/log
+  # rsyslogd points its standard streams at /dev/null when it daemonises
   mkdir -p "${rootfs}/dev"
   mount --bind /dev "${rootfs}/dev"
-  trap "pkill -x rsyslogd; umount ${rootfs}/dev || true" EXIT
+  trap 'pkill -x rsyslogd || true; umount "${rootfs}/dev" || true' EXIT
 
-  # Start daemon with the default config
-  chroot "$rootfs" /usr/sbin/rsyslogd -iNONE
-  sleep 1
+  # The shipped configuration, /etc/rsyslog.d/50-default.conf included, has to
+  # be loadable: a validation run dlopen's every module it pulls in and rejects
+  # a $WorkDirectory or a privilege drop target that is not there.
+  chroot "${rootfs}" /usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf
 
-  # Send a syslog message via the /dev/log Unix socket
-  logger -u "${rootfs}/dev/log" "chisel-test: hello from chisel"
-  sleep 1
-  pkill -x rsyslogd
+  # A message has to survive the trip from a Unix socket to a log file.
+  cp test.conf "${rootfs}/tmp/test.conf"
+  chroot "${rootfs}" /usr/sbin/rsyslogd -iNONE -f /tmp/test.conf
 
-  # Verify the message was logged
-  grep -Fq "chisel-test: hello from chisel" "${rootfs}/var/log/syslog"
+  for _ in $(seq 30); do
+    if [ -S "${rootfs}/tmp/rsyslog-test.sock" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  logger --socket "${rootfs}/tmp/rsyslog-test.sock" "hello-from-chisel"
+
+  for _ in $(seq 30); do
+    if [ -s "${rootfs}/tmp/rsyslog-test.log" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  grep -Fq "hello-from-chisel" "${rootfs}/tmp/rsyslog-test.log"

--- a/tests/spread/integration/rsyslog/test.conf
+++ b/tests/spread/integration/rsyslog/test.conf
@@ -1,0 +1,8 @@
+# imuxsock reads from a socket of our own instead of /dev/log: one LXD
+# instance serves every spread task of a run, and rsyslogd unlinks whatever
+# sits at the system socket path before binding it.
+
+module(load="imuxsock" SysSock.Use="off")
+input(type="imuxsock" Socket="/tmp/rsyslog-test.sock")
+
+*.* action(type="omfile" file="/tmp/rsyslog-test.log")


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `rsyslog`, `rsyslog-relp`, and their dependency chain on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `libestr0` | `libs`, `copyright` | Leaf library; rsyslog dependency |
| `libfastjson4` | `libs`, `copyright` | Leaf library; rsyslog dependency |
| `librelp0` | `libs`, `copyright` | RELP protocol library; rsyslog-relp dependency |
| `rsyslog` | `bins`, `modules`, `config`, `data`, `copyright` | Daemon + 37 loadable dlopen modules |
| `rsyslog-relp` | `modules`, `copyright` | `imrelp.so` / `omrelp.so` RELP modules |

### Forward porting
#1105

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
