### PR TITLE
feat(26.04): add `gcc-13` slices for s390x ppc64le

### DIFF
--- a/slices/cpp-13-aarch64-linux-gnu.yaml
+++ b/slices/cpp-13-aarch64-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-13-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
       gcc-13-base_copyright: {arch: [arm64]}
     contents:
-      /usr/share/doc/cpp-13-aarch64-linux-gnu:
+      /usr/share/doc/cpp-13-aarch64-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/cpp-13-aarch64-linux-gnu.yaml
+++ b/slices/cpp-13-aarch64-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-13-base_copyright:
+      gcc-13-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
+      gcc-13-base_copyright: {arch: [arm64]}
     contents:
       /usr/share/doc/cpp-13-aarch64-linux-gnu:

--- a/slices/cpp-13-powerpc64le-linux-gnu.yaml
+++ b/slices/cpp-13-powerpc64le-linux-gnu.yaml
@@ -1,0 +1,28 @@
+package: cpp-13-powerpc64le-linux-gnu
+
+essential:
+  cpp-13-powerpc64le-linux-gnu_copyright:
+
+slices:
+  cc1:
+    essential:
+      libc6-dev_headers:
+      libc6_libs:
+      libgmp10_libs:
+      libisl23_libs:
+      libmpc3_libs:
+      libmpfr6_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/libexec/gcc-cross/powerpc64le-linux-gnu/13/cc1:
+        arch: [amd64, arm64, i386, s390x]
+      /usr/libexec/gcc/powerpc64le-linux-gnu/13/cc1:
+        arch: [ppc64el]
+
+  copyright:
+    essential:
+      gcc-13-base_copyright: {arch: [ppc64el]}
+      gcc-13-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
+    contents:
+      /usr/share/doc/cpp-13-powerpc64le-linux-gnu:

--- a/slices/cpp-13-powerpc64le-linux-gnu.yaml
+++ b/slices/cpp-13-powerpc64le-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-13-base_copyright: {arch: [ppc64el]}
       gcc-13-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
     contents:
-      /usr/share/doc/cpp-13-powerpc64le-linux-gnu:
+      /usr/share/doc/cpp-13-powerpc64le-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/cpp-13-s390x-linux-gnu.yaml
+++ b/slices/cpp-13-s390x-linux-gnu.yaml
@@ -1,0 +1,28 @@
+package: cpp-13-s390x-linux-gnu
+
+essential:
+  cpp-13-s390x-linux-gnu_copyright:
+
+slices:
+  cc1:
+    essential:
+      libc6-dev_headers:
+      libc6_libs:
+      libgmp10_libs:
+      libisl23_libs:
+      libmpc3_libs:
+      libmpfr6_libs:
+      libzstd1_libs:
+      zlib1g_libs:
+    contents:
+      /usr/libexec/gcc-cross/s390x-linux-gnu/13/cc1:
+        arch: [amd64, arm64, i386, ppc64el]
+      /usr/libexec/gcc/s390x-linux-gnu/13/cc1:
+        arch: [s390x]
+
+  copyright:
+    essential:
+      gcc-13-base_copyright: {arch: [s390x]}
+      gcc-13-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
+    contents:
+      /usr/share/doc/cpp-13-s390x-linux-gnu:

--- a/slices/cpp-13-s390x-linux-gnu.yaml
+++ b/slices/cpp-13-s390x-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-13-base_copyright: {arch: [s390x]}
       gcc-13-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
     contents:
-      /usr/share/doc/cpp-13-s390x-linux-gnu:
+      /usr/share/doc/cpp-13-s390x-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/cpp-13-x86-64-linux-gnu.yaml
+++ b/slices/cpp-13-x86-64-linux-gnu.yaml
@@ -25,4 +25,4 @@ slices:
       gcc-13-base_copyright: {arch: [amd64]}
       gcc-13-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
-      /usr/share/doc/cpp-13-x86-64-linux-gnu:
+      /usr/share/doc/cpp-13-x86-64-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/cpp-13-x86-64-linux-gnu.yaml
+++ b/slices/cpp-13-x86-64-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-13-base_copyright:
+      gcc-13-base_copyright: {arch: [amd64]}
+      gcc-13-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
       /usr/share/doc/cpp-13-x86-64-linux-gnu:

--- a/slices/gcc-13-aarch64-linux-gnu-base.yaml
+++ b/slices/gcc-13-aarch64-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-13-aarch64-linux-gnu-base
+
+essential:
+  gcc-13-aarch64-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-13-aarch64-linux-gnu-base/copyright:

--- a/slices/gcc-13-aarch64-linux-gnu.yaml
+++ b/slices/gcc-13-aarch64-linux-gnu.yaml
@@ -4,19 +4,12 @@ essential:
   gcc-13-aarch64-linux-gnu_copyright:
 
 slices:
-  # NOTE: The gcc-13 slice below contains only the architecture-specific gcc-13 itself.
-  #       The other dependencies like the linker, assembler and compiler are provided via
-  #       gcc-13_gcc-13 slice.
-  # NOTE: If installing this slice directly, please note that for it to work,
-  #       you need to provide the linker, the assembler and cc1 c compiler yourself.
-  #       The default ones are from
-  #       cpp-13-aarch64-linux-gnu and binutils-aarch64-linux-gnu slices.
-  #       You'll also need to create symlinks for them:
-  #       ln -s aarch64-linux-gnu-ld "$rootfs/usr/bin/ld"
-  #       ln -s aarch64-linux-gnu-as "$rootfs/usr/bin/as"
-  # NOTE: You might also want to create a symlink for /usr/bin/gcc, if you are not
-  #       installing the gcc_gcc slice:
-  #       ln -s aarch64-linux-gnu-gcc-13 "$rootfs/usr/bin/gcc"
+  # NOTE: For this slice to work, you need to also provide the linker,
+  #       the assembler and cc1 c compiler. The default ones are from
+  #       `cpp-13-aarch64-linux-gnu` and `binutils-aarch64-linux-gnu` slices.
+  #       Alternatively, use the architecture-independent `gcc-13_gcc-13` slice,
+  #       which provides these dependencies and `/usr/bin/gcc-13`.
+  #       Include `libc6-dev_core` slice to link against the standard C libraries.
   gcc-13:
     essential:
       libc6_libs:

--- a/slices/gcc-13-aarch64-linux-gnu.yaml
+++ b/slices/gcc-13-aarch64-linux-gnu.yaml
@@ -34,6 +34,7 @@ slices:
 
   copyright:
     essential:
-      gcc-13-base_copyright:
+      gcc-13-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
+      gcc-13-base_copyright: {arch: [arm64]}
     contents:
-      /usr/share/doc/gcc-13-aarch64-linux-gnu:
+      /usr/share/doc/gcc-13-aarch64-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/gcc-13-powerpc64le-linux-gnu-base.yaml
+++ b/slices/gcc-13-powerpc64le-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-13-powerpc64le-linux-gnu-base
+
+essential:
+  gcc-13-powerpc64le-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-13-powerpc64le-linux-gnu-base/copyright:

