### PR TITLE
docs(22.04): agent guidance for release branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,14 +3,13 @@
 ## Repository rules
 
 - **BRANCH STRUCTURE:**
-   - `main` is meta-only (reusable CI workflows, CI scripts and their tests, and docs) - there are no slice definitions in `main`.
-   - `ubuntu-XX.XX` branches (like this one) hold [Chisel](https://github.com/canonical/chisel) releases (`chisel.yaml`, Slice Definition Files (aka SDFs) under `slices/`, [Spread](https://github.com/canonical/spread) tests under `tests/spread/`).
-   - Write and modify SDFs and Spread tests on a checkout of the target `ubuntu-XX.XX` release branch. `slices/`, `tests/spread/`, and `chisel.yaml` never land on `main`.
+   - `main` is meta-only (reusable CI workflows, CI scripts and their tests, and docs) - there are no slice definitions in `main`
+   - `ubuntu-XX.XX` branches (like this one) hold [Chisel](https://github.com/canonical/chisel) releases (`chisel.yaml`, Slice Definition Files (aka SDFs) under `slices/`, [Spread](https://github.com/canonical/spread) tests under `tests/spread/`)
 
 ## Working on `ubuntu-XX.XX`
 
 ### CI / Workflow rules
 
-- **THIN CALLERS:** the workflows under `.github/workflows/` -- `ci.yaml` and `ci-pr-target.yaml` -- are thin callers of the reusable workflows on `main`, so CI logic changes belong on `main`, not here.
-- **SPREAD:** `spread.yaml` is the Spread project configuration.
-- **LINTING:** YAML is linted with `yamllint`, configured with `.github/yamllint.yaml` from `main`.
+- **THIN CALLERS:** The workflows under `.github/workflows/` -- `ci.yaml` and `ci-pr-target.yaml` -- are thin callers of the reusable workflows on `main`, so CI logic changes belong on `main`, not here
+- **SPREAD**: `spread.yaml` is the Spread project configuration
+- **LINTING**: YAML is linted with `yamllint`, configured with `.github/yamllint.yaml` from `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,22 +2,8 @@
 
 Guidance for coding agents working on this Chisel release branch.
 
+Guidance for contributors can be found at [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md). on `main`.
+
 ## Repository layout
 
-This repository is organised by git branch: `main` is meta-only (CI and contributor documentation), and every branch named `ubuntu-XX.XX` -- like this one -- is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.
-
-## Full guidance
-
-Full guidance for working on a Chisel release branch lives on the `main` branch, in [AGENTS-release.md](https://github.com/canonical/chisel-releases/blob/main/AGENTS-release.md). ALWAYS read it. The fetch below matches the remote by URL rather than by name:
-
-```bash
-git show "$(git remote -v | awk '/canonical\/chisel-releases/{print $1; exit}')/main:AGENTS-release.md"
-```
-
-or, if that fails:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/canonical/chisel-releases/main/AGENTS-release.md
-```
-
-If you cannot read it, say so and stop rather than guessing at conventions.
+This repository is organised by git branch: `main` is meta-only (reusable CI workflows, CI scripts and their tests, and contributor documentation -- there are no slice definitions there), and every branch named `ubuntu-XX.XX` -- like this one -- is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # AGENTS.md
 
-Guidance for coding agents working on this Chisel release branch.
-
-Guidance for contributors can be found at [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md) on `main`.
-
-## Repository layout
-
-This repository is organised by git branch: `main` is meta-only (reusable CI workflows, CI scripts and their tests, and contributor documentation -- there are no slice definitions there), and every branch named `ubuntu-XX.XX` -- like this one -- is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.
+- Contributor documentation is [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md) on `main`.
+- `main` is meta-only. It contains reusable CI workflows, CI scripts and their tests, and contributor documentation.
+- Every branch named `ubuntu-XX.XX` (like this one) is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). SDFs and spread tests are written and modified on a checkout of the target `ubuntu-XX.XX` release branch; `slices/`, `tests/spread/`, and `chisel.yaml` never land on `main`.
+- The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.
+- Workflows under `.github/workflows/` -- `ci.yaml` and `ci-pr-target.yaml` -- are thin callers of the reusable workflows on `main`.
+- YAML is linted with `yamllint`, configured with `.github/yamllint.yaml` from `main`.
+- `essential` and `contents` keys of every slice are sorted with `LC_ALL=C sort`.
+- A slice added to one release usually needs forward porting to any later *maintained* `ubuntu-XX.XX` releases.
+- `spread.yaml` is the spread project configuration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-- Contributor documentation is [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md) on `main`.
+- Contributor documentation is in [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md) on `main`.
 - `main` is meta-only. It contains reusable CI workflows, CI scripts and their tests, and contributor documentation.
 - Every branch named `ubuntu-XX.XX` (like this one) is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). SDFs and spread tests are written and modified on a checkout of the target `ubuntu-XX.XX` release branch; `slices/`, `tests/spread/`, and `chisel.yaml` never land on `main`.
 - The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Guidance for coding agents working on this Chisel release branch.
