### PR TITLE
fix(26.04): dangling `gcc-15` copyright on cross arches

### DIFF
--- a/slices/cpp-15-aarch64-linux-gnu.yaml
+++ b/slices/cpp-15-aarch64-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
+      gcc-15-base_copyright: {arch: [arm64]}
     contents:
-      /usr/share/doc/cpp-15-aarch64-linux-gnu:
+      /usr/share/doc/cpp-15-aarch64-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/cpp-15-powerpc64le-linux-gnu.yaml
+++ b/slices/cpp-15-powerpc64le-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-base_copyright: {arch: [ppc64el]}
+      gcc-15-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
     contents:
-      /usr/share/doc/cpp-15-powerpc64le-linux-gnu:  # Symlink to gcc-15-base
+      /usr/share/doc/cpp-15-powerpc64le-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/cpp-15-s390x-linux-gnu.yaml
+++ b/slices/cpp-15-s390x-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-base_copyright: {arch: [s390x]}
+      gcc-15-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
     contents:
-      /usr/share/doc/cpp-15-s390x-linux-gnu:  # Symlink to gcc-15-base
+      /usr/share/doc/cpp-15-s390x-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/cpp-15-x86-64-linux-gnu.yaml
+++ b/slices/cpp-15-x86-64-linux-gnu.yaml
@@ -22,6 +22,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-base_copyright: {arch: [amd64]}
+      gcc-15-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
-      /usr/share/doc/cpp-15-x86-64-linux-gnu:
+      /usr/share/doc/cpp-15-x86-64-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/gcc-15-aarch64-linux-gnu-base.yaml
+++ b/slices/gcc-15-aarch64-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-15-aarch64-linux-gnu-base
+
+essential:
+  gcc-15-aarch64-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-15-aarch64-linux-gnu-base/copyright:

--- a/slices/gcc-15-aarch64-linux-gnu.yaml
+++ b/slices/gcc-15-aarch64-linux-gnu.yaml
@@ -27,6 +27,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-aarch64-linux-gnu-base_copyright: {arch: [amd64, i386, ppc64el, s390x]}
+      gcc-15-base_copyright: {arch: [arm64]}
     contents:
-      /usr/share/doc/gcc-15-aarch64-linux-gnu:
+      /usr/share/doc/gcc-15-aarch64-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/gcc-15-powerpc64le-linux-gnu-base.yaml
+++ b/slices/gcc-15-powerpc64le-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-15-powerpc64le-linux-gnu-base
+
+essential:
+  gcc-15-powerpc64le-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-15-powerpc64le-linux-gnu-base/copyright:

--- a/slices/gcc-15-powerpc64le-linux-gnu.yaml
+++ b/slices/gcc-15-powerpc64le-linux-gnu.yaml
@@ -27,6 +27,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-base_copyright: {arch: [ppc64el]}
+      gcc-15-powerpc64le-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, s390x]}
     contents:
-      /usr/share/doc/gcc-15-powerpc64le-linux-gnu:
+      /usr/share/doc/gcc-15-powerpc64le-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/gcc-15-s390x-linux-gnu-base.yaml
+++ b/slices/gcc-15-s390x-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-15-s390x-linux-gnu-base
+
+essential:
+  gcc-15-s390x-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-15-s390x-linux-gnu-base/copyright:

--- a/slices/gcc-15-s390x-linux-gnu.yaml
+++ b/slices/gcc-15-s390x-linux-gnu.yaml
@@ -27,6 +27,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-base_copyright: {arch: [s390x]}
+      gcc-15-s390x-linux-gnu-base_copyright: {arch: [amd64, arm64, i386, ppc64el]}
     contents:
-      /usr/share/doc/gcc-15-s390x-linux-gnu:
+      /usr/share/doc/gcc-15-s390x-linux-gnu:  # Symlink to a gcc-15 base package

--- a/slices/gcc-15-x86-64-linux-gnu-base.yaml
+++ b/slices/gcc-15-x86-64-linux-gnu-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-15-x86-64-linux-gnu-base
+
+essential:
+  gcc-15-x86-64-linux-gnu-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-15-x86-64-linux-gnu-base/copyright:

--- a/slices/gcc-15-x86-64-linux-gnu.yaml
+++ b/slices/gcc-15-x86-64-linux-gnu.yaml
@@ -27,6 +27,7 @@ slices:
 
   copyright:
     essential:
-      gcc-15-base_copyright:
+      gcc-15-base_copyright: {arch: [amd64]}
+      gcc-15-x86-64-linux-gnu-base_copyright: {arch: [arm64, i386, ppc64el, s390x]}
     contents:
-      /usr/share/doc/gcc-15-x86-64-linux-gnu:
+      /usr/share/doc/gcc-15-x86-64-linux-gnu:  # Symlink to a gcc-15 base package

--- a/tests/spread/integration/cpp-15-aarch64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-15-aarch64-linux-gnu/test_c_compiler.sh
@@ -36,9 +36,6 @@ else
     ln -s "aarch64-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
 fi
 
-# NOTE: is this the correct linker path for cross compilation too?
-dynamic_linker="$(find "${rootfs_ld}" -type f -name "ld-linux-*.so.*" -printf "%P\n" -quit)"
-
 cp hello.c "${rootfs_cc}/hello.c"
 
 if $cross; then
@@ -58,8 +55,10 @@ else
 
     # link
     cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
     chroot "${rootfs_ld}" ld -o hello hello.o \
-        -dynamic-linker "$dynamic_linker" \
+        -dynamic-linker "${linker_lib}" \
         -lc \
         /usr/lib/"$arch"-linux-gnu/crt1.o \
         /usr/lib/"$arch"-linux-gnu/crti.o \

--- a/tests/spread/integration/cpp-15-x86-64-linux-gnu/test_c_compiler.sh
+++ b/tests/spread/integration/cpp-15-x86-64-linux-gnu/test_c_compiler.sh
@@ -36,9 +36,6 @@ else
     ln -s "x86_64-linux-gnu-ld" "${rootfs_ld}/usr/bin/ld"
 fi
 
-# NOTE: is this the correct linker path for cross compilation too?
-dynamic_linker="$(find "${rootfs_ld}" -type f -name "ld-linux-*.so.*" -printf "%P\n" -quit)"
-
 cp hello.c "${rootfs_cc}/hello.c"
 
 if $cross; then
@@ -58,8 +55,10 @@ else
 
     # link
     cp "${rootfs_as}/hello.o" "${rootfs_ld}/hello.o"
+    linker_lib="$(ls "${rootfs_ld}"/usr/lib*/ld*.so*)"
+    linker_lib=${linker_lib#"$rootfs_ld"}
     chroot "${rootfs_ld}" ld -o hello hello.o \
-        -dynamic-linker "$dynamic_linker" \
+        -dynamic-linker "${linker_lib}" \
         -lc \
         /usr/lib/"$arch"-linux-gnu/crt1.o \
         /usr/lib/"$arch"-linux-gnu/crti.o \


### PR DESCRIPTION
# Proposed changes

fixes https://github.com/canonical/chisel-releases/issues/1050 for 26.04's gcc-15

## Related issues/PRs

- https://github.com/canonical/chisel-releases/issues/1050
- https://github.com/canonical/chisel-releases/pull/1130
- https://github.com/canonical/chisel-releases/pull/1131

### Forward porting

part of:

- https://github.com/canonical/chisel-releases/pull/1129
  - https://github.com/canonical/chisel-releases/pull/1132 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1137
  - https://github.com/canonical/chisel-releases/pull/1138

## Checklist

* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement)