### PR TITLE
feat(26.04): add libboost-serialization1.83.0 slices

### DIFF
--- a/slices/libboost-serialization1.83.0.yaml
+++ b/slices/libboost-serialization1.83.0.yaml
@@ -1,0 +1,17 @@
+package: libboost-serialization1.83.0
+
+essential:
+  libboost-serialization1.83.0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libgcc-s1_libs:
+      libstdc++6_libs:
+    contents:
+      /usr/lib/*-linux-*/libboost_serialization.so.1.83.0:
+      /usr/lib/*-linux-*/libboost_wserialization.so.1.83.0:
+  copyright:
+    contents:
+      /usr/share/doc/libboost-serialization1.83.0/copyright:

--- a/tests/spread/integration/libboost-serialization1.83.0/task.yaml
+++ b/tests/spread/integration/libboost-serialization1.83.0/task.yaml
@@ -1,0 +1,18 @@
+summary: Integration tests for libboost-serialization1.83.0
+
+execute: |
+  rootfs="$(install-slices libboost-serialization1.83.0_libs)"
+
+  apt install --update -y gcc
+  arch=$(gcc -dumpmachine)
+
+  libdir="${rootfs}/usr/lib/${arch}"
+  ser="${libdir}/libboost_serialization.so.1.83.0"
+  wser="${libdir}/libboost_wserialization.so.1.83.0"
+
+  test -f "$ser"
+  test -f "$wser"
+
+  # Verify the shared objects are valid ELF binaries.
+  [[ "$(od -An -tx1 -N4 "$ser")" == *"7f 45 4c 46"* ]]
+  [[ "$(od -An -tx1 -N4 "$wser")" == *"7f 45 4c 46"* ]]


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `libboost-serialization1.83.0` on `ubuntu-26.04`. This package provides the Boost.Serialization runtime shared libraries.

### Forward porting

#1107 

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)