--- a/slices/gcc-13-powerpc64le-linux-gnu.yaml
+++ b/slices/gcc-13-powerpc64le-linux-gnu.yaml
@@ -1,0 +1,33 @@
+package: gcc-13-powerpc64le-linux-gnu
+
+essential:
+  gcc-13-powerpc64le-linux-gnu_copyright:
+
+slices:
+  # NOTE: For this slice to work, you need to also provide the linker,
+  #       the assembler and cc1 c compiler. The default ones are from
+  #       `cpp-13-powerpc64le-linux-gnu` and `binutils-powerpc64le-linux-gnu` slices.
+  #       Alternatively, use the architecture-independent `gcc-13_gcc-13` slice,
+  #       which provides these dependencies and `/usr/bin/gcc-13`.
+  #       Include `libc6-dev_core` slice to link against the standard C libraries.
+  gcc-13:
+    essential:
+      libc6_libs:
+      libgcc-13-dev_headers:
+    contents:
+      /usr/bin/powerpc64le-linux-gnu-gcc-13:
+      /usr/libexec/gcc-cross/powerpc64le-linux-gnu/13/collect2:
+        arch: [amd64, arm64, i386, s390x]
+      /usr/libexec/gcc-cross/powerpc64le-linux-gnu/13/liblto_plugin.so:
+        arch: [amd64, arm64, i386, s390x]
+      /usr/libexec/gcc/powerpc64le-linux-gnu/13/collect2:
+        arch: [ppc64el]
+      /usr/libexec/gcc/powerpc64le-linux-gnu/13/liblto_plugin.so:
+        arch: [ppc64el]
+
+  copyright:
+    essential:
+      gcc-13-base_copyright: {arch: [ppc64el]}
+      gcc-13-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
+    contents:
+      /usr/share/doc/gcc-13-powerpc64le-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/gcc-13-s390x-linux-gnu-base.yaml
+++ b/slices/gcc-13-s390x-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-13-s390x-linux-gnu-base
+
+essential:
+  gcc-13-s390x-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-13-s390x-linux-gnu-base/copyright:

--- a/slices/gcc-13-s390x-linux-gnu.yaml
+++ b/slices/gcc-13-s390x-linux-gnu.yaml
@@ -1,0 +1,33 @@
+package: gcc-13-s390x-linux-gnu
+
+essential:
+  gcc-13-s390x-linux-gnu_copyright:
+
+slices:
+  # NOTE: For this slice to work, you need to also provide the linker,
+  #       the assembler and cc1 c compiler. The default ones are from
+  #       `cpp-13-s390x-linux-gnu` and `binutils-s390x-linux-gnu` slices.
+  #       Alternatively, use the architecture-independent `gcc-13_gcc-13` slice,
+  #       which provides these dependencies and `/usr/bin/gcc-13`.
+  #       Include `libc6-dev_core` slice to link against the standard C libraries.
+  gcc-13:
+    essential:
+      libc6_libs:
+      libgcc-13-dev_headers:
+    contents:
+      /usr/bin/s390x-linux-gnu-gcc-13:
+      /usr/libexec/gcc-cross/s390x-linux-gnu/13/collect2:
+        arch: [amd64, arm64, i386, ppc64el]
+      /usr/libexec/gcc-cross/s390x-linux-gnu/13/liblto_plugin.so:
+        arch: [amd64, arm64, i386, ppc64el]
+      /usr/libexec/gcc/s390x-linux-gnu/13/collect2:
+        arch: [s390x]
+      /usr/libexec/gcc/s390x-linux-gnu/13/liblto_plugin.so:
+        arch: [s390x]
+
+  copyright:
+    essential:
+      gcc-13-base_copyright: {arch: [s390x]}
+      gcc-13-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
+    contents:
+      /usr/share/doc/gcc-13-s390x-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/gcc-13-x86-64-linux-gnu-base.yaml
+++ b/slices/gcc-13-x86-64-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-13-x86-64-linux-gnu-base
+
+essential:
+  gcc-13-x86-64-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-13-x86-64-linux-gnu-base/copyright:

--- a/slices/gcc-13-x86-64-linux-gnu.yaml
+++ b/slices/gcc-13-x86-64-linux-gnu.yaml
@@ -4,19 +4,12 @@ essential:
   gcc-13-x86-64-linux-gnu_copyright:
 
 slices:
-  # NOTE: The gcc-13 slice below contains only the architecture-specific gcc-13 itself.
-  #       The other dependencies like the linker, assembler and compiler are provided via
-  #       gcc-13_gcc-13 slice.
-  # NOTE: If installing this slice directly, please note that for it to work,
-  #       you need to provide the linker, the assembler and cc1 c compiler yourself.
-  #       The default ones are from
-  #       cpp-13-x86-64-linux-gnu and binutils-x86-64-linux-gnu slices.
-  #       You'll also need to create symlinks for them:
-  #       ln -s x86-64-linux-gnu-ld "$rootfs/usr/bin/ld"
-  #       ln -s x86-64-linux-gnu-as "$rootfs/usr/bin/as"
-  # NOTE: You might also want to create a symlink for /usr/bin/gcc, if you are not
-  #       installing the gcc_gcc slice:
-  #       ln -s x86-64-linux-gnu-gcc-13 "$rootfs/usr/bin/gcc"
+  # NOTE: For this slice to work, you need to also provide the linker,
+  #       the assembler and cc1 c compiler. The default ones are from
+  #       `cpp-13-x86-64-linux-gnu` and `binutils-x86-64-linux-gnu` slices.
+  #       Alternatively, use the architecture-independent `gcc-13_gcc-13` slice,
+  #       which provides these dependencies and `/usr/bin/gcc-13`.
+  #       Include `libc6-dev_core` slice to link against the standard C libraries.
   gcc-13:
     essential:
       libc6_libs:

--- a/slices/gcc-13-x86-64-linux-gnu.yaml
+++ b/slices/gcc-13-x86-64-linux-gnu.yaml
@@ -34,6 +34,7 @@ slices:
 
   copyright:
     essential:
-      gcc-13-base_copyright:
+      gcc-13-base_copyright: {arch: [amd64]}
+      gcc-13-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
-      /usr/share/doc/gcc-13-x86-64-linux-gnu:
+      /usr/share/doc/gcc-13-x86-64-linux-gnu:  # Symlink to a gcc-13 base package

--- a/slices/gcc-13.yaml
+++ b/slices/gcc-13.yaml
@@ -9,8 +9,12 @@ slices:
       binutils_assembler:
       binutils_linker:
       cpp-13-aarch64-linux-gnu_cc1: {arch: [arm64]}
+      cpp-13-powerpc64le-linux-gnu_cc1: {arch: [ppc64el]}
+      cpp-13-s390x-linux-gnu_cc1: {arch: [s390x]}
       cpp-13-x86-64-linux-gnu_cc1: {arch: [amd64]}
       gcc-13-aarch64-linux-gnu_gcc-13: {arch: [arm64]}
+      gcc-13-powerpc64le-linux-gnu_gcc-13: {arch: [ppc64el]}
+      gcc-13-s390x-linux-gnu_gcc-13: {arch: [s390x]}
       gcc-13-x86-64-linux-gnu_gcc-13: {arch: [amd64]}
       libgcc-13-dev_core:
     contents:

--- a/tests/spread/integration/cpp-13-aarch64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-13-aarch64-linux-gnu/test_c_compiler.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-13-aarch64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-13-aarch64-linux-gnu/test_c_compiler.sh
@@ -36,9 +36,6 @@ else
     ln -s "aarch64-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
 fi
 
-# NOTE: is this the correct linker path for cross compilation too?
-dynamic_linker="$(find "${rootfs_ld}" -type f -name "ld-linux-*.so.*" -printf "%P\n" -quit)"
-
 cp hello.c "${rootfs_cc}/hello.c"
 
 if $cross; then
@@ -58,8 +55,10 @@ else
 
     # link
     cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
     chroot "${rootfs_ld}" ld -o hello hello.o \
-        -dynamic-linker "$dynamic_linker" \
+        -dynamic-linker "${linker_lib}" \
         -lc \
         /usr/lib/"$arch"-linux-gnu/crt1.o \
         /usr/lib/"$arch"-linux-gnu/crti.o \

