### PR TITLE
fix(26.04): move defaults to gcc-16

### DIFF
--- a/slices/gcc-16-base.yaml
+++ b/slices/gcc-16-base.yaml
@@ -1,0 +1,9 @@
+package: gcc-16-base
+
+essential:
+  gcc-16-base_copyright:
+
+slices:
+  copyright:
+    contents:
+      /usr/share/doc/gcc-16-base/copyright:

--- a/slices/libasan8.yaml
+++ b/slices/libasan8.yaml
@@ -12,6 +12,6 @@ slices:
       /usr/lib/*-linux-*/libasan.so.8*:
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libasan8:

--- a/slices/libatomic1.yaml
+++ b/slices/libatomic1.yaml
@@ -12,6 +12,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libatomic1:

--- a/slices/libgcc-s1.yaml
+++ b/slices/libgcc-s1.yaml
@@ -12,6 +12,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libgcc-s1:

--- a/slices/libgomp1.yaml
+++ b/slices/libgomp1.yaml
@@ -12,6 +12,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libgomp1:

--- a/slices/libstdc++6.yaml
+++ b/slices/libstdc++6.yaml
@@ -13,6 +13,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libstdc++6:

--- a/slices/libubsan1.yaml
+++ b/slices/libubsan1.yaml
@@ -14,6 +14,6 @@ slices:
 
   copyright:
     essential:
-      gcc-14-base_copyright:
+      gcc-16-base_copyright:
     contents:
       /usr/share/doc/libubsan1:


### PR DESCRIPTION
Backport of https://github.com/canonical/chisel-releases/pull/1148