### PR TITLE
feat(26.04): add pciutils slices

### DIFF
--- a/slices/libpci3.yaml
+++ b/slices/libpci3.yaml
@@ -1,0 +1,19 @@
+package: libpci3
+
+essential:
+  libpci3_copyright:
+
+slices:
+  libs:
+    hint: PCI configuration space library
+    essential:
+      libc6_libs:
+      libudev1_libs:
+      pci.ids_data:
+      zlib1g_libs:
+    contents:
+      /usr/lib/*-linux-*/libpci.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpci3/copyright:

--- a/slices/pci.ids.yaml
+++ b/slices/pci.ids.yaml
@@ -1,0 +1,14 @@
+package: pci.ids
+
+essential:
+  pci.ids_copyright:
+
+slices:
+  data:
+    hint: PCI ID database
+    contents:
+      /usr/share/misc/pci.ids:
+
+  copyright:
+    contents:
+      /usr/share/doc/pci.ids/copyright:

--- a/slices/pciutils.yaml
+++ b/slices/pciutils.yaml
@@ -1,0 +1,23 @@
+package: pciutils
+
+essential:
+  pciutils_copyright:
+
+slices:
+  # update-pciids is left out: it refreshes /usr/share/misc/pci.ids from
+  # pci-ids.ucw.cz, so it needs a writable rootfs plus curl, wget or lynx --
+  # it exits with an error otherwise, and none of those are Depends of this deb.
+  bins:
+    hint: PCI bus inspection utilities
+    essential:
+      libc6_libs:
+      libkmod2_libs:
+      libpci3_libs:
+    contents:
+      /usr/bin/lspci:
+      /usr/bin/pcilmr:
+      /usr/bin/setpci:
+
+  copyright:
+    contents:
+      /usr/share/doc/pciutils/copyright:

--- a/tests/spread/integration/libpci3/task.yaml
+++ b/tests/spread/integration/libpci3/task.yaml
@@ -1,0 +1,30 @@
+summary: Integration tests for libpci3
+
+execute: |
+  rootfs="$(install-slices libpci3_libs)"
+
+  # The soname symlink and the versioned object both have to land.
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libpci.so.3; do
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+  done
+
+  # Prove the library is loadable and usable by pairing it with its consumer in
+  # a fresh rootfs: lspci links against libpci.so.3.
+  rootfs="$(install-slices libpci3_libs pciutils_bins)"
+
+  # A synthetic config space dump for 8086:100e (Intel 82540EM Gigabit
+  # Ethernet), subsystem 8086:001e, class 0200.
+  printf '%s\n' \
+    '00:03.0 Ethernet controller' \
+    '00: 86 80 0e 10 07 00 10 00 03 00 00 02 00 00 00 00' \
+    '10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00' \
+    '20: 00 00 00 00 00 00 00 00 00 00 00 00 86 80 1e 00' \
+    '30: 00 00 00 00 00 00 00 00 00 00 00 00 0b 00 00 00' \
+    > "${rootfs}/dump"
+
+  # libpci parses the config space dump; the numeric form needs no name lookup.
+  out="$(chroot "${rootfs}" /usr/bin/lspci -F /dump -n)"
+  echo "${out}" | grep -Fq "8086:100e"

--- a/tests/spread/integration/pci.ids/task.yaml
+++ b/tests/spread/integration/pci.ids/task.yaml
@@ -1,0 +1,28 @@
+summary: Integration tests for pci.ids
+
+execute: |
+  # pci.ids is a data-only package: prove a consumer can actually resolve names
+  # out of the shipped database rather than just checking that the file exists.
+  rootfs="$(install-slices pci.ids_data pciutils_bins)"
+
+  test -s "${rootfs}/usr/share/misc/pci.ids"
+
+  # A synthetic config space dump for 8086:100e (Intel 82540EM Gigabit
+  # Ethernet), subsystem 8086:001e, class 0200.
+  printf '%s\n' \
+    '00:03.0 Ethernet controller' \
+    '00: 86 80 0e 10 07 00 10 00 03 00 00 02 00 00 00 00' \
+    '10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00' \
+    '20: 00 00 00 00 00 00 00 00 00 00 00 00 86 80 1e 00' \
+    '30: 00 00 00 00 00 00 00 00 00 00 00 00 0b 00 00 00' \
+    > "${rootfs}/dump"
+
+  # Vendor, device and subsystem names all come from /usr/share/misc/pci.ids.
+  out="$(chroot "${rootfs}" /usr/bin/lspci -F /dump -vnn)"
+  echo "${out}" | grep -Fq "Intel Corporation"
+  echo "${out}" | grep -Fq "82540EM Gigabit Ethernet Controller"
+  echo "${out}" | grep -Fq "PRO/1000 MT Desktop Adapter"
+
+  # The database also carries the device-class names.
+  out="$(chroot "${rootfs}" /usr/bin/lspci -F /dump)"
+  echo "${out}" | grep -Fq "Ethernet controller"