--- a/tests/spread/integration/cpp-13-aarch64-linux-gnu/test_preprocessor.sh
+++ b/tests/spread/integration/cpp-13-aarch64-linux-gnu/test_preprocessor.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/hello.c
+++ b/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/hello.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+int main() {
+    const char msg[] = "Hello, world!\n";
+    write(1, msg, sizeof(msg) - 1);
+    return 0;
+}

--- a/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/question.c
+++ b/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/question.c
@@ -1,0 +1,7 @@
+int main() {
+    #ifdef ANSWER
+        return ANSWER;
+    #else
+        return 1;
+    #endif
+}

--- a/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/task.yaml
+++ b/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for cpp-13-powerpc64le-linux-gnu
+
+variants:
+    - c_compiler
+    - help
+    - preprocessor
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/test_c_compiler.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libc libexec binutils unistd crti crtn
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "ppc64le" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+# prepare separate rootfs with cc1, as and ld
+rootfs_cc="$(install-slices \
+    base-files_bin \
+    cpp-13-powerpc64le-linux-gnu_cc1 \
+    libc6-dev_headers \
+)"
+rootfs_as="$(install-slices \
+    binutils-powerpc64le-linux-gnu_assembler \
+)"
+rootfs_ld="$(install-slices \
+    binutils-powerpc64le-linux-gnu_linker \
+    libc6-dev_core \
+)"
+
+if $cross; then
+    ln -s "/usr/libexec/gcc-cross/powerpc64le-linux-gnu/13/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "powerpc64le-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "powerpc64le-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+else
+    ln -s "/usr/libexec/gcc/powerpc64le-linux-gnu/13/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "powerpc64le-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "powerpc64le-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+fi
+
+cp hello.c "${rootfs_cc}/hello.c"
+
+if $cross; then
+    # TODO: We do not have libc6-dev for cross compilation yet
+    :
+else
+    # compile
+    # NOTE: uname -m reports ppc64le, but the multiarch triplet is
+    #       powerpc64le-linux-gnu, so the include/lib paths cannot use $arch.
+    chroot "${rootfs_cc}" cc1 hello.c \
+        -o hello.s \
+        -Wno-implicit-function-declaration \
+        -I "/usr/include/powerpc64le-linux-gnu" \
+        -I "/usr/include/linux"
+
+    # assemble
+    cp "${rootfs_cc}/hello.s" "${rootfs_as}/hello.s"
+    chroot "${rootfs_as}" as -o hello.o hello.s
+
+    # link
+    cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
+    chroot "${rootfs_ld}" ld -o hello hello.o \
+        -dynamic-linker "${linker_lib}" \
+        -lc \
+        /usr/lib/powerpc64le-linux-gnu/crt1.o \
+        /usr/lib/powerpc64le-linux-gnu/crti.o \
+        /usr/lib/powerpc64le-linux-gnu/crtn.o
+
+    # run
+    chroot "${rootfs_ld}" /hello | grep -q "Hello, world!"
+fi

