### PR TITLE
feat(26.04): add slice definitions for `rustdoc`

### DIFF
--- a/slices/rustc-1.93.yaml
+++ b/slices/rustc-1.93.yaml
@@ -16,6 +16,15 @@ slices:
       /usr/bin/rustc-1.93:  # symlink to ../rust-1.93/bin/rustc
       /usr/lib/rust-1.93/bin/rustc:
 
+  rustdoc:
+    essential:
+      libc6_libs:
+      libgcc-s1_libs:
+      libstd-rust-1.93-dev_libs:
+    contents:
+      /usr/bin/rustdoc-1.93:  # symlink to ../lib/rust-1.93/bin/rustdoc
+      /usr/lib/rust-1.93/bin/rustdoc:
+
   copyright:
     contents:
       /usr/share/doc/rustc-1.93/copyright:

--- a/slices/rustc.yaml
+++ b/slices/rustc.yaml
@@ -10,6 +10,12 @@ slices:
     contents:
       /usr/bin/rustc:  # symlink to ../lib/rustc-1.93/bin/rustc
 
+  rustdoc:
+    essential:
+      rustc-1.93_rustdoc:
+    contents:
+      /usr/bin/rustdoc:  # symlink to ../lib/rust-1.93/bin/rustdoc
+
   copyright:
     contents:
       /usr/share/doc/rustc/copyright:

--- a/tests/spread/integration/cargo-1.93/task.yaml
+++ b/tests/spread/integration/cargo-1.93/task.yaml
@@ -1,6 +1,7 @@
 summary: Integration tests for cargo-1.93
 
 variants:
+    - doc
     - eza
     - hello_crate
     - hello

--- a/tests/spread/integration/cargo-1.93/test_doc.sh
+++ b/tests/spread/integration/cargo-1.93/test_doc.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs cargo
+
+rootfs="$(install-slices cargo-1.93_cargo rustc-1.93_rustdoc)"
+ln -s cargo-1.93 "$rootfs/usr/bin/cargo"
+
+# Create minimal /dev/null
+mkdir -p "$rootfs/dev"
+touch "$rootfs/dev/null"
+chmod +x "$rootfs/dev/null"
+
+cp -r testfiles/hello_crate "$rootfs"
+
+chroot "$rootfs" cargo doc --manifest-path /hello_crate/Cargo.toml
+test -f "$rootfs/hello_crate/target/doc/hello/index.html"
+test -f "$rootfs/hello_crate/target/doc/greeter/index.html"

--- a/tests/spread/integration/cargo/task.yaml
+++ b/tests/spread/integration/cargo/task.yaml
@@ -1,6 +1,7 @@
 summary: Integration tests for cargo
 
 variants:
+    - doc
     - eza
     - hello_crate
     - hello

--- a/tests/spread/integration/cargo/test_doc.sh
+++ b/tests/spread/integration/cargo/test_doc.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs
+
+rootfs="$(install-slices cargo_cargo rustc_rustdoc)"
+
+# Create minimal /dev/null
+mkdir -p "$rootfs/dev"
+touch "$rootfs/dev/null"
+chmod +x "$rootfs/dev/null"
+
+cp -r testfiles/hello_crate "$rootfs"
+
+chroot "$rootfs" cargo doc --manifest-path /hello_crate/Cargo.toml
+test -f "$rootfs/hello_crate/target/doc/hello/index.html"
+test -f "$rootfs/hello_crate/target/doc/greeter/index.html"

--- a/tests/spread/integration/rustc-1.93/task.yaml
+++ b/tests/spread/integration/rustc-1.93/task.yaml
@@ -3,6 +3,7 @@ summary: Integration tests for rustc-1.93
 variants:
     - hello
     - help_and_version
+    - rustdoc
     - std
     - static
 

--- a/tests/spread/integration/rustc-1.93/test_rustdoc.sh
+++ b/tests/spread/integration/rustc-1.93/test_rustdoc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustdoc
+
+rootfs="$(install-slices rustc-1.93_rustdoc)"
+
+# the unversioned /usr/bin/rustdoc is not part of the rustc-1.93 package
+chroot "$rootfs" rustdoc-1.93 --version | grep -Fiq 'rustdoc 1.93'
+chroot "$rootfs" /usr/lib/rust-1.93/bin/rustdoc --help | grep -Fq 'rustdoc [options] <input>'
+
+cp testfiles/hello.rs "$rootfs/hello.rs"
+chroot "$rootfs" rustdoc-1.93 /hello.rs -o /doc-out
+test -f "$rootfs/doc-out/hello/index.html"

--- a/tests/spread/integration/rustc/task.yaml
+++ b/tests/spread/integration/rustc/task.yaml
@@ -3,6 +3,7 @@ summary: Integration tests for rustc
 variants:
     - hello
     - help_and_version
+    - rustdoc
     - std
     - static
 

--- a/tests/spread/integration/rustc/test_rustdoc.sh
+++ b/tests/spread/integration/rustc/test_rustdoc.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# spellchecker: ignore rootfs rustdoc
+
+rootfs="$(install-slices rustc_rustdoc)"
+
+chroot "$rootfs" rustdoc --version | grep -Fiq 'rustdoc 1.93'
+chroot "$rootfs" rustdoc --help | grep -Fq 'rustdoc [options] <input>'
+
+cp testfiles/hello.rs "$rootfs/hello.rs"
+chroot "$rootfs" rustdoc /hello.rs -o /doc-out
+test -f "$rootfs/doc-out/hello/index.html"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for Rust's documentation generator, [`rustdoc`](https://doc.rust-lang.org/rustdoc/).

Unlike the other Rust toolchain binaries we support, `rustdoc` does not have its own package on Ubuntu 26.04: the versioned binary is shipped by [`rustc-1.93`](https://packages.ubuntu.com/resolute/rustc-1.93), and the unversioned `/usr/bin/rustdoc` symlink by [`rustc`](https://packages.ubuntu.com/resolute/rustc). So, instead of new slice files, this PR adds a `rustdoc` slice to the existing `slices/rustc-1.93.yaml` and `slices/rustc.yaml`.

I kept `rustdoc` itself separated from `rustc` since it embeds the compiler and can document pure-Rust crates without the latter, avoiding the compiler's toolchain dependencies (GCC, libc development files, and so on).

Besides the standalone `rustdoc` variants for the `rustc`/`rustc-1.93` test suites, this PR adds `doc` variants for `cargo`/`cargo-1.93`, exercising rustdoc as used by Cargo.

We already have `rustc`/`rustc-1.93` and `cargo`/`cargo-1.93` - this PR extends the list of supported Rust toolchain binaries.

## Related issues/PRs

https://github.com/canonical/rust-rock/issues/23

### Forward porting

Forward porting is not applicable since rustc-1.93 will be dropped from the Stonking archive. We will need to write slice definitions for rustc-1.97.

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
