### PR TITLE
feat(26.04): add `cpp-14` slices for s390x ppc64le

### DIFF
--- a/slices/cpp-14-aarch64-linux-gnu.yaml
+++ b/slices/cpp-14-aarch64-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-14-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
       gcc-14-base_copyright: {arch: [arm64]}
     contents:
-      /usr/share/doc/cpp-14-aarch64-linux-gnu:
+      /usr/share/doc/cpp-14-aarch64-linux-gnu:  # Symlink to a gcc-14 base package

--- a/slices/cpp-14-aarch64-linux-gnu.yaml
+++ b/slices/cpp-14-aarch64-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-14-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
+      gcc-14-base_copyright: {arch: [arm64]}
     contents:
       /usr/share/doc/cpp-14-aarch64-linux-gnu:

--- a/slices/cpp-14-powerpc64le-linux-gnu.yaml
+++ b/slices/cpp-14-powerpc64le-linux-gnu.yaml
@@ -1,0 +1,28 @@
+package: cpp-14-powerpc64le-linux-gnu
+
+essential:
+  cpp-14-powerpc64le-linux-gnu_copyright:
+
+slices:
+  cc1:
+    essential:
+      libc6-dev_headers:
+      libc6_libs:
+      libgmp10_libs:
+      libisl23_libs:
+      libmpc3_libs:
+      libmpfr6_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/libexec/gcc-cross/powerpc64le-linux-gnu/14/cc1:
+        arch: [amd64, arm64, i386, s390x]
+      /usr/libexec/gcc/powerpc64le-linux-gnu/14/cc1:
+        arch: [ppc64el]
+
+  copyright:
+    essential:
+      gcc-14-base_copyright: {arch: [ppc64el]}
+      gcc-14-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
+    contents:
+      /usr/share/doc/cpp-14-powerpc64le-linux-gnu:

--- a/slices/cpp-14-powerpc64le-linux-gnu.yaml
+++ b/slices/cpp-14-powerpc64le-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-14-base_copyright: {arch: [ppc64el]}
       gcc-14-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
     contents:
-      /usr/share/doc/cpp-14-powerpc64le-linux-gnu:
+      /usr/share/doc/cpp-14-powerpc64le-linux-gnu:  # Symlink to a gcc-14 base package

--- a/slices/cpp-14-s390x-linux-gnu.yaml
+++ b/slices/cpp-14-s390x-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-14-base_copyright: {arch: [s390x]}
       gcc-14-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
     contents:
-      /usr/share/doc/cpp-14-s390x-linux-gnu:
+      /usr/share/doc/cpp-14-s390x-linux-gnu:  # Symlink to a gcc-14 base package

--- a/slices/cpp-14-s390x-linux-gnu.yaml
+++ b/slices/cpp-14-s390x-linux-gnu.yaml
@@ -1,0 +1,28 @@
+package: cpp-14-s390x-linux-gnu
+
+essential:
+  cpp-14-s390x-linux-gnu_copyright:
+
+slices:
+  cc1:
+    essential:
+      libc6-dev_headers:
+      libc6_libs:
+      libgmp10_libs:
+      libisl23_libs:
+      libmpc3_libs:
+      libmpfr6_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/libexec/gcc-cross/s390x-linux-gnu/14/cc1:
+        arch: [amd64, arm64, i386, ppc64el]
+      /usr/libexec/gcc/s390x-linux-gnu/14/cc1:
+        arch: [s390x]
+
+  copyright:
+    essential:
+      gcc-14-base_copyright: {arch: [s390x]}
+      gcc-14-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
+    contents:
+      /usr/share/doc/cpp-14-s390x-linux-gnu:

--- a/slices/cpp-14-x86-64-linux-gnu.yaml
+++ b/slices/cpp-14-x86-64-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-14-base_copyright: {arch: [amd64]}
       gcc-14-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
-      /usr/share/doc/cpp-14-x86-64-linux-gnu:
+      /usr/share/doc/cpp-14-x86-64-linux-gnu:  # Symlink to a gcc-14 base package

