### PR TITLE
docs: Update Chisel documentation links in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,6 @@ two project maintainers.
 
 If you are slicing Debian packages and thus proposing new slice definitions,
 make sure you read the [package slicing guidelines available in the
-Chisel documentation](https://documentation.ubuntu.com/chisel/en/latest/how-to/slice-a-package/).
+Chisel documentation](https://ubuntu.com/chisel/docs/latest/how-to/slice-a-package/).
 
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ that release.
 
 For more information on the SDFs' YAML schema and how to install slices, please
 refer to the
-[Chisel documentation](https://documentation.ubuntu.com/chisel/en/latest/).
+[Chisel documentation](https://ubuntu.com/chisel/docs).
 
 ## Using a Specific Chisel Release
 
 Chisel releases are meant to be used with the `chisel` CLI. Many of the `chisel`
 commands have a `--release` optional argument (to know which commands support
 this option, please refer to the
-[Chisel documentation](https://documentation.ubuntu.com/chisel/en/latest/).
+[Chisel documentation](https://ubuntu.com/chisel/docs).
 
 When running a `chisel` command where `--release` is supported,
 


### PR DESCRIPTION
# Proposed changes
Updates the Chisel documentation link to the migrated URL.

## Related issues/PRs
<!-- If any -->

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [ ] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [ ] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [ ] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->