--- a/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/test_help.sh
+++ b/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/test_help.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "aarch64" ]]; then
+elif [[ "$arch" == "ppc64le" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-13-aarch64-linux-gnu_cc1 \
+    cpp-13-powerpc64le-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/aarch64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/powerpc64le-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/aarch64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/powerpc64le-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 if $cross; then

--- a/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/test_preprocessor.sh
+++ b/tests/spread/integration/cpp-13-powerpc64le-linux-gnu/test_preprocessor.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "x86_64" ]]; then
+elif [[ "$arch" == "ppc64le" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-13-x86-64-linux-gnu_cc1 \
+    cpp-13-powerpc64le-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/x86_64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/powerpc64le-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/x86_64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/powerpc64le-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 cp question.c "${rootfs}/question.c"

--- a/tests/spread/integration/cpp-13-s390x-linux-gnu/hello.c
+++ b/tests/spread/integration/cpp-13-s390x-linux-gnu/hello.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+int main() {
+    const char msg[] = "Hello, world!\n";
+    write(1, msg, sizeof(msg) - 1);
+    return 0;
+}

--- a/tests/spread/integration/cpp-13-s390x-linux-gnu/question.c
+++ b/tests/spread/integration/cpp-13-s390x-linux-gnu/question.c
@@ -1,0 +1,7 @@
+int main() {
+    #ifdef ANSWER
+        return ANSWER;
+    #else
+        return 1;
+    #endif
+}

--- a/tests/spread/integration/cpp-13-s390x-linux-gnu/task.yaml
+++ b/tests/spread/integration/cpp-13-s390x-linux-gnu/task.yaml
@@ -1,0 +1,8 @@
+summary: Integration tests for cpp-13-s390x-linux-gnu
+
+variants:
+    - c_compiler
+    - help
+    - preprocessor
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/cpp-13-s390x-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-13-s390x-linux-gnu/test_c_compiler.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libc libexec binutils unistd crti crtn
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "x86_64" ]]; then
+    cross=true
+elif [[ "$arch" == "s390x" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+# prepare separate rootfs with cc1, as and ld
+rootfs_cc="$(install-slices \
+    base-files_bin \
+    cpp-13-s390x-linux-gnu_cc1 \
+    libc6-dev_headers \
+)"
+rootfs_as="$(install-slices \
+    binutils-s390x-linux-gnu_assembler \
+)"
+rootfs_ld="$(install-slices \
+    binutils-s390x-linux-gnu_linker \
+    libc6-dev_core \
+)"
+
+if $cross; then
+    ln -s "/usr/libexec/gcc-cross/s390x-linux-gnu/13/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "s390x-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "s390x-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+else
+    ln -s "/usr/libexec/gcc/s390x-linux-gnu/13/cc1" "${rootfs_cc}/usr/bin/cc1"
+    ln -s "s390x-linux-gnu-as" "${rootfs_as}/usr/bin/as"
+    ln -s "s390x-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
+fi
+
+cp hello.c "${rootfs_cc}/hello.c"
+
+if $cross; then
+    # TODO: We do not have libc6-dev for cross compilation yet
+    :
+else
+    # compile
+    # NOTE: hardcode the triplet rather than deriving from $arch; uname -m
+    #       happens to match here (s390x) but not on all arches (e.g. ppc64le).
+    chroot "${rootfs_cc}" cc1 hello.c \
+        -o hello.s \
+        -Wno-implicit-function-declaration \
+        -I "/usr/include/s390x-linux-gnu" \
+        -I "/usr/include/linux"
+
+    # assemble
+    cp "${rootfs_cc}/hello.s" "${rootfs_as}/hello.s"
+    chroot "${rootfs_as}" as -o hello.o hello.s
+
+    # link
+    cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
+    chroot "${rootfs_ld}" ld -o hello hello.o \
+        -dynamic-linker "${linker_lib}" \
+        -lc \
+        /usr/lib/s390x-linux-gnu/crt1.o \
+        /usr/lib/s390x-linux-gnu/crti.o \
+        /usr/lib/s390x-linux-gnu/crtn.o
+
+    # run
+    chroot "${rootfs_ld}" /hello | grep -q "Hello, world!"
+fi

--- a/tests/spread/integration/cpp-13-s390x-linux-gnu/test_help.sh
+++ b/tests/spread/integration/cpp-13-s390x-linux-gnu/test_help.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "ppc64le" || "$arch" == "s390x" || "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "aarch64" ]]; then
+elif [[ "$arch" == "s390x" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-13-aarch64-linux-gnu_cc1 \
+    cpp-13-s390x-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/aarch64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/s390x-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/aarch64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/s390x-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 if $cross; then

--- a/tests/spread/integration/cpp-13-s390x-linux-gnu/test_preprocessor.sh
+++ b/tests/spread/integration/cpp-13-s390x-linux-gnu/test_preprocessor.sh
@@ -3,9 +3,9 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "x86_64" ]]; then
     cross=true
-elif [[ "$arch" == "x86_64" ]]; then
+elif [[ "$arch" == "s390x" ]]; then
     cross=false
 else
     echo "Unsupported architecture: $arch"
@@ -14,13 +14,13 @@ fi
 
 rootfs="$(install-slices \
     base-files_bin \
-    cpp-13-x86-64-linux-gnu_cc1 \
+    cpp-13-s390x-linux-gnu_cc1 \
 )"
 
 if $cross; then
-    ln -s "/usr/libexec/gcc-cross/x86_64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc-cross/s390x-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 else
-    ln -s "/usr/libexec/gcc/x86_64-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
+    ln -s "/usr/libexec/gcc/s390x-linux-gnu/13/cc1" "${rootfs}/usr/bin/cc1"
 fi
 
 cp question.c "${rootfs}/question.c"

--- a/tests/spread/integration/cpp-13-x86-64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-13-x86-64-linux-gnu/test_c_compiler.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
     cross=true
 elif [[ "$arch" == "x86_64" ]]; then
     cross=false

--- a/tests/spread/integration/cpp-13-x86-64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-13-x86-64-linux-gnu/test_c_compiler.sh
@@ -36,9 +36,6 @@ else
     ln -s "x86_64-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
 fi
 
-# NOTE: is this the correct linker path for cross compilation too?
-dynamic_linker="$(find "${rootfs_ld}" -type f -name "ld-linux-*.so.*" -printf "%P\n" -quit)"
-
 cp hello.c "${rootfs_cc}/hello.c"
 
 if $cross; then
@@ -58,8 +55,10 @@ else
 
     # link
     cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
     chroot "${rootfs_ld}" ld -o hello hello.o \
-        -dynamic-linker "$dynamic_linker" \
+        -dynamic-linker "${linker_lib}" \
         -lc \
         /usr/lib/"$arch"-linux-gnu/crt1.o \
         /usr/lib/"$arch"-linux-gnu/crti.o \

--- a/tests/spread/integration/cpp-13-x86-64-linux-gnu/test_help.sh
+++ b/tests/spread/integration/cpp-13-x86-64-linux-gnu/test_help.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "ppc64le" || "$arch" == "s390x" ]]; then
     cross=true
 elif [[ "$arch" == "x86_64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13-aarch64-linux-gnu/test_hello.sh
+++ b/tests/spread/integration/gcc-13-aarch64-linux-gnu/test_hello.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "x86_64" || "$arch" == "s390x" || "$arch" == "ppc64le" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13-aarch64-linux-gnu/test_print.sh
+++ b/tests/spread/integration/gcc-13-aarch64-linux-gnu/test_print.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "x86_64" || "$arch" == "s390x" || "$arch" == "ppc64le" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13-aarch64-linux-gnu/test_std.sh
+++ b/tests/spread/integration/gcc-13-aarch64-linux-gnu/test_std.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "x86_64" ]]; then
+if [[ "$arch" == "x86_64" || "$arch" == "s390x" || "$arch" == "ppc64le" ]]; then
     cross=true
 elif [[ "$arch" == "aarch64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/task.yaml
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for gcc-13-powerpc64le-linux-gnu
+
+variants:
+    - dump
+    - hello
+    - help_and_version
+    - print
+    - std
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_dump.sh
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_dump.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs dumpmachine dumpversion dumpspecs
+
+rootfs="$(install-slices gcc-13-powerpc64le-linux-gnu_gcc-13)"
+ln -s "powerpc64le-linux-gnu-gcc-13" "${rootfs}/usr/bin/gcc"
+
+dumpmachine=$(chroot "${rootfs}" gcc -dumpmachine)
+test "$dumpmachine" = "powerpc64le-linux-gnu"
+dumpversion=$(chroot "${rootfs}" gcc -dumpversion)
+test "$dumpversion" = "13"
+
+# shellcheck disable=SC2063
+dumpspecs=$(chroot "${rootfs}" gcc -dumpspecs | grep '^*' | tr '\n' ' ')
+expected_keys=("asm" "cc1" "cpp" "link" "lib")
+for key in "${expected_keys[@]}"; do
+    # shellcheck disable=SC2063
+    echo "$dumpspecs" | grep -q "*${key}:"
+done

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_hello.sh
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_hello.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" || "$arch" == "aarch64" || "$arch" == "s390x" ]]; then
+    cross=true
+elif [[ "$arch" == "ppc64le" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-13-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-13-powerpc64le-linux-gnu_gcc-13
+        cpp-13-powerpc64le-linux-gnu_cc1
+        binutils-powerpc64le-linux-gnu_assembler
+        binutils-powerpc64le-linux-gnu_linker
+        libgcc-13-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s powerpc64le-linux-gnu-gcc-13 "${rootfs}/usr/bin/gcc"
+    ln -s powerpc64le-linux-gnu-as "${rootfs}/usr/bin/as"
+    ln -s powerpc64le-linux-gnu-ld "${rootfs}/usr/bin/ld"
+
+    cp testfiles/hello.c "${rootfs}/hello.c"
+
+    chroot "${rootfs}" gcc /hello.c -o /hello
+    chroot "${rootfs}" /hello | grep -q "Hello from C!"
+fi

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_help_and_version.sh
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_help_and_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs
+
+rootfs="$(install-slices gcc-13-powerpc64le-linux-gnu_gcc-13)"
+ln -s "powerpc64le-linux-gnu-gcc-13" "${rootfs}/usr/bin/gcc"
+
+# something like: Usage: gcc [options] file...
+help=$(chroot "${rootfs}" gcc --help | head -n1)
+echo "$help" | grep -q "Usage: gcc"
+
+# something like: gcc (Ubuntu 13.2.0-19ubuntu2) 13.2.0
+version=$(chroot "${rootfs}" gcc --version | head -n1)
+echo "$version" | grep -q "gcc"
+echo "$version" | grep -q "13."

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_print.sh
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_print.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libgcc libexec libc multiarch
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" || "$arch" == "aarch64" || "$arch" == "s390x" ]]; then
+    cross=true
+elif [[ "$arch" == "ppc64le" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    gcc_dir="gcc-cross"
+    sysroot="/"
+else
+    gcc_dir="gcc"
+    sysroot=""
+fi
+
+rootfs="$(install-slices gcc-13-powerpc64le-linux-gnu_gcc-13)"
+ln -s "powerpc64le-linux-gnu-gcc-13" "${rootfs}/usr/bin/gcc"
+
+test "$(chroot "${rootfs}" gcc -print-search-dirs | head -n 1)" = "install: /usr/lib/$gcc_dir/powerpc64le-linux-gnu/13/"
+chroot "${rootfs}" gcc -print-search-dirs | head -n 2 | tail -n 1 | grep -q "/usr/libexec/$gcc_dir/powerpc64le-linux-gnu/13/"
+
+test "$(chroot "${rootfs}" gcc -print-libgcc-file-name)" = "libgcc.a"
+chroot "${rootfs}" gcc -print-file-name=libc.so.6 | grep -q "libc.so.6"
+
+# create a fake program called 'foo' in libexec dir to test -print-prog-name
+touch "${rootfs}/usr/libexec/$gcc_dir/powerpc64le-linux-gnu/13/foo"
+chmod +x "${rootfs}/usr/libexec/$gcc_dir/powerpc64le-linux-gnu/13/foo"
+
+chroot "${rootfs}" gcc -print-prog-name=foo
+test "$(chroot "${rootfs}" gcc -print-prog-name=foo)" = "/usr/libexec/$gcc_dir/powerpc64le-linux-gnu/13/foo"
+
+# we're not configured for multiple architectures
+test "$(chroot "${rootfs}" gcc -print-multiarch)" = "powerpc64le-linux-gnu"
+test "$(chroot "${rootfs}" gcc -print-multi-directory)" = "."
+chroot "${rootfs}" gcc -print-multi-lib # the output may vary. just run it
+test "$(chroot "${rootfs}" gcc -print-multi-os-directory)" = "../lib"
+
+test "$(chroot "${rootfs}" gcc -print-sysroot)" = "$sysroot"
+(chroot "${rootfs}" gcc -print-sysroot-headers-suffix 2>&1 || true) | grep -q "not configured with sysroot"

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_std.sh
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/test_std.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils libgcc libc
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" || "$arch" == "aarch64" || "$arch" == "s390x" ]]; then
+    cross=true
+elif [[ "$arch" == "ppc64le" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-13-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-13-powerpc64le-linux-gnu_gcc-13
+        cpp-13-powerpc64le-linux-gnu_cc1
+        binutils-powerpc64le-linux-gnu_assembler
+        binutils-powerpc64le-linux-gnu_linker
+        libgcc-13-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s powerpc64le-linux-gnu-gcc-13 "${rootfs}/usr/bin/gcc"
+    ln -s powerpc64le-linux-gnu-as "${rootfs}/usr/bin/as"
+    ln -s powerpc64le-linux-gnu-ld "${rootfs}/usr/bin/ld"
+
+    cp testfiles/test_std.c "${rootfs}/test_std.c"
+    cp testfiles/test_std.h "${rootfs}/test_std.h"
+
+    chroot "${rootfs}" gcc /test_std.c -o /test_std
+    chroot "${rootfs}" /test_std
+
+    # try again with a bunch of C standards
+    # for std in c99 c11 c17 c23; do
+    #     rm -f "${rootfs}/test_std"
+    #     chroot "${rootfs}" gcc -std="$std" -DSTD="$std" /test_std.c -o /test_std
+    #     chroot "${rootfs}" /test_std
+    # done
+fi

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/testfiles/hello.c
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/testfiles/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\n");
+    return 0;
+}

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/testfiles/test_std.c
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/testfiles/test_std.c
@@ -1,0 +1,223 @@
+#include "test_std.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <assert.h>
+#include <stdint.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdalign.h>
+#include <signal.h>
+
+
+int main() {
+    printf("Running basic standard library checks...\n");
+    TestCase tests[] = {
+        {"Arithmetic", check_arithmetic},
+        {"File I/O", check_file_io},
+        {"Concurrency", check_concurrency},
+        {"Memory", check_memory},
+        {"Time", check_time},
+        {"Environment Variables and Args", check_env},
+        {"Atomics", check_atomic},
+        {"Process Control", check_process_control},
+        {"Signals", check_signals},
+    };
+
+    int overall_result = 1;
+    for (int i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        TestResult result;
+        tests[i].test_func(&result);
+        if (result.passed) {
+            printf("Test %d (%s) passed\n", i + 1, tests[i].name);
+        } else {
+            printf("Test %d (%s) failed: %s\n", i + 1, tests[i].name, result.message);
+            overall_result = 0;
+        }
+    }
+
+    if (!overall_result) {
+        printf("Some tests failed.\n");
+        return 1;
+    } else {
+        printf("\nAll basic checks passed!\n");
+        return 0;
+    }
+}
+
+void check_arithmetic(TestResult* result) {
+    if (10 + 5 != 15) { result->passed = 0; result->message = "Integer addition failed"; return; }
+    if (10 - 5 != 5) { result->passed = 0; result->message = "Integer subtraction failed"; return; }
+    if (10 * 5 != 50) { result->passed = 0; result->message = "Integer multiplication failed"; return; }
+    if (10 / 5 != 2) { result->passed = 0; result->message = "Integer division failed"; return; }
+    if (10 % 3 != 1) { result->passed = 0; result->message = "Integer modulus failed"; return; }
+
+    double a = 10.0;
+    double b = 5.0;
+    if (a / b != 2.0) { result->passed = 0; result->message = "Floating point division failed"; return; }
+
+// we have infinity only in C23
+#ifdef INFINITY
+    double c = 1.0;
+    double d = 0.0;
+    if (!(c / d == INFINITY)) { result->passed = 0; result->message = "Division by zero did not yield infinity"; return; }
+#endif
+
+    result->passed = 1;
+    result->message = "Arithmetic tests passed";
+}
+
+void check_file_io(TestResult* result) {
+    const char* filename = "test_file.txt";
+    const char* test_data = "Hello from C file I/O!";
+    FILE* file = fopen(filename, "w");
+    if (!file) { result->passed = 0; result->message = "File creation failed"; return; }
+    if (fwrite(test_data, 1, strlen(test_data), file) != strlen(test_data)) {
+        fclose(file);
+        result->passed = 0; result->message = "File write failed"; return;
+    }
+    fclose(file);
+    file = fopen(filename, "r");
+    if (!file) { result->passed = 0; result->message = "File open failed"; return; }
+    char buffer[256];
+    size_t read_bytes = fread(buffer, 1, sizeof(buffer)-1, file);
+    if (read_bytes <= 0) {
+        fclose(file);
+        result->passed = 0; result->message = "File read failed"; return;
+    }
+    buffer[read_bytes] = '\0';
+    fclose(file);
+    if (strcmp(buffer, test_data) != 0) { result->passed = 0; result->message = "File contents do not match"; return; }
+    if (remove(filename) != 0) { result->passed = 0; result->message = "File removal failed"; return; }
+    result->passed = 1;
+    result->message = "File I/O tests passed";
+}
+
+void* thread_func(void* arg) {
+    int* counter = (int*)arg;
+    for (int i = 0; i < 100000; i++) {
+        __atomic_fetch_add(counter, 1, __ATOMIC_SEQ_CST);
+    }
+    return NULL;
+}
+
+void check_concurrency(TestResult* result) {
+    pthread_t threads[10];
+    int counter = 0;
+    for (int i = 0; i < 10; i++) {
+        if (pthread_create(&threads[i], NULL, thread_func, &counter) != 0) {
+            result->passed = 0; result->message = "Thread creation failed"; return;
+        }
+    }
+    for (int i = 0; i < 10; i++) {
+        if (pthread_join(threads[i], NULL) != 0) {
+            result->passed = 0; result->message = "Thread join failed"; return;
+        }
+    }
+    if (counter != 1000000) { result->passed = 0; result->message = "Counter value incorrect"; return; }
+    result->passed = 1;
+    result->message = "Concurrency tests passed";
+}
+
+void check_memory(TestResult* result) {
+    if (sizeof(int32_t) != 4) { result->passed = 0; result->message = "size_of::<int32_t>() failed"; return; }
+    if (sizeof(double) != 8) { result->passed = 0; result->message = "size_of::<double>() failed"; return; }
+    if (alignof(int32_t) != 4) { result->passed = 0; result->message = "align_of::<int32_t>() failed"; return; }
+    if (alignof(double) != 8) { result->passed = 0; result->message = "align_of::<double>() failed"; return; }
+
+    struct AlignedStruct {
+        char a;
+        int32_t b;
+    };
+    if (sizeof(struct AlignedStruct) != 8) { result->passed = 0; result->message = "size_of::<AlignedStruct>() failed"; return; }
+
+    result->passed = 1;
+    result->message = "Memory tests passed";
+}
+
+void check_time(TestResult* result) {
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    usleep(50000); // sleep for 50 milliseconds
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_nsec - start.tv_nsec) / 1000000;
+    if (elapsed_ms < 50) { result->passed = 0; result->message = "Sleep duration incorrect"; return; }
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    if (tv.tv_sec < 1700000000) { result->passed = 0; result->message = "System time is likely incorrect or too far in the past"; return; }
+
+    result->passed = 1;
+    result->message = "Time tests passed";
+}
+
+void check_env(TestResult* result) {
+    const char* test_key = "C_TEST_VAR";
+    const char* test_val = "c_test_value";
+    if (setenv(test_key, test_val, 1) != 0) { result->passed = 0; result->message = "Failed to set env var"; return; }
+    char* var_val = getenv(test_key);
+    if (!var_val || strcmp(var_val, test_val) != 0) { result->passed = 0; result->message = "Failed to get correct environment variable value"; return; }
+
+    int argc = 1;
+    char* argv[] = {"program_name", NULL};
+    if (argc < 1) { result->passed = 0; result->message = "Command line arguments check failed"; return; }
+
+    result->passed = 1;
+    result->message = "Environment tests passed";
+}
+
+void check_atomic(TestResult* result) {
+    atomic_int atomic_counter = 0;
+    atomic_fetch_add(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 1) { result->passed = 0; result->message = "Atomic increment failed"; return; }
+    atomic_fetch_sub(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 0) { result->passed = 0; result->message = "Atomic decrement failed"; return; }
+    result->passed = 1;
+    result->message = "Atomic tests passed";
+}
+
+void check_process_control(TestResult* result) {
+    pid_t pid = fork();
+    if (pid < 0) { result->passed = 0; result->message = "Fork failed"; return; }
+    if (pid == 0) {
+        // Child process
+        exit(42);
+    } else {
+        // Parent process
+        int status;
+        if (waitpid(pid, &status, 0) < 0) { result->passed = 0; result->message = "Waitpid failed"; return; }
+        if (WIFEXITED(status)) {
+            int exit_status = WEXITSTATUS(status);
+            if (exit_status != 42) { result->passed = 0; result->message = "Child exit status incorrect"; return; }
+        } else {
+            result->passed = 0; result->message = "Child did not exit normally"; return;
+        }
+    }
+    result->passed = 1;
+    result->message = "Process control tests passed";
+}
+
+void check_signals(TestResult* result) {
+    // Simple signal handling test
+    struct sigaction sa;
+    sa.sa_handler = SIG_IGN; // Ignore the signal
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGUSR1, &sa, NULL) != 0) { result->passed = 0; result->message = "Sigaction failed"; return; }
+
+    // Send the signal to self
+    if (raise(SIGUSR1) != 0) { result->passed = 0; result->message = "Raise signal failed"; return; }
+
+    result->passed = 1;
+    result->message = "Signal handling tests passed";
+}

--- a/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/testfiles/test_std.h
+++ b/tests/spread/integration/gcc-13-powerpc64le-linux-gnu/testfiles/test_std.h
@@ -1,0 +1,25 @@
+#ifndef TEST_STD_H
+#define TEST_STD_H
+
+typedef struct {
+    int passed;
+    const char* message;
+} TestResult;
+
+typedef struct {
+    const char* name;
+    void (*test_func)(TestResult* result);
+} TestCase;
+
+void check_arithmetic(TestResult* result);
+void check_file_io(TestResult* result);
+void* thread_func(void* arg);
+void check_concurrency(TestResult* result);
+void check_memory(TestResult* result);
+void check_time(TestResult* result);
+void check_env(TestResult* result);
+void check_atomic(TestResult* result);
+void check_process_control(TestResult* result);
+void check_signals(TestResult* result);
+
+#endif // TEST_STD_H

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/task.yaml
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/task.yaml
@@ -1,0 +1,10 @@
+summary: Integration tests for gcc-13-s390x-linux-gnu
+
+variants:
+    - dump
+    - hello
+    - help_and_version
+    - print
+    - std
+
+execute: bash -ex ./test_${SPREAD_VARIANT}.sh

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/test_dump.sh
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/test_dump.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs dumpmachine dumpversion dumpspecs
+
+rootfs="$(install-slices gcc-13-s390x-linux-gnu_gcc-13)"
+ln -s "s390x-linux-gnu-gcc-13" "${rootfs}/usr/bin/gcc"
+
+dumpmachine=$(chroot "${rootfs}" gcc -dumpmachine)
+test "$dumpmachine" = "s390x-linux-gnu"
+dumpversion=$(chroot "${rootfs}" gcc -dumpversion)
+test "$dumpversion" = "13"
+
+# shellcheck disable=SC2063
+dumpspecs=$(chroot "${rootfs}" gcc -dumpspecs | grep '^*' | tr '\n' ' ')
+expected_keys=("asm" "cc1" "cpp" "link" "lib")
+for key in "${expected_keys[@]}"; do
+    # shellcheck disable=SC2063
+    echo "$dumpspecs" | grep -q "*${key}:"
+done

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/test_hello.sh
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/test_hello.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" || "$arch" == "aarch64" || "$arch" == "ppc64le" ]]; then
+    cross=true
+elif [[ "$arch" == "s390x" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-13-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-13-s390x-linux-gnu_gcc-13
+        cpp-13-s390x-linux-gnu_cc1
+        binutils-s390x-linux-gnu_assembler
+        binutils-s390x-linux-gnu_linker
+        libgcc-13-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s s390x-linux-gnu-gcc-13 "${rootfs}/usr/bin/gcc"
+    ln -s s390x-linux-gnu-as "${rootfs}/usr/bin/as"
+    ln -s s390x-linux-gnu-ld "${rootfs}/usr/bin/ld"
+
+    cp testfiles/hello.c "${rootfs}/hello.c"
+
+    chroot "${rootfs}" gcc /hello.c -o /hello
+    chroot "${rootfs}" /hello | grep -q "Hello from C!"
+fi

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/test_help_and_version.sh
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/test_help_and_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs
+
+rootfs="$(install-slices gcc-13-s390x-linux-gnu_gcc-13)"
+ln -s "s390x-linux-gnu-gcc-13" "${rootfs}/usr/bin/gcc"
+
+# something like: Usage: gcc [options] file...
+help=$(chroot "${rootfs}" gcc --help | head -n1)
+echo "$help" | grep -q "Usage: gcc"
+
+# something like: gcc (Ubuntu 13.2.0-19ubuntu2) 13.2.0
+version=$(chroot "${rootfs}" gcc --version | head -n1)
+echo "$version" | grep -q "gcc"
+echo "$version" | grep -q "13."

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/test_print.sh
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/test_print.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs libgcc libexec libc multiarch
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" || "$arch" == "aarch64" || "$arch" == "ppc64le" ]]; then
+    cross=true
+elif [[ "$arch" == "s390x" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    gcc_dir="gcc-cross"
+    sysroot="/"
+else
+    gcc_dir="gcc"
+    sysroot=""
+fi
+
+rootfs="$(install-slices gcc-13-s390x-linux-gnu_gcc-13)"
+ln -s "s390x-linux-gnu-gcc-13" "${rootfs}/usr/bin/gcc"
+
+test "$(chroot "${rootfs}" gcc -print-search-dirs | head -n 1)" = "install: /usr/lib/$gcc_dir/s390x-linux-gnu/13/"
+chroot "${rootfs}" gcc -print-search-dirs | head -n 2 | tail -n 1 | grep -q "/usr/libexec/$gcc_dir/s390x-linux-gnu/13/"
+
+test "$(chroot "${rootfs}" gcc -print-libgcc-file-name)" = "libgcc.a"
+chroot "${rootfs}" gcc -print-file-name=libc.so.6 | grep -q "libc.so.6"
+
+# create a fake program called 'foo' in libexec dir to test -print-prog-name
+touch "${rootfs}/usr/libexec/$gcc_dir/s390x-linux-gnu/13/foo"
+chmod +x "${rootfs}/usr/libexec/$gcc_dir/s390x-linux-gnu/13/foo"
+
+chroot "${rootfs}" gcc -print-prog-name=foo
+test "$(chroot "${rootfs}" gcc -print-prog-name=foo)" = "/usr/libexec/$gcc_dir/s390x-linux-gnu/13/foo"
+
+# we're not configured for multiple architectures
+test "$(chroot "${rootfs}" gcc -print-multiarch)" = "s390x-linux-gnu"
+test "$(chroot "${rootfs}" gcc -print-multi-directory)" = "."
+chroot "${rootfs}" gcc -print-multi-lib # the output may vary. just run it
+test "$(chroot "${rootfs}" gcc -print-multi-os-directory)" = "../lib"
+
+test "$(chroot "${rootfs}" gcc -print-sysroot)" = "$sysroot"
+(chroot "${rootfs}" gcc -print-sysroot-headers-suffix 2>&1 || true) | grep -q "not configured with sysroot"

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/test_std.sh
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/test_std.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs binutils libgcc libc
+
+arch=$(uname -m)
+cross=false
+if [[ "$arch" == "x86_64" || "$arch" == "aarch64" || "$arch" == "ppc64le" ]]; then
+    cross=true
+elif [[ "$arch" == "s390x" ]]; then
+    cross=false
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+if $cross; then
+    # TODO: We do not have libgcc-13-dev-amd64-cross for cross compilation yet
+    :
+else
+    slices=(
+        gcc-13-s390x-linux-gnu_gcc-13
+        cpp-13-s390x-linux-gnu_cc1
+        binutils-s390x-linux-gnu_assembler
+        binutils-s390x-linux-gnu_linker
+        libgcc-13-dev_core
+        libc6-dev_core
+    )
+    rootfs="$(install-slices "${slices[@]}")"
+    ln -s s390x-linux-gnu-gcc-13 "${rootfs}/usr/bin/gcc"
+    ln -s s390x-linux-gnu-as "${rootfs}/usr/bin/as"
+    ln -s s390x-linux-gnu-ld "${rootfs}/usr/bin/ld"
+
+    cp testfiles/test_std.c "${rootfs}/test_std.c"
+    cp testfiles/test_std.h "${rootfs}/test_std.h"
+
+    chroot "${rootfs}" gcc /test_std.c -o /test_std
+    chroot "${rootfs}" /test_std
+
+    # try again with a bunch of C standards
+    # for std in c99 c11 c17 c23; do
+    #     rm -f "${rootfs}/test_std"
+    #     chroot "${rootfs}" gcc -std="$std" -DSTD="$std" /test_std.c -o /test_std
+    #     chroot "${rootfs}" /test_std
+    # done
+fi

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/testfiles/hello.c
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/testfiles/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\n");
+    return 0;
+}

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/testfiles/test_std.c
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/testfiles/test_std.c
@@ -1,0 +1,223 @@
+#include "test_std.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <assert.h>
+#include <stdint.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdalign.h>
+#include <signal.h>
+
+
+int main() {
+    printf("Running basic standard library checks...\n");
+    TestCase tests[] = {
+        {"Arithmetic", check_arithmetic},
+        {"File I/O", check_file_io},
+        {"Concurrency", check_concurrency},
+        {"Memory", check_memory},
+        {"Time", check_time},
+        {"Environment Variables and Args", check_env},
+        {"Atomics", check_atomic},
+        {"Process Control", check_process_control},
+        {"Signals", check_signals},
+    };
+
+    int overall_result = 1;
+    for (int i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        TestResult result;
+        tests[i].test_func(&result);
+        if (result.passed) {
+            printf("Test %d (%s) passed\n", i + 1, tests[i].name);
+        } else {
+            printf("Test %d (%s) failed: %s\n", i + 1, tests[i].name, result.message);
+            overall_result = 0;
+        }
+    }
+
+    if (!overall_result) {
+        printf("Some tests failed.\n");
+        return 1;
+    } else {
+        printf("\nAll basic checks passed!\n");
+        return 0;
+    }
+}
+
+void check_arithmetic(TestResult* result) {
+    if (10 + 5 != 15) { result->passed = 0; result->message = "Integer addition failed"; return; }
+    if (10 - 5 != 5) { result->passed = 0; result->message = "Integer subtraction failed"; return; }
+    if (10 * 5 != 50) { result->passed = 0; result->message = "Integer multiplication failed"; return; }
+    if (10 / 5 != 2) { result->passed = 0; result->message = "Integer division failed"; return; }
+    if (10 % 3 != 1) { result->passed = 0; result->message = "Integer modulus failed"; return; }
+
+    double a = 10.0;
+    double b = 5.0;
+    if (a / b != 2.0) { result->passed = 0; result->message = "Floating point division failed"; return; }
+
+// we have infinity only in C23
+#ifdef INFINITY
+    double c = 1.0;
+    double d = 0.0;
+    if (!(c / d == INFINITY)) { result->passed = 0; result->message = "Division by zero did not yield infinity"; return; }
+#endif
+
+    result->passed = 1;
+    result->message = "Arithmetic tests passed";
+}
+
+void check_file_io(TestResult* result) {
+    const char* filename = "test_file.txt";
+    const char* test_data = "Hello from C file I/O!";
+    FILE* file = fopen(filename, "w");
+    if (!file) { result->passed = 0; result->message = "File creation failed"; return; }
+    if (fwrite(test_data, 1, strlen(test_data), file) != strlen(test_data)) {
+        fclose(file);
+        result->passed = 0; result->message = "File write failed"; return;
+    }
+    fclose(file);
+    file = fopen(filename, "r");
+    if (!file) { result->passed = 0; result->message = "File open failed"; return; }
+    char buffer[256];
+    size_t read_bytes = fread(buffer, 1, sizeof(buffer)-1, file);
+    if (read_bytes <= 0) {
+        fclose(file);
+        result->passed = 0; result->message = "File read failed"; return;
+    }
+    buffer[read_bytes] = '\0';
+    fclose(file);
+    if (strcmp(buffer, test_data) != 0) { result->passed = 0; result->message = "File contents do not match"; return; }
+    if (remove(filename) != 0) { result->passed = 0; result->message = "File removal failed"; return; }
+    result->passed = 1;
+    result->message = "File I/O tests passed";
+}
+
+void* thread_func(void* arg) {
+    int* counter = (int*)arg;
+    for (int i = 0; i < 100000; i++) {
+        __atomic_fetch_add(counter, 1, __ATOMIC_SEQ_CST);
+    }
+    return NULL;
+}
+
+void check_concurrency(TestResult* result) {
+    pthread_t threads[10];
+    int counter = 0;
+    for (int i = 0; i < 10; i++) {
+        if (pthread_create(&threads[i], NULL, thread_func, &counter) != 0) {
+            result->passed = 0; result->message = "Thread creation failed"; return;
+        }
+    }
+    for (int i = 0; i < 10; i++) {
+        if (pthread_join(threads[i], NULL) != 0) {
+            result->passed = 0; result->message = "Thread join failed"; return;
+        }
+    }
+    if (counter != 1000000) { result->passed = 0; result->message = "Counter value incorrect"; return; }
+    result->passed = 1;
+    result->message = "Concurrency tests passed";
+}
+
+void check_memory(TestResult* result) {
+    if (sizeof(int32_t) != 4) { result->passed = 0; result->message = "size_of::<int32_t>() failed"; return; }
+    if (sizeof(double) != 8) { result->passed = 0; result->message = "size_of::<double>() failed"; return; }
+    if (alignof(int32_t) != 4) { result->passed = 0; result->message = "align_of::<int32_t>() failed"; return; }
+    if (alignof(double) != 8) { result->passed = 0; result->message = "align_of::<double>() failed"; return; }
+
+    struct AlignedStruct {
+        char a;
+        int32_t b;
+    };
+    if (sizeof(struct AlignedStruct) != 8) { result->passed = 0; result->message = "size_of::<AlignedStruct>() failed"; return; }
+
+    result->passed = 1;
+    result->message = "Memory tests passed";
+}
+
+void check_time(TestResult* result) {
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    usleep(50000); // sleep for 50 milliseconds
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_nsec - start.tv_nsec) / 1000000;
+    if (elapsed_ms < 50) { result->passed = 0; result->message = "Sleep duration incorrect"; return; }
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    if (tv.tv_sec < 1700000000) { result->passed = 0; result->message = "System time is likely incorrect or too far in the past"; return; }
+
+    result->passed = 1;
+    result->message = "Time tests passed";
+}
+
+void check_env(TestResult* result) {
+    const char* test_key = "C_TEST_VAR";
+    const char* test_val = "c_test_value";
+    if (setenv(test_key, test_val, 1) != 0) { result->passed = 0; result->message = "Failed to set env var"; return; }
+    char* var_val = getenv(test_key);
+    if (!var_val || strcmp(var_val, test_val) != 0) { result->passed = 0; result->message = "Failed to get correct environment variable value"; return; }
+
+    int argc = 1;
+    char* argv[] = {"program_name", NULL};
+    if (argc < 1) { result->passed = 0; result->message = "Command line arguments check failed"; return; }
+
+    result->passed = 1;
+    result->message = "Environment tests passed";
+}
+
+void check_atomic(TestResult* result) {
+    atomic_int atomic_counter = 0;
+    atomic_fetch_add(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 1) { result->passed = 0; result->message = "Atomic increment failed"; return; }
+    atomic_fetch_sub(&atomic_counter, 1);
+    if (atomic_load(&atomic_counter) != 0) { result->passed = 0; result->message = "Atomic decrement failed"; return; }
+    result->passed = 1;
+    result->message = "Atomic tests passed";
+}
+
+void check_process_control(TestResult* result) {
+    pid_t pid = fork();
+    if (pid < 0) { result->passed = 0; result->message = "Fork failed"; return; }
+    if (pid == 0) {
+        // Child process
+        exit(42);
+    } else {
+        // Parent process
+        int status;
+        if (waitpid(pid, &status, 0) < 0) { result->passed = 0; result->message = "Waitpid failed"; return; }
+        if (WIFEXITED(status)) {
+            int exit_status = WEXITSTATUS(status);
+            if (exit_status != 42) { result->passed = 0; result->message = "Child exit status incorrect"; return; }
+        } else {
+            result->passed = 0; result->message = "Child did not exit normally"; return;
+        }
+    }
+    result->passed = 1;
+    result->message = "Process control tests passed";
+}
+
+void check_signals(TestResult* result) {
+    // Simple signal handling test
+    struct sigaction sa;
+    sa.sa_handler = SIG_IGN; // Ignore the signal
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGUSR1, &sa, NULL) != 0) { result->passed = 0; result->message = "Sigaction failed"; return; }
+
+    // Send the signal to self
+    if (raise(SIGUSR1) != 0) { result->passed = 0; result->message = "Raise signal failed"; return; }
+
+    result->passed = 1;
+    result->message = "Signal handling tests passed";
+}

--- a/tests/spread/integration/gcc-13-s390x-linux-gnu/testfiles/test_std.h
+++ b/tests/spread/integration/gcc-13-s390x-linux-gnu/testfiles/test_std.h
@@ -1,0 +1,25 @@
+#ifndef TEST_STD_H
+#define TEST_STD_H
+
+typedef struct {
+    int passed;
+    const char* message;
+} TestResult;
+
+typedef struct {
+    const char* name;
+    void (*test_func)(TestResult* result);
+} TestCase;
+
+void check_arithmetic(TestResult* result);
+void check_file_io(TestResult* result);
+void* thread_func(void* arg);
+void check_concurrency(TestResult* result);
+void check_memory(TestResult* result);
+void check_time(TestResult* result);
+void check_env(TestResult* result);
+void check_atomic(TestResult* result);
+void check_process_control(TestResult* result);
+void check_signals(TestResult* result);
+
+#endif // TEST_STD_H

--- a/tests/spread/integration/gcc-13-x86-64-linux-gnu/test_hello.sh
+++ b/tests/spread/integration/gcc-13-x86-64-linux-gnu/test_hello.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "ppc64le" ]]; then
     cross=true
 elif [[ "$arch" == "x86_64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13-x86-64-linux-gnu/test_print.sh
+++ b/tests/spread/integration/gcc-13-x86-64-linux-gnu/test_print.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "ppc64le" ]]; then
     cross=true
 elif [[ "$arch" == "x86_64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13-x86-64-linux-gnu/test_std.sh
+++ b/tests/spread/integration/gcc-13-x86-64-linux-gnu/test_std.sh
@@ -3,7 +3,7 @@
 
 arch=$(uname -m)
 cross=false
-if [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" || "$arch" == "s390x" || "$arch" == "ppc64le" ]]; then
     cross=true
 elif [[ "$arch" == "x86_64" ]]; then
     cross=false

--- a/tests/spread/integration/gcc-13/test_hello.sh
+++ b/tests/spread/integration/gcc-13/test_hello.sh
@@ -1,19 +1,9 @@
-# TODO: remove the --arch and the ${arch} logic once
-# canonical/chisel #256 is merged.
+rootfs="$(install-slices gcc-13_gcc-13 libc6-dev_libs)"
+
 arch=$(uname -m)
 arch="${arch//_/-}"
+[ "${arch}" = "ppc64le" ] && arch="powerpc64le"
 arch_triplet="${arch}-linux-gnu"
-
-if [ "${arch}" = "aarch64" ]; then
-chisel_arch="arm64"
-elif [ "${arch}" = "x86-64" ]; then
-chisel_arch="amd64"
-else
-echo "Unsupported architecture: ${arch}"
-exit 1
-fi
-
-rootfs="$(install-slices --arch "${chisel_arch}" gcc-13_gcc-13 libc6-dev_libs)"
 
 cp ../gcc-13-${arch_triplet}/testfiles/hello.c "${rootfs}/hello.c"
 


### PR DESCRIPTION
# Proposed changes

forward port of the `gcc` half of #1092. this brings gcc-13 level with gcc-15 on 26.04.

## Related issues/PRs

- https://github.com/canonical/chisel-releases/issues/1050
- https://github.com/canonical/chisel-releases/pull/1131
- https://github.com/canonical/chisel-releases/pull/1132

### Forward porting

part of:

- https://github.com/canonical/chisel-releases/pull/1091
  - https://github.com/canonical/chisel-releases/pull/1092
- https://github.com/canonical/chisel-releases/pull/1127
  - https://github.com/canonical/chisel-releases/pull/1130 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1133
  - https://github.com/canonical/chisel-releases/pull/1134

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)