### PR TITLE
fix(26.10): move defaults to gcc-16

### DIFF
--- a/slices/gcc-16-base.yaml
+++ b/slices/gcc-16-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-16-base
+
+essential:
+  gcc-16-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-16-base/copyright:

--- a/slices/libasan8.yaml
+++ b/slices/libasan8.yaml
@@ -12,6 +12,6 @@ slices:
       /usr/lib/*-linux-*/libasan.so.8*:
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libasan8:

--- a/slices/libatomic1.yaml
+++ b/slices/libatomic1.yaml
@@ -12,6 +12,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libatomic1:

--- a/slices/libgcc-s1.yaml
+++ b/slices/libgcc-s1.yaml
@@ -12,6 +12,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libgcc-s1:

--- a/slices/libgomp1.yaml
+++ b/slices/libgomp1.yaml
@@ -12,6 +12,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libgomp1:

--- a/slices/libstdc++6.yaml
+++ b/slices/libstdc++6.yaml
@@ -13,6 +13,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libstdc++6:

--- a/slices/libubsan1.yaml
+++ b/slices/libubsan1.yaml
@@ -14,6 +14,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libubsan1:


### PR DESCRIPTION
# Proposed changes
<!-- Describe the changes proposed in this PR.

Provide good PR descriptions as the project maintainers aren't necessarily
familiar with the packages you are slicing.

We use conventional commits
(https://www.conventionalcommits.org/en/v1.0.0/#specification), so if not yet
specified in your commit messages, make sure you describe the type of change
being proposed in this PR (i.e. feat, test, fix, ci, chore, docs).
-->

Move gcc-#-base dependency defaults to gcc-16.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
