### PR TITLE
feat(26.04): add libdaemon0 slices

### DIFF
--- a/slices/libdaemon0.yaml
+++ b/slices/libdaemon0.yaml
@@ -1,0 +1,15 @@
+package: libdaemon0
+
+essential:
+  libdaemon0_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libdaemon.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdaemon0/copyright:

--- a/tests/spread/integration/libdaemon0/task.yaml
+++ b/tests/spread/integration/libdaemon0/task.yaml
@@ -18,7 +18,8 @@ execute: |
   }
   trap cleanup EXIT
 
-  apt install --update -y gcc libdaemon-dev
+  # gcc alone only recommends libc6-dev, so ask for the headers explicitly.
+  apt install --update -y gcc libc6-dev libdaemon-dev
   libdir="/usr/lib/$(gcc -dumpmachine)"
 
   # Both the soname symlink and the versioned object must land, otherwise the

--- a/tests/spread/integration/libdaemon0/task.yaml
+++ b/tests/spread/integration/libdaemon0/task.yaml
@@ -1,11 +1,6 @@
 summary: Integration tests for libdaemon0
 
 execute: |
-  # libdaemon0_copyright: fresh rootfs so a missing dep cannot hide behind
-  # another test.
-  rootfs="$(install-slices libdaemon0_copyright)"
-  test -s "$rootfs/usr/share/doc/libdaemon0/copyright"
-
   # libdaemon0_libs: the package has no sliced consumer, so build one -- a
   # program linked against libdaemon.so.0 that drives the library's dlog, dpid,
   # dsignal, dnonblock and dfork/retval entry points -- and run it in the

--- a/tests/spread/integration/libdaemon0/task.yaml
+++ b/tests/spread/integration/libdaemon0/task.yaml
@@ -1,0 +1,40 @@
+summary: Integration tests for libdaemon0
+
+execute: |
+  # libdaemon0_copyright: fresh rootfs so a missing dep cannot hide behind
+  # another test.
+  rootfs="$(install-slices libdaemon0_copyright)"
+  test -s "$rootfs/usr/share/doc/libdaemon0/copyright"
+
+  # libdaemon0_libs: the package has no sliced consumer, so build one -- a
+  # program linked against libdaemon.so.0 that drives the library's dlog, dpid,
+  # dsignal, dnonblock and dfork/retval entry points -- and run it in the
+  # sliced rootfs. base-files_tmp supplies the /tmp the PID file test needs.
+  rootfs="$(install-slices libdaemon0_libs base-files_tmp)"
+
+  cleanup() {
+    umount "$rootfs/proc" || true
+    umount "$rootfs/dev" || true
+  }
+  trap cleanup EXIT
+
+  apt install --update -y gcc libdaemon-dev
+  libdir="/usr/lib/$(gcc -dumpmachine)"
+
+  # Both the soname symlink and the versioned object must land, otherwise the
+  # dynamic linker cannot resolve consumers built against libdaemon.so.0.
+  test -L "$rootfs$libdir/libdaemon.so.0"
+  test -f "$rootfs$libdir/$(readlink "$rootfs$libdir/libdaemon.so.0")"
+
+  gcc test.c -ldaemon -o test-libdaemon
+  ldd test-libdaemon | grep -Fiq "libdaemon.so.0"
+  cp test-libdaemon "$rootfs/"
+
+  # daemon_fork() reopens stdio on /dev/null and daemon_close_all() walks
+  # /proc/self/fd; a sliced rootfs provides neither.
+  mkdir -p "$rootfs/dev" "$rootfs/proc"
+  mount --bind /dev "$rootfs/dev"
+  mount --bind /proc "$rootfs/proc"
+
+  output="$(chroot "$rootfs" /test-libdaemon)"
+  echo "$output" | grep -Fiq "dlog works"