--- a/slices/cpp-14-x86-64-linux-gnu.yaml
+++ b/slices/cpp-14-x86-64-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-14-base_copyright: {arch: [amd64]}
+      gcc-14-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
       /usr/share/doc/cpp-14-x86-64-linux-gnu:

--- a/slices/gcc-14-aarch64-linux-gnu-base.yaml
+++ b/slices/gcc-14-aarch64-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-14-aarch64-linux-gnu-base
+
+essential:
+  gcc-14-aarch64-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-14-aarch64-linux-gnu-base/copyright:

--- a/slices/gcc-14-powerpc64le-linux-gnu-base.yaml
+++ b/slices/gcc-14-powerpc64le-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-14-powerpc64le-linux-gnu-base
+
+essential:
+  gcc-14-powerpc64le-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-14-powerpc64le-linux-gnu-base/copyright:

--- a/slices/gcc-14-s390x-linux-gnu-base.yaml
+++ b/slices/gcc-14-s390x-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-14-s390x-linux-gnu-base
+
+essential:
+  gcc-14-s390x-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-14-s390x-linux-gnu-base/copyright:

--- a/slices/gcc-14-x86-64-linux-gnu-base.yaml
+++ b/slices/gcc-14-x86-64-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-14-x86-64-linux-gnu-base
+
+essential:
+  gcc-14-x86-64-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-14-x86-64-linux-gnu-base/copyright:

--- a/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_c_compiler.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_c_compiler.sh
@@ -36,9 +36,6 @@ else
     ln -s "aarch64-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
 fi
 
-# NOTE: is this the correct linker path for cross compilation too?
-dynamic_linker="$(find "${rootfs_ld}" -type f -name "ld-linux-*.so.*" -printf "%P\n" -quit)"
-
 cp hello.c "${rootfs_cc}/hello.c"
 
 if $cross; then
@@ -58,8 +55,10 @@ else
 
     # link
     cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
     chroot "${rootfs_ld}" ld -o hello hello.o \
-        -dynamic-linker "$dynamic_linker" \
+        -dynamic-linker "${linker_lib}" \
         -lc \
         /usr/lib/"$arch"-linux-gnu/crt1.o \
         /usr/lib/"$arch"-linux-gnu/crti.o \

--- a/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_help.sh
+++ b/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_help.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_preprocessor.sh
+++ b/tests/spread/integration/cpp-14-aarch64-linux-gnu/test_preprocessor.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/hello.c
+++ b/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/hello.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+int main() {
+    const char msg[] = "Hello, world!\n";
+    write(1, msg, sizeof(msg) - 1);
+    return 0;
+}

--- a/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/question.c
+++ b/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/question.c
@@ -1,0 +1,7 @@
+int main() {
+    #ifdef ANSWER
+        return ANSWER;
+    #else
+        return 1;
+    #endif
+}

