### PR TITLE
feat(26.04): add rsyslog-relp and dependency slices

### DIFF
--- a/slices/libestr0.yaml
+++ b/slices/libestr0.yaml
@@ -1,0 +1,15 @@
+package: libestr0
+
+essential:
+  libestr0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libestr.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libestr0/copyright:

--- a/slices/libfastjson4.yaml
+++ b/slices/libfastjson4.yaml
@@ -1,0 +1,15 @@
+package: libfastjson4
+
+essential:
+  libfastjson4_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libfastjson.so.4*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfastjson4/copyright:

--- a/slices/librelp0.yaml
+++ b/slices/librelp0.yaml
@@ -1,0 +1,17 @@
+package: librelp0
+
+essential:
+  librelp0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libgnutls30t64_libs:
+      libssl3t64_libs:
+    contents:
+      /usr/lib/*-linux-*/librelp.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/librelp0/copyright:

--- a/slices/rsyslog-relp.yaml
+++ b/slices/rsyslog-relp.yaml
@@ -1,0 +1,18 @@
+package: rsyslog-relp
+
+essential:
+  rsyslog-relp_copyright:
+
+slices:
+  modules:
+    essential:
+      libc6_libs:
+      librelp0_libs:
+      rsyslog_bins:
+    contents:
+      /usr/lib/*-linux-*/rsyslog/imrelp.so:
+      /usr/lib/*-linux-*/rsyslog/omrelp.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/rsyslog-relp/copyright:

--- a/slices/rsyslog.yaml
+++ b/slices/rsyslog.yaml
@@ -1,0 +1,82 @@
+package: rsyslog
+
+essential:
+  rsyslog_copyright:
+
+slices:
+  bins:
+    essential:
+      libc6_libs:
+      libestr0_libs:
+      libfastjson4_libs:
+      libsystemd0_libs:
+      libuuid1_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/sbin/rsyslogd:
+
+  modules:
+    essential:
+      rsyslog_bins:
+    contents:
+      /usr/lib/*-linux-*/rsyslog/fmhash.so:
+      /usr/lib/*-linux-*/rsyslog/imfile.so:
+      /usr/lib/*-linux-*/rsyslog/imjournal.so:
+      /usr/lib/*-linux-*/rsyslog/imklog.so:
+      /usr/lib/*-linux-*/rsyslog/imkmsg.so:
+      /usr/lib/*-linux-*/rsyslog/immark.so:
+      /usr/lib/*-linux-*/rsyslog/impstats.so:
+      /usr/lib/*-linux-*/rsyslog/imptcp.so:
+      /usr/lib/*-linux-*/rsyslog/imtcp.so:
+      /usr/lib/*-linux-*/rsyslog/imudp.so:
+      /usr/lib/*-linux-*/rsyslog/imuxsock.so:
+      /usr/lib/*-linux-*/rsyslog/lmnet.so:
+      /usr/lib/*-linux-*/rsyslog/lmnetstrms.so:
+      /usr/lib/*-linux-*/rsyslog/lmnsd_ptcp.so:
+      /usr/lib/*-linux-*/rsyslog/lmregexp.so:
+      /usr/lib/*-linux-*/rsyslog/lmtcpclt.so:
+      /usr/lib/*-linux-*/rsyslog/lmtcpsrv.so:
+      /usr/lib/*-linux-*/rsyslog/lmzlibw.so:
+      /usr/lib/*-linux-*/rsyslog/lmzstdw.so:
+      /usr/lib/*-linux-*/rsyslog/mmanon.so:
+      /usr/lib/*-linux-*/rsyslog/mmexternal.so:
+      /usr/lib/*-linux-*/rsyslog/mmfields.so:
+      /usr/lib/*-linux-*/rsyslog/mmjsonparse.so:
+      /usr/lib/*-linux-*/rsyslog/mmleefparse.so:
+      /usr/lib/*-linux-*/rsyslog/mmpstrucdata.so:
+      /usr/lib/*-linux-*/rsyslog/mmrm1stspace.so:
+      /usr/lib/*-linux-*/rsyslog/mmsequence.so:
+      /usr/lib/*-linux-*/rsyslog/mmutf8fix.so:
+      /usr/lib/*-linux-*/rsyslog/omjournal.so:
+      /usr/lib/*-linux-*/rsyslog/ommail.so:
+      /usr/lib/*-linux-*/rsyslog/omprog.so:
+      /usr/lib/*-linux-*/rsyslog/omuxsock.so:
+      /usr/lib/*-linux-*/rsyslog/pmaixforwardedfrom.so:
+      /usr/lib/*-linux-*/rsyslog/pmciscoios.so:
+      /usr/lib/*-linux-*/rsyslog/pmcisconames.so:
+      /usr/lib/*-linux-*/rsyslog/pmlastmsg.so:
+      /usr/lib/*-linux-*/rsyslog/pmsnare.so:
+
+  config:
+    contents:
+      /etc/rsyslog.conf:
+      /etc/rsyslog.d/50-default.conf:
+        copy: /usr/share/rsyslog/50-default.conf
+
+  var:
+    essential:
+      base-passwd_data:
+    contents:
+      /var/spool/rsyslog/: {make: true, mode: 0700}
+    mutate: |
+      pw = content.read("/etc/passwd")
+      if "syslog:" not in pw:
+          content.write("/etc/passwd", pw + "syslog:x:100:101::/nonexistent:/usr/sbin/nologin\n")
+      gr = content.read("/etc/group")
+      if "syslog:" not in gr:
+          content.write("/etc/group", gr + "syslog:x:101:\n")
+
+  copyright:
+    contents:
+      /usr/share/doc/rsyslog/copyright:

--- a/tests/spread/integration/libestr0/task.yaml
+++ b/tests/spread/integration/libestr0/task.yaml
@@ -1,0 +1,11 @@
+summary: Integration tests for libestr0
+
+execute: |
+  # libestr0_libs: pure library consumed by rsyslog. Verify the shared object is
+  # valid ELF and that rsyslogd (which links against libestr) starts.
+  rootfs="$(install-slices libestr0_libs rsyslog_bins rsyslog_config rsyslog_var)"
+  sofile="$(find "$rootfs/usr/lib" -name 'libestr.so.*' -type f | head -1)"
+  test -n "$sofile"
+  test "$(head -c4 "$sofile" | od -An -tx1 | tr -d ' \n')" = "7f454c46"
+  mkdir -p "$rootfs/dev" && mknod "$rootfs/dev/null" c 1 3
+  chroot "$rootfs" rsyslogd -N1 -iNONE 2>&1 | grep -Fq "End of config validation run"

--- a/tests/spread/integration/libfastjson4/task.yaml
+++ b/tests/spread/integration/libfastjson4/task.yaml
@@ -1,0 +1,11 @@
+summary: Integration tests for libfastjson4
+
+execute: |
+  # libfastjson4_libs: pure library consumed by rsyslog. Verify the shared object
+  # is valid ELF and that rsyslogd (which links against libfastjson) starts.
+  rootfs="$(install-slices libfastjson4_libs rsyslog_bins rsyslog_config rsyslog_var)"
+  sofile="$(find "$rootfs/usr/lib" -name 'libfastjson.so.*' -type f | head -1)"
+  test -n "$sofile"
+  test "$(head -c4 "$sofile" | od -An -tx1 | tr -d ' \n')" = "7f454c46"
+  mkdir -p "$rootfs/dev" && mknod "$rootfs/dev/null" c 1 3
+  chroot "$rootfs" rsyslogd -N1 -iNONE 2>&1 | grep -Fq "End of config validation run"

--- a/tests/spread/integration/librelp0/task.yaml
+++ b/tests/spread/integration/librelp0/task.yaml
@@ -1,0 +1,13 @@
+summary: Integration tests for librelp0
+
+execute: |
+  # librelp0_libs: pure library consumed by rsyslog-relp. Verify the shared
+  # object is valid ELF and that the imrelp module (which links against librelp)
+  # can be loaded by rsyslogd.
+  rootfs="$(install-slices librelp0_libs rsyslog-relp_modules rsyslog_config rsyslog_var)"
+  sofile="$(find "$rootfs/usr/lib" -name 'librelp.so.*' -type f | head -1)"
+  test -n "$sofile"
+  test "$(head -c4 "$sofile" | od -An -tx1 | tr -d ' \n')" = "7f454c46"
+  mkdir -p "$rootfs/dev" && mknod "$rootfs/dev/null" c 1 3
+  printf 'module(load="imrelp")\n' > "$rootfs/etc/rsyslog.d/test-relp.conf"
+  chroot "$rootfs" rsyslogd -N1 -iNONE 2>&1 | grep -Fq "End of config validation run"