--- a/tests/spread/integration/libdaemon0/test.c
+++ b/tests/spread/integration/libdaemon0/test.c
@@ -1,0 +1,119 @@
+/* Exercises the core libdaemon modules: dlog, dpid, dsignal, dnonblock and the
+ * dfork/retval daemonizing path. Exits non-zero with a distinct code per
+ * failure so a chroot run pinpoints which part of the library broke. */
+
+#include <libdaemon/dfork.h>
+#include <libdaemon/dlog.h>
+#include <libdaemon/dnonblock.h>
+#include <libdaemon/dpid.h>
+#include <libdaemon/dsignal.h>
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define PID_FILE "/tmp/libdaemon-test.pid"
+
+static const char *pid_file_proc(void) {
+    return PID_FILE;
+}
+
+/* dlog: log to stdout so the caller can grep the message. Flush before the
+ * daemon_fork() test so the forked child cannot duplicate the buffer. */
+static int test_log(void) {
+    daemon_log_ident = "libdaemon-test";
+    daemon_log_use = DAEMON_LOG_STDOUT;
+    daemon_log(LOG_INFO, "dlog works");
+    fflush(stdout);
+    return 0;
+}
+
+/* dpid: create a PID file, read our own PID back out, then remove it. */
+static int test_pid_file(void) {
+    daemon_pid_file_ident = "libdaemon-test";
+    daemon_pid_file_proc = pid_file_proc;
+
+    if (daemon_pid_file_create() < 0)
+        return 2;
+    if (daemon_pid_file_is_running() != getpid())
+        return 3;
+    if (daemon_pid_file_remove() < 0)
+        return 4;
+    if (daemon_pid_file_is_running() >= 0)
+        return 5;
+    return 0;
+}
+
+/* dsignal: queue a signal through the library's pipe and read it back. */
+static int test_signal(void) {
+    if (daemon_signal_init(SIGUSR1, 0) < 0)
+        return 6;
+    if (daemon_signal_fd() < 0)
+        return 7;
+    if (raise(SIGUSR1) != 0)
+        return 8;
+    if (daemon_signal_next() != SIGUSR1)
+        return 9;
+    daemon_signal_done();
+    return 0;
+}
+
+/* dnonblock: flip O_NONBLOCK on a pipe end and confirm it stuck. */
+static int test_nonblock(void) {
+    int fds[2];
+
+    if (pipe(fds) < 0)
+        return 10;
+    if (daemon_nonblock(fds[0], 1) < 0)
+        return 11;
+    if (!(fcntl(fds[0], F_GETFL) & O_NONBLOCK))
+        return 12;
+    if (daemon_nonblock(fds[0], 0) < 0)
+        return 13;
+    if (fcntl(fds[0], F_GETFL) & O_NONBLOCK)
+        return 14;
+    close(fds[0]);
+    close(fds[1]);
+    return 0;
+}
+
+/* dfork: daemonize, have the daemon report success over the retval channel. */
+static int test_fork(void) {
+    pid_t pid;
+
+    if (daemon_retval_init() < 0)
+        return 15;
+
+    if ((pid = daemon_fork()) < 0) {
+        daemon_retval_done();
+        return 16;
+    }
+
+    if (pid == 0) {
+        /* Daemon process: detached from the terminal, reports back and exits. */
+        daemon_retval_send(42);
+        _exit(0);
+    }
+
+    if (daemon_retval_wait(20) != 42)
+        return 17;
+    return 0;
+}
+
+int main(void) {
+    int rc;
+
+    if ((rc = test_log()) != 0)
+        return rc;
+    if ((rc = test_pid_file()) != 0)
+        return rc;
+    if ((rc = test_signal()) != 0)
+        return rc;
+    if ((rc = test_nonblock()) != 0)
+        return rc;
+    if ((rc = test_fork()) != 0)
+        return rc;
+
+    return 0;
+}


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `libdaemon0` on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `libdaemon0` | `libs`, `copyright` | Leaf library; only depends on `libc6` |

### Forward porting
#1116

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
