### PR TITLE
fix(26.10): rootfs'es pile up across spread tasks

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -5,6 +5,8 @@ path: /chisel-releases
 environment:
   PROJECT_PATH: /chisel-releases
   SHARED_LIBRARIES: $PROJECT_PATH/tests/spread/lib
+  # Rootfs'es share one directory so that clean-rootfs can sweep them between tasks.
+  ROOTFS_DIR: /tmp/chisel-rootfs
   PATH: /snap/bin:$PATH:$SHARED_LIBRARIES
   MANIFESTS_EXPORT_DIR: $(HOST:echo "${MANIFESTS_EXPORT_DIR:-/usr/share/manifests}")
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -150,6 +150,8 @@ prepare: |
   tar -xf "$tarball" -C /usr/local/bin
 
 prepare-each: chisel version
+# One instance serves every task of a run, so rootfs'es have to go as they finish.
+restore-each: clean-rootfs
 
 suites:
   tests/spread/integration/:

--- a/tests/spread/integration/rabbitmq-server/task.yaml
+++ b/tests/spread/integration/rabbitmq-server/task.yaml
@@ -24,4 +24,4 @@ execute: |
 
 restore: |
   # Kill the RabbitMQ server, which by default runs on port 25672
-  kill `sudo lsof -t -i :25672`
+  kill `sudo lsof -t -i :25672` || true

--- a/tests/spread/lib/clean-rootfs
+++ b/tests/spread/lib/clean-rootfs
@@ -5,10 +5,12 @@
 # take up. Called between tasks by the restore-each hook in spread.yaml; tests
 # that cut several large rootfs'es can also call it on ones they are done with.
 # Usage: clean-rootfs [<rootfs>...]
-# With no arguments, every rootfs in the directory install-slices uses is removed.
+# With no arguments, every rootfs in $ROOTFS_DIR is removed.
 
