### PR TITLE
fix(26.04): util-linux no longer needs liblastlog

### DIFF
--- a/slices/util-linux.yaml
+++ b/slices/util-linux.yaml
@@ -147,8 +147,6 @@ slices:
       libc6_libs:
       libcrypt1_libs:
       libselinux1_libs:
-      libsmartcols1_libs:
-      libsystemd0_libs:
     contents:
       /usr/sbin/sulogin:
 

--- a/slices/util-linux.yaml
+++ b/slices/util-linux.yaml
@@ -146,7 +146,6 @@ slices:
     essential:
       libc6_libs:
       libcrypt1_libs:
-      liblastlog2-2_libs:
       libselinux1_libs:
       libsmartcols1_libs:
       libsystemd0_libs:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

Removed unneeded dependency from `util-linux_login`.

**IMPORTANT NOTE**: this is an interesting case where the opening of a new release carried a change that cause orphaned dependencies. In https://github.com/canonical/chisel-releases/pull/662, @lengau introduced a missing dependency to `util-linux`, that was needed for the `lslogins` binary. 

In 26.04, that binary is no longer in the pkg and consequently no longer in the `util-linux_login` slice. **However**, the `liblastlog2-2` is left over from https://github.com/canonical/chisel-releases/pull/662, and is getting unnecessarily installed. That's not good, cause it goes against what we try to do with Chisel -> _remove everything that is unnecessary_

I noticed this because `liblastlog2-2` brings in sqlite3 libs too, which completely caught me off guard. 

So what's the takeaway? We're doing a good job at detecting and testing dependencies that are missing, and we don't do enough checks to ensure that we are not shipping unnecessary. `lslogins` was removed in https://github.com/canonical/chisel-releases/pull/857/changes#diff-19d63239e73ac43045433aa7c62758e215be4782ad63accaec2435ddaf8254d0L156. The CI that list the dependency diff did NOT run in https://github.com/canonical/chisel-releases/pull/857, unfortunately. That would have (hopefully) said that there was an unnecessary dependency. BUT, even with that, it would have just been an informative comment, while IMO this should've been a CI error. @lczyk can you pls ACK, weigh in, and if agreeing, create a candidate roadmap item for us to tackle this in future releases?


## Related issues/PRs
<!-- If any -->

https://github.com/canonical/chisel-releases/pull/662

### Forward porting
<!-- This change MUST also be proposed to all newer, and still supported,
releases. List the corresponding PRs, or ignore if not applicable. -->

https://github.com/canonical/chisel-releases/pull/1146

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
