### PR TITLE
feat(26.10): add python3-redis slices

### DIFF
--- a/slices/python3-redis.yaml
+++ b/slices/python3-redis.yaml
@@ -1,0 +1,19 @@
+package: python3-redis
+
+essential:
+  python3-redis_copyright:
+
+slices:
+  libs:
+    essential:
+      # The deb's "python3-supported-min (>= 3.11.3) | python3-async-timeout"
+      # alternative is satisfied by python3 itself, which provides
+      # python3-supported-min and ships asyncio.timeout in the stdlib.
+      python3_standard:
+    contents:
+      /usr/lib/python3/dist-packages/redis-*.dist-info/**:
+      /usr/lib/python3/dist-packages/redis/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-redis/copyright:

--- a/tests/spread/integration/python3-redis/task.yaml
+++ b/tests/spread/integration/python3-redis/task.yaml
@@ -18,6 +18,7 @@ execute: |
     --ignore-warnings ARM64-COW-BUG &
   redis_pid=$!
 
+  # Wait for redis-server to start accepting connections on port 6399
   for _ in $(seq 1 30); do
     chroot "$rootfs" /usr/bin/redis-cli -p 6399 ping 2>/dev/null | grep -Fq PONG && break
     kill -0 "$redis_pid" 2>/dev/null || break
@@ -57,8 +58,8 @@ execute: |
   ps.close()
   "
 
-  # The asyncio client relies on asyncio.timeout from the stdlib rather than on
-  # the python3-async-timeout dependency alternative.
+  # Verify that the asyncio client relies on asyncio.timeout from the stdlib,
+  # rather than python3-async-timeout.
   chroot "$rootfs" python3 -c "
   import asyncio
   import redis.asyncio as aioredis

--- a/tests/spread/integration/python3-redis/task.yaml
+++ b/tests/spread/integration/python3-redis/task.yaml
@@ -11,12 +11,16 @@ execute: |
   rootfs="$(install-slices python3-redis_libs redis-server_bins)"
 
   # LC_ALL=C keeps redis-server from inheriting a locale the rootfs lacks.
+  # On arm64 redis probes the kernel for the COW bug by forking; that probe
+  # cannot run in the chroot and redis exits, so waive it explicitly.
   LC_ALL=C chroot "$rootfs" /usr/bin/redis-server \
-    --port 6399 --save "" --appendonly no &
+    --port 6399 --save "" --appendonly no \
+    --ignore-warnings ARM64-COW-BUG &
   redis_pid=$!
 
   for _ in $(seq 1 30); do
     chroot "$rootfs" /usr/bin/redis-cli -p 6399 ping 2>/dev/null | grep -Fq PONG && break
+    kill -0 "$redis_pid" 2>/dev/null || break
     sleep 1
   done
   chroot "$rootfs" /usr/bin/redis-cli -p 6399 ping | grep -Fq PONG

--- a/tests/spread/integration/python3-redis/task.yaml
+++ b/tests/spread/integration/python3-redis/task.yaml
@@ -1,0 +1,68 @@
+summary: Integration tests for python3-redis
+
+execute: |
+  function cleanup() {
+    kill "$redis_pid" 2>/dev/null || true
+  }
+  trap cleanup EXIT
+
+  # python3-redis is a client library, so pair it with a real server and drive
+  # the wire protocol end to end.
+  rootfs="$(install-slices python3-redis_libs redis-server_bins)"
+
+  # LC_ALL=C keeps redis-server from inheriting a locale the rootfs lacks.
+  LC_ALL=C chroot "$rootfs" /usr/bin/redis-server \
+    --port 6399 --save "" --appendonly no &
+  redis_pid=$!
+
+  for _ in $(seq 1 30); do
+    chroot "$rootfs" /usr/bin/redis-cli -p 6399 ping 2>/dev/null | grep -Fq PONG && break
+    sleep 1
+  done
+  chroot "$rootfs" /usr/bin/redis-cli -p 6399 ping | grep -Fq PONG
+
+  # Every command namespace the package ships must at least import.
+  chroot "$rootfs" python3 -c "
+  import redis, redis.asyncio, redis.cluster, redis.sentinel
+  import redis.commands.json, redis.commands.search, redis.commands.timeseries
+  print(redis.__version__)
+  "
+
+  # Strings, lists, hashes, pipelines and pub/sub over the sync client.
+  chroot "$rootfs" python3 -c "
+  import redis
+  r = redis.Redis(host='127.0.0.1', port=6399, decode_responses=True)
+  assert r.ping()
+  r.set('chisel:key', 'value')
+  assert r.get('chisel:key') == 'value'
+  r.delete('chisel:key')
+  assert r.get('chisel:key') is None
+  r.rpush('chisel:list', 'a', 'b', 'c')
+  assert r.lrange('chisel:list', 0, -1) == ['a', 'b', 'c']
+  r.hset('chisel:hash', mapping={'f1': '1', 'f2': '2'})
+  assert r.hgetall('chisel:hash') == {'f1': '1', 'f2': '2'}
+  p = r.pipeline()
+  p.incr('chisel:ctr')
+  p.incr('chisel:ctr')
+  assert p.execute() == [1, 2]
+  ps = r.pubsub()
+  ps.subscribe('chisel:chan')
+  assert ps.get_message(timeout=5)['type'] == 'subscribe'
+  r.publish('chisel:chan', 'hello')
+  assert ps.get_message(timeout=5)['data'] == 'hello'
+  ps.close()
+  "
+
+  # The asyncio client relies on asyncio.timeout from the stdlib rather than on
+  # the python3-async-timeout dependency alternative.
+  chroot "$rootfs" python3 -c "
+  import asyncio
+  import redis.asyncio as aioredis
+  async def main():
+      r = aioredis.Redis(host='127.0.0.1', port=6399, decode_responses=True)
+      assert await r.ping()
+      await r.set('chisel:async', '1')
+      assert await r.get('chisel:async') == '1'
+      await r.aclose()
+  asyncio.run(main())
+  "


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `python3-redis` on `ubuntu-26.10`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `python3-redis` | `libs`, `copyright` | Pure-Python Redis client; the `python3-supported-min \| python3-async-timeout` alternative is satisfied by `python3` itself |

Integration test drives the sync and asyncio clients against a real `redis-server_bins` instance.

### Forward porting
#1115

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