-# Must match install-slices.
-_ROOTFS_DIR=/tmp/chisel-rootfs
+if [ -z "${ROOTFS_DIR:-}" ]; then
+    echo "Error: ROOTFS_DIR is not set" >&2
+    exit 1
+fi
 
 function main() {
     local rootfs
@@ -20,10 +22,10 @@ function main() {
         return
     fi
 
-    [ -d "$_ROOTFS_DIR" ] || return 0
+    [ -d "$ROOTFS_DIR" ] || return 0
     while IFS= read -r rootfs; do
         remove_rootfs "$rootfs"
-    done < <(find "$_ROOTFS_DIR" -mindepth 1 -maxdepth 1)
+    done < <(find "$ROOTFS_DIR" -mindepth 1 -maxdepth 1)
 }
 
 function remove_rootfs() {
@@ -31,9 +33,9 @@ function remove_rootfs() {
     local rootfs="${1%"${1##*[!/]}"}"
 
     # install-slices only ever creates direct children; anything else is not ours
-    case "${rootfs#"$_ROOTFS_DIR"/}" in
+    case "${rootfs#"$ROOTFS_DIR"/}" in
         "$rootfs" | "" | . | .. | */*)
-            echo "Error: refusing to remove '$1', which is not a rootfs in $_ROOTFS_DIR" >&2
+            echo "Error: refusing to remove '$1', which is not a rootfs in $ROOTFS_DIR" >&2
             exit 1
             ;;
     esac

--- a/tests/spread/lib/clean-rootfs
+++ b/tests/spread/lib/clean-rootfs
@@ -5,7 +5,8 @@
 # take up. Called between tasks by the restore-each hook in spread.yaml; tests
 # that cut several large rootfs'es can also call it on ones they are done with.
 # Usage: clean-rootfs [<rootfs>...]
-# With no arguments, every rootfs in $ROOTFS_DIR is removed.
+# Each argument has to be a path install-slices returned; anything else is
+# ignored. With no arguments, every rootfs in $ROOTFS_DIR is removed.
 
 if [ -z "${ROOTFS_DIR:-}" ]; then
     echo "Error: ROOTFS_DIR is not set" >&2
@@ -13,33 +14,29 @@ if [ -z "${ROOTFS_DIR:-}" ]; then
 fi
 
 function main() {
-    local rootfs
+    local rootfs target
 
-    if [ "$#" -gt 0 ]; then
-        for rootfs in "$@"; do
+    for rootfs in "$ROOTFS_DIR"/*; do
+        # an unmatched glob expands to itself
+        [ -e "$rootfs" ] || continue
+
+        if [ "$#" -eq 0 ]; then
             remove_rootfs "$rootfs"
-        done
-        return
-    fi
+            continue
+        fi
 
-    [ -d "$ROOTFS_DIR" ] || return 0
-    while IFS= read -r rootfs; do
-        remove_rootfs "$rootfs"
-    done < <(find "$ROOTFS_DIR" -mindepth 1 -maxdepth 1)
+        for target in "$@"; do
+            if [ "$target" = "$rootfs" ]; then
+                # rootfs is from /* glob. rm only sees paths under ROOTFS_DIR
+                remove_rootfs "$rootfs"
+                break
+            fi
+        done
+    done
 }
 
 function remove_rootfs() {
-    # trailing slashes would read as a nested path to the guard below
-    local rootfs="${1%"${1##*[!/]}"}"
-
-    # install-slices only ever creates direct children; anything else is not ours
-    case "${rootfs#"$ROOTFS_DIR"/}" in
-        "$rootfs" | "" | . | .. | */*)
-            echo "Error: refusing to remove '$1', which is not a rootfs in $ROOTFS_DIR" >&2
-            exit 1
-            ;;
-    esac
-    [ -e "$rootfs" ] || return 0
+    local rootfs="$1"
 
     unmount_all "$rootfs"
     if [ -n "$(mounts_under "$rootfs")" ]; then
@@ -47,7 +44,7 @@ function remove_rootfs() {
         return 0
     fi
 
-    # a non-zero exit here would fail the restore hook, and spread gives up on
+    # non-zero exit here would fail the restore hook, and spread gives up on
     # every remaining task of the run when that happens
     rm -rf -- "$rootfs" || echo "Warning: could not remove $rootfs" >&2
 }

--- a/tests/spread/lib/clean-rootfs
+++ b/tests/spread/lib/clean-rootfs
@@ -1,0 +1,71 @@
+#!/bin/bash -e
+# spellchecker: ignore rootfs
+
+# Removes chiselled rootfs'es created by install-slices, freeing the disk they
+# take up. Called between tasks by the restore-each hook in spread.yaml; tests
+# that cut several large rootfs'es can also call it on ones they are done with.
+# Usage: clean-rootfs [<rootfs>...]
+# With no arguments, every rootfs in the directory install-slices uses is removed.
+
+# Must match install-slices.
+_ROOTFS_DIR=/tmp/chisel-rootfs
+
+function main() {
+    local rootfs
+
+    if [ "$#" -gt 0 ]; then
+        for rootfs in "$@"; do
+            remove_rootfs "$rootfs"
+        done
+        return
+    fi
+
+    [ -d "$_ROOTFS_DIR" ] || return 0
+    while IFS= read -r rootfs; do
+        remove_rootfs "$rootfs"
+    done < <(find "$_ROOTFS_DIR" -mindepth 1 -maxdepth 1)
+}
+
+function remove_rootfs() {
+    # trailing slashes would read as a nested path to the guard below
+    local rootfs="${1%"${1##*[!/]}"}"
+
+    # install-slices only ever creates direct children; anything else is not ours
+    case "${rootfs#"$_ROOTFS_DIR"/}" in
+        "$rootfs" | "" | . | .. | */*)
+            echo "Error: refusing to remove '$1', which is not a rootfs in $_ROOTFS_DIR" >&2
+            exit 1
+            ;;
+    esac
+    [ -e "$rootfs" ] || return 0
+
+    unmount_all "$rootfs"
+    if [ -n "$(mounts_under "$rootfs")" ]; then
+        echo "Warning: $rootfs still has mounts under it, leaving it in place" >&2
+        return 0
+    fi
+
+    # a non-zero exit here would fail the restore hook, and spread gives up on
+    # every remaining task of the run when that happens
+    rm -rf -- "$rootfs" || echo "Warning: could not remove $rootfs" >&2
+}
+
+# Tests bind-mount /proc, /dev and friends into their rootfs and do not all unmount
+# on the way out; `rm -rf` over a live bind mount deletes the host's copy.
+function unmount_all() {
+    local rootfs="$1"
+    local mountpoint
+
+    # deepest first, so a mount is gone before the one holding it
+    while IFS= read -r mountpoint; do
+        umount --lazy "$mountpoint" || true
+    done < <(mounts_under "$rootfs" | sort -r)
+}
+
+function mounts_under() {
+    local rootfs="$1"
+    awk -v root="$rootfs" -v prefix="$rootfs/" \
+        '$2 == root || index($2, prefix) == 1 { print $2 }' /proc/self/mounts
+}
+
+main "$@"

--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -22,7 +22,8 @@ function main() {
     #shellcheck disable=SC2174 # the parent always exists, only the leaf is created
     mkdir -p -m 755 "$ROOTFS_DIR"
 
-    local rootfs="$(mktemp -d -p "$ROOTFS_DIR")"
+    local rootfs
+    rootfs="$(mktemp -d -p "$ROOTFS_DIR")"
     chisel_cut "$rootfs" "$slices"
     if [ -n "$MANIFESTS_EXPORT_DIR" ]; then
         export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"

--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -5,8 +5,10 @@
 # Usage: install-slices [<slice>...]
 # Returns the path of the chiselled rootfs
 
-# Rootfs'es share one directory so that clean-rootfs can sweep them between tasks.
-_ROOTFS_DIR=/tmp/chisel-rootfs
+if [ -z "${ROOTFS_DIR:-}" ]; then
+    echo "Error: ROOTFS_DIR is not set" >&2
+    exit 1
+fi
 
 _OUTPUT="$(mktemp)"
 trap 'rm -f "$_OUTPUT"' EXIT
@@ -18,9 +20,9 @@ function main() {
 
     # chrooted daemons that drop privileges need the path to stay traversable
     #shellcheck disable=SC2174 # the parent always exists, only the leaf is created
-    mkdir -p -m 755 "$_ROOTFS_DIR"
+    mkdir -p -m 755 "$ROOTFS_DIR"
 
-    local rootfs="$(mktemp -d -p "$_ROOTFS_DIR")"
+    local rootfs="$(mktemp -d -p "$ROOTFS_DIR")"
     chisel_cut "$rootfs" "$slices"
     if [ -n "$MANIFESTS_EXPORT_DIR" ]; then
         export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"

--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -5,14 +5,26 @@
 # Usage: install-slices [<slice>...]
 # Returns the path of the chiselled rootfs
 
+# Rootfs'es share one directory so that clean-rootfs can sweep them between tasks.
+_ROOTFS_DIR=/tmp/chisel-rootfs
+
+_OUTPUT="$(mktemp)"
+trap 'rm -f "$_OUTPUT"' EXIT
+
 function main() {
     local slices="$*"
     # add base-files_chisel slice to ensure we generate the manifest
     slices="${slices} base-files_chisel"
 
-    local rootfs="$(mktemp -d)"
+    # chrooted daemons that drop privileges need the path to stay traversable
+    #shellcheck disable=SC2174 # the parent always exists, only the leaf is created
+    mkdir -p -m 755 "$_ROOTFS_DIR"
+
+    local rootfs="$(mktemp -d -p "$_ROOTFS_DIR")"
     chisel_cut "$rootfs" "$slices"
-    [ -n "$MANIFESTS_EXPORT_DIR" ] && export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"
+    if [ -n "$MANIFESTS_EXPORT_DIR" ]; then
+        export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"
+    fi
 
     echo "${rootfs}"
 }
@@ -50,7 +62,6 @@ function chisel_cut() {
     local n_retries=3
     local attempt
 
-    local output=$(mktemp)
     for ((attempt=1; attempt<=n_retries; attempt++)); do
         #shellcheck disable=SC2086
         chisel cut \
@@ -59,12 +70,12 @@ function chisel_cut() {
             --release "$PROJECT_PATH" \
             --root "$rootfs" \
             $slices \
-            2>&1 | tee "$output" >&2
+            2>&1 | tee "$_OUTPUT" >&2
         [[ "${PIPESTATUS[0]}" -eq 0 ]] && break
 
         local matched=""
         for pattern in "${_PATTERNS_TO_RETRY[@]}"; do
-            if grep -q "$pattern" "$output"; then
+            if grep -q "$pattern" "$_OUTPUT"; then
                 matched="$pattern"
                 break
             fi


### PR DESCRIPTION
# Proposed changes

forward-port of #1156. partially addresses #1077.

`install-slices` test helper never removed the rootfs'es which it created which led to oom on some low-resources runners like ppc. this PR adds `clean-rootfs` helper which can be used both in the tests themselves and in spread's `restore-each` to clean up the runners between test runs.

## Related issues/PRs

- https://github.com/canonical/chisel-releases/issues/1077
- https://github.com/canonical/chisel-releases/pull/1156

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1158 **(this PR)**
- https://github.com/canonical/chisel-releases/pull/1156
- https://github.com/canonical/chisel-releases/pull/1159
- https://github.com/canonical/chisel-releases/pull/1160
- https://github.com/canonical/chisel-releases/pull/1161

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)