### PR TITLE
feat(26.10): add libpython3.14 slices

### DIFF
--- a/slices/libpython3.14.yaml
+++ b/slices/libpython3.14.yaml
@@ -1,0 +1,21 @@
+package: libpython3.14
+
+essential:
+  libpython3.14_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libexpat1_libs:
+      libpython3.14-stdlib_core:
+      zlib1g_libs:
+    contents:
+      /usr/lib/*-linux-*/libpython3.14.so.1:
+      /usr/lib/*-linux-*/libpython3.14.so.1.0:
+
+  copyright:
+    essential:
+      libpython3.14-stdlib_copyright:
+    contents:
+      /usr/share/doc/libpython3.14:  # Symlink to libpython3.14-stdlib

--- a/tests/spread/integration/libpython3.14/task.yaml
+++ b/tests/spread/integration/libpython3.14/task.yaml
@@ -2,7 +2,9 @@ summary: Integration tests for libpython3.14
 
 execute: |
   rootfs="$(install-slices libpython3.14_libs)"
-  arch=$(uname -m)-linux-gnu
+
+  apt install -y gcc
+  arch=$(gcc -dumpmachine)
 
   # The shared Python runtime library and its soname symlink.
   test -f "${rootfs}/usr/lib/${arch}/libpython3.14.so.1.0"

--- a/tests/spread/integration/libpython3.14/task.yaml
+++ b/tests/spread/integration/libpython3.14/task.yaml
@@ -1,0 +1,13 @@
+summary: Integration tests for libpython3.14
+
+execute: |
+  rootfs="$(install-slices libpython3.14_libs)"
+  arch=$(uname -m)-linux-gnu
+
+  # The shared Python runtime library and its soname symlink.
+  test -f "${rootfs}/usr/lib/${arch}/libpython3.14.so.1.0"
+  test -L "${rootfs}/usr/lib/${arch}/libpython3.14.so.1"
+  [[ "$(readlink "${rootfs}/usr/lib/${arch}/libpython3.14.so.1")" == "libpython3.14.so.1.0" ]]
+
+  # libpython3.14.so.1.0 must be a loadable ELF shared object.
+  [[ "$(head -c4 "${rootfs}/usr/lib/${arch}/libpython3.14.so.1.0" | od -An -tx1 | tr -d ' \n')" == "7f454c46" ]]


### PR DESCRIPTION
# Proposed changes

Forward port of #1139.

Add slice definitions for `libpython3.14` on `ubuntu-26.10`. This package ships the shared Python runtime library (`libpython3.14.so.1.0`) and its soname symlink.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `libpython3.14` | `libs`, `copyright` | Shared Python runtime library; doc dir is a symlink to `libpython3.14-stdlib` |

### Forward porting
Forward port of #1139

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->