### PR TITLE
feat(26.10): add python3-yaml slices

### DIFF
--- a/slices/python3-yaml.yaml
+++ b/slices/python3-yaml.yaml
@@ -1,0 +1,21 @@
+package: python3-yaml
+
+essential:
+  python3-yaml_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libyaml-0-2_libs:
+      python3_standard:
+    contents:
+      # Compatibility stub re-exporting the extension as the old top-level
+      # "_yaml" module.
+      /usr/lib/python3/dist-packages/_yaml/__init__.py:
+      /usr/lib/python3/dist-packages/pyyaml-*.dist-info/**:
+      /usr/lib/python3/dist-packages/yaml/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-yaml/copyright:

--- a/tests/spread/integration/python3-yaml/task.yaml
+++ b/tests/spread/integration/python3-yaml/task.yaml
@@ -1,0 +1,33 @@
+summary: Integration tests for python3-yaml
+
+execute: |
+  rootfs="$(install-slices python3-yaml_libs)"
+
+  # The LibYAML C extension must be usable, not just importable: without
+  # libyaml-0-2 PyYAML silently falls back to the pure-Python parser.
+  chroot "$rootfs" python3 -c "
+  import yaml
+  assert yaml.__with_libyaml__, 'LibYAML extension not available'
+  print(yaml.__version__)
+  "
+
+  # Parse and emit with both the pure-Python and the C implementations.
+  chroot "$rootfs" python3 -c "
+  import yaml
+  doc = 'a: 1\nb: [x, y]\nc:\n  d: true\n'
+  want = {'a': 1, 'b': ['x', 'y'], 'c': {'d': True}}
+  for loader in (yaml.SafeLoader, yaml.CSafeLoader):
+      assert yaml.load(doc, Loader=loader) == want, loader
+  for dumper in (yaml.SafeDumper, yaml.CSafeDumper):
+      assert yaml.safe_load(yaml.dump({'k': [1, 2]}, Dumper=dumper)) == {'k': [1, 2]}, dumper
+  assert list(yaml.safe_load_all('---\na: 1\n---\nb: 2\n')) == [{'a': 1}, {'b': 2}]
+  try:
+      yaml.safe_load('a: [1, 2\n')
+  except yaml.YAMLError:
+      pass
+  else:
+      raise AssertionError('malformed input did not raise YAMLError')
+  "
+
+  # The legacy top-level "_yaml" stub module re-exports the extension.
+  chroot "$rootfs" python3 -W ignore::DeprecationWarning -c "import _yaml"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `python3-yaml` on `ubuntu-26.10`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `python3-yaml` | `libs`, `copyright` | PyYAML plus its LibYAML C extension, so `yaml.__with_libyaml__` holds and `CSafeLoader`/`CSafeDumper` work |

### Forward porting
#1114

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
