### PR TITLE
feat(26.10): add ethtool

### DIFF
--- a/slices/ethtool.yaml
+++ b/slices/ethtool.yaml
@@ -1,0 +1,21 @@
+package: ethtool
+
+essential:
+  - ethtool_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libmnl0_libs
+    contents:
+      /usr/sbin/ethtool:
+
+  network-if:
+    contents:
+      /etc/network/if-pre-up.d/ethtool:
+      /etc/network/if-up.d/ethtool:
+
+  copyright:
+    contents:
+      /usr/share/doc/ethtool/copyright:

--- a/slices/ethtool.yaml
+++ b/slices/ethtool.yaml
@@ -11,7 +11,9 @@ slices:
     contents:
       /usr/sbin/ethtool:
 
-  network-if:
+  network-if-hooks:
+    essential:
+      - ethtool_bins
     contents:
       /etc/network/if-pre-up.d/ethtool:
       /etc/network/if-up.d/ethtool:

--- a/slices/ethtool.yaml
+++ b/slices/ethtool.yaml
@@ -1,19 +1,19 @@
 package: ethtool
 
 essential:
-  - ethtool_copyright
+  ethtool_copyright:
 
 slices:
   bins:
     essential:
-      - libc6_libs
-      - libmnl0_libs
+      libc6_libs:
+      libmnl0_libs:
     contents:
       /usr/sbin/ethtool:
 
   network-if-hooks:
     essential:
-      - ethtool_bins
+      ethtool_bins:
     contents:
       /etc/network/if-pre-up.d/ethtool:
       /etc/network/if-up.d/ethtool:

--- a/tests/spread/integration/ethtool/task.yaml
+++ b/tests/spread/integration/ethtool/task.yaml
@@ -1,0 +1,25 @@
+summary: Integration tests for ethtool
+
+execute: |
+  rootfs="$(install-slices ethtool_bins)"
+
+  chroot "${rootfs}/" /usr/sbin/ethtool --version
+
+  # Exercise ethtool against a real interface without changing system state.
+  # ethtool reads interface metadata from sysfs, so bind-mount /sys.
+  mkdir -p "${rootfs}/sys" "${rootfs}/proc"
+  mount --bind /sys "${rootfs}/sys"
+  mount --bind /proc "${rootfs}/proc"
+
+  iface="$(ls -1 /sys/class/net | grep -v '^lo$' | head -n 1 || true)"
+  if [ -z "${iface}" ]; then
+    echo "No non-loopback interface found; skipping ethtool interface smoke test"
+  else
+    # Basic query that should succeed on most interfaces.
+    chroot "${rootfs}/" /usr/sbin/ethtool "${iface}" | grep -E 'Settings for|Speed:|Link detected:' >/dev/null
+    # Driver info is another lightweight query; some virtual interfaces may not support it.
+    chroot "${rootfs}/" /usr/sbin/ethtool -i "${iface}" >/dev/null || true
+  fi
+
+  umount -l "${rootfs}/sys"
+  umount -l "${rootfs}/proc"


### PR DESCRIPTION
# Proposed changes

carbon-copy of https://github.com/canonical/chisel-releases/pull/881

## Related issues/PRs

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1124 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/881

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how] https://github.com/canonical/chisel-rele
  ases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)

## Additional Context

26.10 is in devel mode and chisel does not, at the moment, support 26.10. hence, the 26.10 branch is just being kept up to date with 26.04. the state of this branch vs its 26.04 version ought to be identical. the commit history can be checked with:

```shell
$ git range-diff --no-patch
    canonical/ubuntu-26.04..Meulengracht/feature/ethtool
    canonical/ubuntu-26.10..lczyk/feat/26.10/ethtool
1:  9d907426 = 1:  7fa5f72e slices,tests: add ethtool
2:  101a7291 = 2:  14ed5d0e slices: address review feedback around the network/if*.d scripts
3:  6084a755 = 3:  6dd7d9db feat: v3 ethtool
```

and the diff of the entire branch with:

```shell
$ diff <(git diff canonical/ubuntu-26.04...Meulengracht/feature/ethtool) <(git diff canonical/ubuntu-26.10 lczyk/feat/26.10/ethtool)
```