+
+## Repository layout
+
+This repository is organised by git branch: `main` is meta-only (CI and contributor documentation), and every branch named `ubuntu-XX.XX` -- like this one -- is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.
+
+## Full guidance
+
+Full guidance for working on a Chisel release branch lives on the `main` branch, in [AGENTS-release.md](https://github.com/canonical/chisel-releases/blob/main/AGENTS-release.md). ALWAYS read it. The fetch below matches the remote by URL rather than by name:
+
+```bash
+git show "$(git remote -v | awk '/canonical\/chisel-releases/{print $1; exit}')/main:AGENTS-release.md"
+```
+
+or, if that fails:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/canonical/chisel-releases/main/AGENTS-release.md
+```
+
+If you cannot read it, say so and stop rather than guessing at conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,16 @@
 # AGENTS.md
 
-- Contributor documentation is in [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md) on `main`.
-- `main` is meta-only. It contains reusable CI workflows, CI scripts and their tests, and contributor documentation.
-- Every branch named `ubuntu-XX.XX` (like this one) is one [Chisel](https://github.com/canonical/chisel) release, holding the release manifest (`chisel.yaml`), the Slice Definition Files (SDFs, `slices/`), and their [spread](https://github.com/canonical/spread) tests (`tests/spread/`). SDFs and spread tests are written and modified on a checkout of the target `ubuntu-XX.XX` release branch; `slices/`, `tests/spread/`, and `chisel.yaml` never land on `main`.
-- The upstream repository is [`canonical/chisel-releases`](https://github.com/canonical/chisel-releases), but this clone may be of a fork.
-- Workflows under `.github/workflows/` -- `ci.yaml` and `ci-pr-target.yaml` -- are thin callers of the reusable workflows on `main`.
-- YAML is linted with `yamllint`, configured with `.github/yamllint.yaml` from `main`.
-- `essential` and `contents` keys of every slice are sorted with `LC_ALL=C sort`.
-- A slice added to one release usually needs forward porting to any later *maintained* `ubuntu-XX.XX` releases.
-- `spread.yaml` is the spread project configuration.
+## Repository rules
+
+- **BRANCH STRUCTURE:**
+   - `main` is meta-only (reusable CI workflows, CI scripts and their tests, and docs) - there are no slice definitions in `main`.
+   - `ubuntu-XX.XX` branches (like this one) hold [Chisel](https://github.com/canonical/chisel) releases (`chisel.yaml`, Slice Definition Files (aka SDFs) under `slices/`, [Spread](https://github.com/canonical/spread) tests under `tests/spread/`).
+   - Write and modify SDFs and Spread tests on a checkout of the target `ubuntu-XX.XX` release branch. `slices/`, `tests/spread/`, and `chisel.yaml` never land on `main`.
+
+## Working on `ubuntu-XX.XX`
+
+### CI / Workflow rules
+
+- **THIN CALLERS:** the workflows under `.github/workflows/` -- `ci.yaml` and `ci-pr-target.yaml` -- are thin callers of the reusable workflows on `main`, so CI logic changes belong on `main`, not here.
+- **SPREAD:** `spread.yaml` is the Spread project configuration.
+- **LINTING:** YAML is linted with `yamllint`, configured with `.github/yamllint.yaml` from `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Guidance for coding agents working on this Chisel release branch.
 
-Guidance for contributors can be found at [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md). on `main`.
+Guidance for contributors can be found at [CONTRIBUTING.md](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md) on `main`.
 
 ## Repository layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@ This is the `ubuntu-22.04` [Chisel](https://github.com/canonical/chisel/) releas
 
  - the Chisel release configuration file is `chisel.yaml`
  - slice definitions for Debian packages MUST go under `slices/`
- - slice definitions for packages of `kind: bin` MUST go under `bin-slices/`
  - [Spread](https://github.com/canonical/spread) tests for slice definitions go under `tests/spread`
  - the Spread configuration file is `spread.yaml`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 # AGENTS.md
 
-## Repository rules
+This is the `ubuntu-22.04` [Chisel](https://github.com/canonical/chisel/) release ([docs](https://ubuntu.com/chisel/docs/latest/)).
 
-- **BRANCH STRUCTURE:**
-   - `main` is meta-only (reusable CI workflows, CI scripts and their tests, and docs) - there are no slice definitions in `main`
-   - `ubuntu-XX.XX` branches (like this one) hold [Chisel](https://github.com/canonical/chisel) releases (`chisel.yaml`, Slice Definition Files (aka SDFs) under `slices/`, [Spread](https://github.com/canonical/spread) tests under `tests/spread/`)
+ - the Chisel release configuration file is `chisel.yaml`
+ - slice definitions for Debian packages MUST go under `slices/`
+ - slice definitions for packages of `kind: bin` MUST go under `bin-slices/`
+ - [Spread](https://github.com/canonical/spread) tests for slice definitions go under `tests/spread`
+ - the Spread configuration file is `spread.yaml`
 
-## Working on `ubuntu-XX.XX`
+## Instructions for working on package slices
 
-### CI / Workflow rules
+If creating, modifying or testing slice definitions, you MUST install and use
+the `chisel-slicer` skill (from https://github.com/canonical/mason/tree/main/skills/chisel-slicer/SKILL.md). If missing: `npx tessl i canonical/mason@0.1.0 --skill chisel-slicer`.
 
-- **THIN CALLERS:** The workflows under `.github/workflows/` -- `ci.yaml` and `ci-pr-target.yaml` -- are thin callers of the reusable workflows on `main`, so CI logic changes belong on `main`, not here
-- **SPREAD**: `spread.yaml` is the Spread project configuration
-- **LINTING**: YAML is linted with `yamllint`, configured with `.github/yamllint.yaml` from `main`.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ubuntu-22.04
 
+<!-- AI AGENTS: Agent guidance is in AGENTS.md -->
+
 This is the `ubuntu-22.04` Chisel release.
 
 To learn more about Chisel, Chisel releases and how to contribute to this


### PR DESCRIPTION
# Proposed changes

this PR adds [AGENTS.md](https://agents.md/) standard agent guidance file to this release branch of chisel-releases. ~~in order to alleviate the maintenance of the files on the release branches, i've chosen for the per-release AGENTS.md file to be identical in all releases and release-independent. the AGENTS.md file in this PR is therefore only a short instructions file guiding the agent to the `AGENTS-release.md` in `main`.~~

## Related issues/PRs

- https://github.com/canonical/chisel-releases/pull/1150

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1152
- https://github.com/canonical/chisel-releases/pull/1151
- https://github.com/canonical/chisel-releases/pull/1153
- https://github.com/canonical/chisel-releases/pull/1154 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1155

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)