### PR TITLE
feat(26.04): add bridge-utils slices

### DIFF
--- a/slices/bridge-utils.yaml
+++ b/slices/bridge-utils.yaml
@@ -1,0 +1,23 @@
+package: bridge-utils
+
+essential:
+  bridge-utils_copyright:
+
+slices:
+  bins:
+    hint: Ethernet bridge administration
+    essential:
+      libc6_libs:
+    contents:
+      /usr/sbin/brctl:
+
+  # The deb also ships the ifupdown hooks (/etc/network/if-*.d/bridge ->
+  # /usr/lib/bridge-utils/ifupdown.sh), /etc/default/bridge-utils, and the udev
+  # hotplug helper (/usr/lib/udev/bridge-network-interface and its rule). All of
+  # them need "ifquery" from ifupdown, and the udev rule needs a running udevd;
+  # neither ifupdown nor udevd is in chisel-releases, so those paths are left
+  # out until a consumer exists.
+
+  copyright:
+    contents:
+      /usr/share/doc/bridge-utils/copyright:

--- a/tests/spread/integration/bridge-utils/task.yaml
+++ b/tests/spread/integration/bridge-utils/task.yaml
@@ -1,0 +1,43 @@
+summary: Integration tests for bridge-utils
+
+execute: |
+  rootfs="$(install-slices bridge-utils_bins)"
+
+  cleanup() {
+    chroot "${rootfs}" /usr/sbin/brctl delbr chisel-br0 2>/dev/null || true
+    umount -l "${rootfs}/sys" 2>/dev/null || true
+  }
+  trap cleanup EXIT
+
+  # brctl reports its version and usage without any kernel interaction.
+  chroot "${rootfs}" /usr/sbin/brctl --version | grep -Fiq "bridge-utils"
+  out="$(chroot "${rootfs}" /usr/sbin/brctl 2>&1 || true)"
+  echo "${out}" | grep -Fiq "usage: brctl"
+
+  # "show"/"showstp"/"showmacs" read /sys/class/net, so sysfs has to be visible.
+  mkdir -p "${rootfs}/sys"
+  mount --bind /sys "${rootfs}/sys"
+
+  # Enumerating an empty bridge list has to succeed (and prints no header).
+  chroot "${rootfs}" /usr/sbin/brctl show >/dev/null
+
+  # Create a bridge, configure it, read the settings back, then remove it.
+  chroot "${rootfs}" /usr/sbin/brctl addbr chisel-br0
+  out="$(chroot "${rootfs}" /usr/sbin/brctl show)"
+  echo "${out}" | grep -Fiq "bridge name"
+  echo "${out}" | grep -Fq "chisel-br0"
+
+  chroot "${rootfs}" /usr/sbin/brctl stp chisel-br0 on
+  chroot "${rootfs}" /usr/sbin/brctl setageing chisel-br0 120
+  chroot "${rootfs}" /usr/sbin/brctl setbridgeprio chisel-br0 4096
+
+  out="$(chroot "${rootfs}" /usr/sbin/brctl showstp chisel-br0)"
+  echo "${out}" | grep -Eq "ageing time[[:space:]]+120\.00"
+  echo "${out}" | grep -Eq "bridge id[[:space:]]+1000\."
+
+  out="$(chroot "${rootfs}" /usr/sbin/brctl showmacs chisel-br0)"
+  echo "${out}" | grep -Fiq "port no"
+
+  chroot "${rootfs}" /usr/sbin/brctl delbr chisel-br0
+  out="$(chroot "${rootfs}" /usr/sbin/brctl show)"
+  ! echo "${out}" | grep -Fq "chisel-br0"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `bridge-utils` on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `bridge-utils` | `bins`, `copyright` | `brctl`, Linux Ethernet bridge administration |

The ifupdown hooks (`/etc/network/if-*.d/bridge`, `ifupdown.sh`,
`/etc/default/bridge-utils`) and the udev hotplug helper are left out: both need
`ifquery` from `ifupdown`, and the udev rule also needs a running `udevd` --
neither is in chisel-releases.

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