--- a/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/task.yaml
+++ b/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for cpp-14-powerpc64le-linux-gnu
+
+variants:
+    - c_compiler
+    - help
+    - preprocessor
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/test_c_compiler.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libc libexec binutils unistd crti crtn
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "ppc64le" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+# prepare separate rootfs with cc1, as and ld
+rootfs_cc="$(install-slices \
+    base-files_bin \
+    cpp-14-powerpc64le-linux-gnu_cc1 \
+    libc6-dev_headers \
+)"
+rootfs_as="$(install-slices \
+    binutils-powerpc64le-linux-gnu_assembler \
+)"
+rootfs_ld="$(install-slices \
+    binutils-powerpc64le-linux-gnu_linker \
+    libc6-dev_core \
+)"
+
+if $cross; then
+    ln -s "/usr/libexec/gcc-cross/powerpc64le-linux-gnu/14/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "powerpc64le-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "powerpc64le-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+else
+    ln -s "/usr/libexec/gcc/powerpc64le-linux-gnu/14/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "powerpc64le-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "powerpc64le-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+fi
+
+cp hello.c "${rootfs_cc}/hello.c"
+
+if $cross; then
+    # TODO: We do not have libc6-dev for cross compilation yet
+    :
+else
+    # compile
+    # NOTE: uname -m reports ppc64le, but the multiarch triplet is
+    #       powerpc64le-linux-gnu, so the include/lib paths cannot use $arch.
+    chroot "${rootfs_cc}" cc1 hello.c \
+        -o hello.s \
+        -Wno-implicit-function-declaration \
+        -I "/usr/include/powerpc64le-linux-gnu" \
+        -I "/usr/include/linux"
+
+    # assemble
+    cp "${rootfs_cc}/hello.s" "${rootfs_as}/hello.s"
+    chroot "${rootfs_as}" as -o hello.o hello.s
+
+    # link
+    cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
+    chroot "${rootfs_ld}" ld -o hello hello.o \
+        -dynamic-linker "${linker_lib}" \
+        -lc \
+        /usr/lib/powerpc64le-linux-gnu/crt1.o \
+        /usr/lib/powerpc64le-linux-gnu/crti.o \
+        /usr/lib/powerpc64le-linux-gnu/crtn.o
+
+    # run
+    chroot "${rootfs_ld}" /hello | grep -q "Hello, world!"
+fi

