### PR TITLE
feat(26.04): add net-tools slices

### DIFF
--- a/slices/net-tools.yaml
+++ b/slices/net-tools.yaml
@@ -1,0 +1,29 @@
+package: net-tools
+
+essential:
+  net-tools_copyright:
+
+slices:
+  # net-tools is a collection of small, closely related networking utilities.
+  # They are kept in a single slice because consumers that pull net-tools in as
+  # a dependency generally cannot predict which of them will be invoked.
+  bins:
+    essential:
+      libc6_libs:
+      libselinux1_libs:
+    contents:
+      /usr/bin/netstat:
+      /usr/sbin/arp:
+      /usr/sbin/ifconfig:
+      /usr/sbin/ipmaddr:
+      /usr/sbin/iptunnel:
+      /usr/sbin/mii-tool:
+      /usr/sbin/nameif:
+      /usr/sbin/plipconfig:
+      /usr/sbin/rarp:
+      /usr/sbin/route:
+      /usr/sbin/slattach:
+
+  copyright:
+    contents:
+      /usr/share/doc/net-tools/copyright:

--- a/tests/spread/integration/net-tools/task.yaml
+++ b/tests/spread/integration/net-tools/task.yaml
@@ -1,0 +1,40 @@
+summary: Integration tests for net-tools
+
+execute: |
+  function cleanup() {
+    umount "$rootfs/proc" || true
+  }
+  trap cleanup EXIT
+
+  rootfs="$(install-slices net-tools_bins)"
+
+  # Every tool here reads kernel state out of /proc/net.
+  mkdir -p "$rootfs/proc"
+  mount --bind /proc "$rootfs/proc"
+
+  # Interface configuration and statistics.
+  chroot "$rootfs" /usr/sbin/ifconfig lo | grep -Fq "127.0.0.1"
+  chroot "$rootfs" /usr/sbin/ifconfig -a | grep -Fq "lo"
+  chroot "$rootfs" /usr/bin/netstat -i | grep -Fq "lo"
+
+  # Routing table, via both entry points.
+  chroot "$rootfs" /usr/bin/netstat -rn | grep -Fiq "routing table"
+  chroot "$rootfs" /usr/sbin/route -n | grep -Fiq "destination"
+
+  # Listening sockets, plus an ARP cache lookup for an address that is never
+  # cached (the cache itself is empty in a fresh container).
+  chroot "$rootfs" /usr/bin/netstat -tuln | grep -Fiq "proto"
+  chroot "$rootfs" /usr/sbin/arp -n 10.99.99.99 | grep -Fiq "no entry"
+
+  # Multicast addresses and tunnel list.
+  chroot "$rootfs" /usr/sbin/ipmaddr show | grep -Fq "lo"
+  chroot "$rootfs" /usr/sbin/iptunnel show
+
+  # The remaining tools need hardware (a MII-capable NIC, a PLIP or serial
+  # line) or a RARP-enabled kernel, so only their own output is asserted --
+  # enough to prove the dynamic linker resolves them.
+  chroot "$rootfs" /usr/sbin/mii-tool --version | grep -Fiq "net-tools"
+  chroot "$rootfs" /usr/sbin/plipconfig --version | grep -Fiq "net-tools"
+  chroot "$rootfs" /usr/sbin/rarp --version | grep -Fiq "net-tools"
+  chroot "$rootfs" /usr/sbin/slattach --version | grep -Fiq "net-tools"
+  chroot "$rootfs" /usr/sbin/nameif --version 2>&1 | grep -Fiq "usage: nameif"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `net-tools` on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `net-tools` | `bins`, `copyright` | The 11 shipped networking utilities in one slice: consumers that depend on `net-tools` cannot predict which of them gets invoked |

### Forward porting
#1117

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