--- a/tests/spread/integration/rsyslog-relp/task.yaml
+++ b/tests/spread/integration/rsyslog-relp/task.yaml
@@ -1,0 +1,14 @@
+summary: Integration tests for rsyslog-relp
+
+execute: |
+  # rsyslog-relp_modules: verify the RELP modules are valid ELF and loadable
+  # by rsyslogd.  rsyslog-relp_modules pulls in rsyslog_bins and librelp0_libs
+  # via essential; rsyslog_config + rsyslog_var complete the runtime set.
+  rootfs="$(install-slices rsyslog-relp_modules rsyslog_config rsyslog_var)"
+  for so in "$rootfs"/usr/lib/*/rsyslog/*relp.so; do
+      test "$(head -c4 "$so" | od -An -tx1 | tr -d ' \n')" = "7f454c46"
+  done
+  mkdir -p "$rootfs/dev" && mknod "$rootfs/dev/null" c 1 3
+  printf 'module(load="imrelp")\ninput(type="imrelp" port="10514")\n' \
+      > "$rootfs/etc/rsyslog.d/test-relp.conf"
+  chroot "$rootfs" rsyslogd -N1 -iNONE 2>&1 | grep -Fq "End of config validation run"

--- a/tests/spread/integration/rsyslog/task.yaml
+++ b/tests/spread/integration/rsyslog/task.yaml
@@ -1,0 +1,27 @@
+summary: Integration tests for rsyslog
+
+execute: |
+  # rsyslog_bins: verify the daemon binary runs and reports its version.
+  rootfs="$(install-slices rsyslog_bins rsyslog_config rsyslog_var)"
+  mkdir -p "$rootfs/dev" && mknod "$rootfs/dev/null" c 1 3
+  chroot "$rootfs" rsyslogd -v 2>&1 | grep -Fq "rsyslogd"
+  chroot "$rootfs" rsyslogd -N1 -iNONE 2>&1 | grep -Fq "End of config validation run"
+
+  # rsyslog_modules: verify all shipped modules are valid ELF and loadable.
+  rootfs="$(install-slices rsyslog_modules rsyslog_config rsyslog_var)"
+  for so in "$rootfs"/usr/lib/*/rsyslog/*.so; do
+      test "$(head -c4 "$so" | od -An -tx1 | tr -d ' \n')" = "7f454c46"
+  done
+  mkdir -p "$rootfs/dev" && mknod "$rootfs/dev/null" c 1 3
+  chroot "$rootfs" rsyslogd -N1 -iNONE 2>&1 | grep -Fq "End of config validation run"
+
+  # rsyslog_config: verify config files are present.
+  rootfs="$(install-slices rsyslog_config)"
+  test -f "$rootfs/etc/rsyslog.conf"
+  test -f "$rootfs/etc/rsyslog.d/50-default.conf"
+
+  # rsyslog_var: verify syslog user/group and spool directory.
+  rootfs="$(install-slices rsyslog_var)"
+  grep -Fq "syslog:" "$rootfs/etc/passwd"
+  grep -Fq "syslog:" "$rootfs/etc/group"
+  test -d "$rootfs/var/spool/rsyslog"


### PR DESCRIPTION
## Summary

Add slice definitions for `rsyslog-relp` and its full dependency chain on `ubuntu-26.04`.

### Packages added (bottom-up)

| Package | Slices | Notes |
|---------|--------|-------|
| `libestr0` | `libs`, `copyright` | Leaf library; consumed by rsyslog |
| `libfastjson4` | `libs`, `copyright` | Leaf library; consumed by rsyslog |
| `librelp0` | `libs`, `copyright` | RELP protocol library; consumed by rsyslog-relp |
| `rsyslog` | `bins`, `modules`, `config`, `var`, `copyright` | Daemon + 37 loadable modules; `var` slice uses a `mutate` script to create the `syslog` user/group (normally done by postinst via `adduser`) |
| `rsyslog-relp` | `modules`, `copyright` | `imrelp.so` / `omrelp.so` RELP modules |

### Design decisions

- **`adduser` / `ucf` not sliced**: they are install-time tools (postinst), not runtime dependencies — `rsyslogd` does not link or call them at runtime. The `syslog` user is instead created via a `mutate:` script in `rsyslog_var` (depends on `base-passwd_data`, which runs its mutate first per chisel's dependency-ordered mutation).
- **rsyslog modules listed explicitly** (not globbed) to avoid a cross-package path-conflict with `rsyslog-relp_modules` in the same `/usr/lib/*-linux-*/rsyslog/` directory.
- **Config reproduced from postinst**: `/etc/rsyslog.d/50-default.conf` is created via `copy:` from the deb's `/usr/share/rsyslog/50-default.conf` (postinst normally uses `ucf`).
- **Dropped auxiliary configs**: logrotate/logcheck configs dropped (those tools aren't sliced); apparmor/services/scripts/tmpfiles omitted for a minimal, cron-style slice set — can be added in follow-ups.
- **Format v3**: all `essential:` entries use the map form.

### Verification

- `check-slice.py`: all 5 SDFs clean (format v3)
- `check-diff.py`: no append-only regressions
- `check-test.py`: rsyslog binaries all exercised; library/module packages have no `bins` (info only)
- `chisel cut` (Layer 1 installability): all 8 slices cut successfully
- Manual functional tests: `rsyslogd -v` (8.2512.0), `rsyslogd -N1` config validation passes, all 39 `.so` modules valid ELF, `syslog` user/group created by mutate, `/var/spool/rsyslog` created (mode 0700)
- Spread tests written for all 5 packages (not run locally — `spread` not installed in this environment; CI will execute them)

### Forward-port note

Net-new packages — no existing SDFs on other release branches to forward-port from. If/when these land on 26.04, they can be forward-ported to future release branches.