--- a/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/test_help.sh
+++ b/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/test_help.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "x86_64" ]]; then
+elif [[ "$arch" == "ppc64le" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-14-x86-64-linux-gnu_cc1 \
+    cpp-14-powerpc64le-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/powerpc64le-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/powerpc64le-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 if $cross; then

--- a/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/test_preprocessor.sh
+++ b/tests/spread/integration/cpp-14-powerpc64le-linux-gnu/test_preprocessor.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "x86_64" ]]; then
+elif [[ "$arch" == "ppc64le" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-14-x86-64-linux-gnu_cc1 \
+    cpp-14-powerpc64le-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/powerpc64le-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/powerpc64le-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 cp question.c "${rootfs}/question.c"

--- a/tests/spread/integration/cpp-14-s390x-linux-gnu/hello.c
+++ b/tests/spread/integration/cpp-14-s390x-linux-gnu/hello.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+int main() {
+    const char msg[] = "Hello, world!\n";
+    write(1, msg, sizeof(msg) - 1);
+    return 0;
+}

--- a/tests/spread/integration/cpp-14-s390x-linux-gnu/question.c
+++ b/tests/spread/integration/cpp-14-s390x-linux-gnu/question.c
@@ -1,0 +1,7 @@
+int main() {
+    #ifdef ANSWER
+        return ANSWER;
+    #else
+        return 1;
+    #endif
+}

--- a/tests/spread/integration/cpp-14-s390x-linux-gnu/task.yaml
+++ b/tests/spread/integration/cpp-14-s390x-linux-gnu/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for cpp-14-s390x-linux-gnu
+
+variants:
+    - c_compiler
+    - help
+    - preprocessor
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/cpp-14-s390x-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-14-s390x-linux-gnu/test_c_compiler.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libc libexec binutils unistd crti crtn
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "s390x" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+# prepare separate rootfs with cc1, as and ld
+rootfs_cc="$(install-slices \
+    base-files_bin \
+    cpp-14-s390x-linux-gnu_cc1 \
+    libc6-dev_headers \
+)"
+rootfs_as="$(install-slices \
+    binutils-s390x-linux-gnu_assembler \
+)"
+rootfs_ld="$(install-slices \
+    binutils-s390x-linux-gnu_linker \
+    libc6-dev_core \
+)"
+
+if $cross; then
+    ln -s "/usr/libexec/gcc-cross/s390x-linux-gnu/14/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "s390x-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "s390x-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+else
+    ln -s "/usr/libexec/gcc/s390x-linux-gnu/14/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "s390x-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "s390x-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+fi
+
+cp hello.c "${rootfs_cc}/hello.c"
+
+if $cross; then
+    # TODO: We do not have libc6-dev for cross compilation yet
+    :
+else
+    # compile
+    # NOTE: hardcode the triplet rather than deriving from $arch; uname -m
+    #       happens to match here (s390x) but not on all arches (e.g. ppc64le).
+    chroot "${rootfs_cc}" cc1 hello.c \
+        -o hello.s \
+        -Wno-implicit-function-declaration \
+        -I "/usr/include/s390x-linux-gnu" \
+        -I "/usr/include/linux"
+
+    # assemble
+    cp "${rootfs_cc}/hello.s" "${rootfs_as}/hello.s"
+    chroot "${rootfs_as}" as -o hello.o hello.s
+
+    # link
+    cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
+    chroot "${rootfs_ld}" ld -o hello hello.o \
+        -dynamic-linker "${linker_lib}" \
+        -lc \
+        /usr/lib/s390x-linux-gnu/crt1.o \
+        /usr/lib/s390x-linux-gnu/crti.o \
+        /usr/lib/s390x-linux-gnu/crtn.o
+
+    # run
+    chroot "${rootfs_ld}" /hello | grep -q "Hello, world!"
+fi

--- a/tests/spread/integration/cpp-14-s390x-linux-gnu/test_help.sh
+++ b/tests/spread/integration/cpp-14-s390x-linux-gnu/test_help.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "x86_64" ]]; then
+elif [[ "$arch" == "s390x" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-14-x86-64-linux-gnu_cc1 \
+    cpp-14-s390x-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/s390x-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/s390x-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 if $cross; then

--- a/tests/spread/integration/cpp-14-s390x-linux-gnu/test_preprocessor.sh
+++ b/tests/spread/integration/cpp-14-s390x-linux-gnu/test_preprocessor.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "x86_64" ]]; then
+elif [[ "$arch" == "s390x" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-14-x86-64-linux-gnu_cc1 \
+    cpp-14-s390x-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/s390x-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/x86_64-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/s390x-linux-gnu/14/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 cp question.c "${rootfs}/question.c"

--- a/tests/spread/integration/cpp-14-x86-64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-14-x86-64-linux-gnu/test_c_compiler.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
     cross=true
 elif [[ "$arch" == "x86_64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-14-x86-64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-14-x86-64-linux-gnu/test_c_compiler.sh
@@ -36,9 +36,6 @@ else
     ln -s "x86_64-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
 fi
 
-# NOTE: is this the correct linker path for cross compilation too?
-dynamic_linker="$(find "${rootfs_ld}" -type f -name "ld-linux-*.so.*" -printf "%P\n" -quit)"
-
 cp hello.c "${rootfs_cc}/hello.c"
 
 if $cross; then
@@ -58,8 +55,10 @@ else
 
     # link
     cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
     chroot "${rootfs_ld}" ld -o hello hello.o \
-        -dynamic-linker "$dynamic_linker" \
+        -dynamic-linker "${linker_lib}" \
         -lc \
         /usr/lib/"$arch"-linux-gnu/crt1.o \
         /usr/lib/"$arch"-linux-gnu/crti.o \


### PR DESCRIPTION
# Proposed changes

just like #1127 but with `13` -> `14`. every file the same except for the version bump. check with:

```shell
diff <(git diff canonical/ubuntu-26.04...lczyk/feat/26.04/cpp-13 | grep -v '^index' | sed '/^@@/!s/13/14/g') <(git diff canonical/ubuntu-26.04...lczyk/feat/26.04/cpp-14 | grep -v '^index')
```

## Related issues/PRs

- https://github.com/canonical/chisel-releases/issues/1050
- https://github.com/canonical/chisel-releases/pull/1127
- https://github.com/canonical/chisel-releases/pull/1129

### Forward porting

part of:

- https://github.com/canonical/chisel-releases/pull/1128 **(this PR)**
  - https://github.com/canonical/chisel-releases/pull/1131
- https://github.com/canonical/chisel-releases/pull/1135
  - https://github.com/canonical/chisel-releases/pull/1136

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)