--- a/tests/spread/integration/pciutils/task.yaml
+++ b/tests/spread/integration/pciutils/task.yaml
@@ -1,0 +1,80 @@
+summary: Integration tests for pciutils
+
+execute: |
+  rootfs="$(install-slices pciutils_bins)"
+
+  out="$(chroot "${rootfs}" /usr/bin/lspci --version)"
+  echo "${out}" | grep -Fq "lspci version"
+  out="$(chroot "${rootfs}" /usr/bin/setpci --version)"
+  echo "${out}" | grep -Fq "setpci version"
+
+  # A saved config space dump keeps lspci independent of the host's real PCI
+  # topology. It describes 8086:100e (Intel 82540EM Gigabit Ethernet),
+  # subsystem 8086:001e, class 0200, revision 03.
+  printf '%s\n' \
+    '00:03.0 Ethernet controller' \
+    '00: 86 80 0e 10 07 00 10 00 03 00 00 02 00 00 00 00' \
+    '10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00' \
+    '20: 00 00 00 00 00 00 00 00 00 00 00 00 86 80 1e 00' \
+    '30: 00 00 00 00 00 00 00 00 00 00 00 00 0b 00 00 00' \
+    > "${rootfs}/dump"
+
+  out="$(chroot "${rootfs}" /usr/bin/lspci -F /dump -nn -vv)"
+  echo "${out}" | grep -Fq "[8086:100e]"
+  echo "${out}" | grep -Fq "[0200]"
+  echo "${out}" | grep -Fq "Subsystem"
+  echo "${out}" | grep -Fiq "82540EM Gigabit Ethernet Controller"
+
+  # -i overrides the ID database, proving the lookup path is honoured.
+  printf '8086  ChiselVendor\n\t100e  ChiselDevice\n' > "${rootfs}/ids"
+  out="$(chroot "${rootfs}" /usr/bin/lspci -F /dump -i /ids)"
+  echo "${out}" | grep -Fq "ChiselVendor ChiselDevice"
+
+  # The machine-readable listing has to parse as well.
+  out="$(chroot "${rootfs}" /usr/bin/lspci -F /dump -mm -n)"
+  echo "${out}" | grep -Fq '"0200" "8086" "100e"'
+
+  # setpci knows the symbolic register names without touching any hardware.
+  out="$(chroot "${rootfs}" /usr/bin/setpci --dumpregs)"
+  echo "${out}" | grep -Fq "VENDOR_ID"
+  echo "${out}" | grep -Fq "DEVICE_ID"
+  out="$(chroot "${rootfs}" /usr/bin/setpci --help 2>&1)"
+  echo "${out}" | grep -Fq "Usage: setpci"
+
+  # setpci and pcilmr have no dump reader, so give them the same device through
+  # a synthetic sysfs tree inside the rootfs -- pcilib's sysfs access method
+  # only needs /sys/bus/pci/devices/<addr>/{config,class,vendor,device,irq}.
+  # Building it in the rootfs keeps the test hermetic on every architecture.
+  dev="${rootfs}/sys/bus/pci/devices/0000:00:03.0"
+  mkdir -p "${dev}"
+  printf '\x86\x80\x0e\x10\x07\x00\x10\x00\x03\x00\x00\x02\x00\x00\x00\x00' > "${dev}/config"
+  printf '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' >> "${dev}/config"
+  printf '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x86\x80\x1e\x00' >> "${dev}/config"
+  printf '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00' >> "${dev}/config"
+  echo "0x020000" > "${dev}/class"
+  echo "0x8086" > "${dev}/vendor"
+  echo "0x100e" > "${dev}/device"
+  echo "11" > "${dev}/irq"
+
+  # lspci finds the device through sysfs, with no dump file involved.
+  out="$(chroot "${rootfs}" /usr/bin/lspci -nn)"
+  echo "${out}" | grep -Fq "00:03.0"
+  echo "${out}" | grep -Fq "[8086:100e]"
+
+  # setpci reads named registers, selecting by both slot and vendor:device.
+  out="$(chroot "${rootfs}" /usr/bin/setpci -s 00:03.0 VENDOR_ID DEVICE_ID CLASS_DEVICE)"
+  echo "${out}" | tr '\n' ' ' | grep -Fq "8086 100e 0200"
+  out="$(chroot "${rootfs}" /usr/bin/setpci -d 8086:100e SUBSYSTEM_VENDOR_ID)"
+  echo "${out}" | grep -Fq "8086"
+
+  # ... and writes them back.
+  chroot "${rootfs}" /usr/bin/setpci -s 00:03.0 LATENCY_TIMER=20
+  out="$(chroot "${rootfs}" /usr/bin/setpci -s 00:03.0 LATENCY_TIMER)"
+  echo "${out}" | grep -Fxq "20"
+
+  # pcilmr needs real PCIe links to margin; with a working access method it
+  # reports that none are available and prints its usage.
+  out="$(chroot "${rootfs}" /usr/bin/pcilmr 2>&1)"
+  echo "${out}" | grep -Fq "pcilmr [--margin]"
+  out="$(chroot "${rootfs}" /usr/bin/pcilmr --scan 2>&1)"
+  echo "${out}" | grep -Fiq "lane margining"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `pciutils` and its dependency chain on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `pci.ids` | `data`, `copyright` | `Architecture: all` PCI ID database |
| `libpci3` | `libs`, `copyright` | `libpci.so.3`, PCI configuration space library |
| `pciutils` | `bins`, `copyright` | `lspci`, `setpci`, `pcilmr` |

`/usr/sbin/update-pciids` is left out: it refreshes the ID database over the
network, so it needs a writable rootfs plus `curl`, `wget` or `lynx`, none of
which is a `Depends` of the deb.

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
