### PR TITLE
feat(26.04): add tcpdump slices

### DIFF
--- a/slices/libibverbs1.yaml
+++ b/slices/libibverbs1.yaml
@@ -1,0 +1,20 @@
+package: libibverbs1
+
+essential:
+  libibverbs1_copyright:
+
+slices:
+  # The adduser dependency is only used by the postinst, to create the "rdma"
+  # group; maintainer scripts are handled differently in Chisel.
+  libs:
+    hint: InfiniBand and RDMA userspace library
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+      libnl-route-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libibverbs.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libibverbs1/copyright:

--- a/slices/libpcap0.8t64.yaml
+++ b/slices/libpcap0.8t64.yaml
@@ -1,0 +1,19 @@
+package: libpcap0.8t64
+
+essential:
+  libpcap0.8t64_copyright:
+
+slices:
+  libs:
+    hint: Packet capture library
+    essential:
+      libc6_libs:
+      libdbus-1-3_libs:
+      libibverbs1_libs:
+    contents:
+      /usr/lib/*-linux-*/libpcap.so.0.8:  # Symlink to libpcap.so.1.10.x
+      /usr/lib/*-linux-*/libpcap.so.1.10*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpcap0.8t64/copyright:

--- a/slices/tcpdump.yaml
+++ b/slices/tcpdump.yaml
@@ -1,0 +1,30 @@
+package: tcpdump
+
+essential:
+  tcpdump_copyright:
+
+slices:
+  # /etc/apparmor.d/usr.bin.tcpdump is left out: loading it needs
+  # apparmor_parser plus an AppArmor-enabled kernel, and per-package profiles
+  # are not shipped by any other slice definition here.
+  bins:
+    hint: Network traffic capture and analysis
+    essential:
+      libc6_libs:
+      libpcap0.8t64_libs:
+      libssl3t64_libs:
+    contents:
+      # For live capture tcpdump drops privileges to the "tcpdump" user, so it
+      # needs that user in /etc/passwd (see the sysusers-config slice) or
+      # -Z <user> on the command line. Reading and writing savefiles does not.
+      /usr/bin/tcpdump:
+
+  sysusers-config:
+    contents:
+      # The deb's postinst runs systemd-sysusers to create the "tcpdump" user;
+      # maintainer scripts are handled differently in Chisel.
+      /usr/lib/sysusers.d/tcpdump.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/tcpdump/copyright:

--- a/tests/spread/integration/libibverbs1/task.yaml
+++ b/tests/spread/integration/libibverbs1/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for libibverbs1
+
+execute: |
+  rootfs="$(install-slices libibverbs1_libs)"
+
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libibverbs.so.1; do
+    rel="${lib#"${rootfs}"}"
+
+    # The soname symlink and the versioned object both have to land.
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+
+    # The dynamic linker has to resolve the whole closure from inside the
+    # rootfs: anything the slice forgot shows up as "not found".
+    ld="$(find "${rootfs}/usr/lib" -maxdepth 2 -name 'ld*.so.*' -print -quit)"
+    test -n "${ld}"
+    out="$(chroot "${rootfs}" "${ld#"${rootfs}"}" --list "${rel}")"
+    echo "${out}" | grep -Fq "libc.so.6 =>"
+    echo "${out}" | grep -Fq "libnl-3.so.200 =>"
+    echo "${out}" | grep -Fq "libnl-route-3.so.200 =>"
+    ! echo "${out}" | grep -Fq "not found"
+  done

--- a/tests/spread/integration/libpcap0.8t64/task.yaml
+++ b/tests/spread/integration/libpcap0.8t64/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for libpcap0.8t64
+
+execute: |
+  rootfs="$(install-slices libpcap0.8t64_libs)"
+
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libpcap.so.0.8; do
+    rel="${lib#"${rootfs}"}"
+
+    # The soname symlink and the versioned object both have to land.
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+
+    # The dynamic linker has to resolve the whole closure from inside the
+    # rootfs: anything the slice forgot shows up as "not found".
+    ld="$(find "${rootfs}/usr/lib" -maxdepth 2 -name 'ld*.so.*' -print -quit)"
+    test -n "${ld}"
+    out="$(chroot "${rootfs}" "${ld#"${rootfs}"}" --list "${rel}")"
+    echo "${out}" | grep -Fq "libc.so.6 =>"
+    echo "${out}" | grep -Fq "libibverbs.so.1 =>"
+    echo "${out}" | grep -Fq "libdbus-1.so.3 =>"
+    ! echo "${out}" | grep -Fq "not found"
+  done

--- a/tests/spread/integration/tcpdump/task.yaml
+++ b/tests/spread/integration/tcpdump/task.yaml
@@ -1,0 +1,89 @@
+summary: Integration tests for tcpdump
+
+execute: |
+  # Build a two-packet EN10MB savefile by hand: an ARP request
+  # (who-has 10.0.0.2 tell 10.0.0.1) and an IPv4/UDP datagram
+  # (10.0.0.1.4444 > 10.0.0.2.4445, payload "chisel"). Hand-rolling it keeps the
+  # test hermetic -- no capture device, no network, same bytes on every arch.
+  hex() { printf '%b' "$(printf '%s' "$1" | tr -d ' ' | sed 's/../\\x&/g')"; }
+  make_pcap() {
+    {
+      hex 'd4c3b2a1 0200 0400 00000000 00000000 ffff0000 01000000'
+      hex '01000000 00000000 2a000000 2a000000'
+      hex 'ffffffffffff 020000000001 0806'
+      hex '0001 0800 06 04 0001 020000000001 0a000001 000000000000 0a000002'
+      hex '02000000 00000000 30000000 30000000'
+      hex '020000000002 020000000001 0800'
+      hex '4500 0022 0001 0000 40 11 66c8 0a000001 0a000002'
+      hex '115c 115d 000e 0000'
+      printf 'chisel'
+    } > "$1"
+  }
+
+  rootfs="$(install-slices tcpdump_bins)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+  make_pcap "${rootfs}/test.pcap"
+
+  out="$(chroot "${rootfs}" /usr/bin/tcpdump --version 2>&1)"
+  echo "${out}" | grep -Fq "tcpdump version 4.99"
+  echo "${out}" | grep -Fq "libpcap version"
+  out="$(chroot "${rootfs}" /usr/bin/tcpdump -h 2>&1)"
+  echo "${out}" | grep -Fq "Usage: tcpdump"
+
+  # Debian's tcpdump drops privileges to the "tcpdump" user whenever it runs as
+  # root, so -Z root is needed until that user exists (see the sysusers test at
+  # the end of this file).
+  td() { chroot "${rootfs}" /usr/bin/tcpdump -Z root -nn "$@"; }
+
+  # Decode the savefile: protocol dissection is the core function.
+  out="$(td -r /test.pcap 2>&1)"
+  echo "${out}" | grep -Fq "ARP, Request who-has 10.0.0.2 tell 10.0.0.1"
+  echo "${out}" | grep -Fq "10.0.0.1.4444 > 10.0.0.2.4445: UDP, length 6"
+
+  # Link-layer and verbose IP decoding.
+  out="$(td -e -r /test.pcap 2>&1)"
+  echo "${out}" | grep -Fq "02:00:00:00:00:01 > ff:ff:ff:ff:ff:ff"
+  echo "${out}" | grep -Fq "ethertype IPv4 (0x0800)"
+  out="$(td -v -r /test.pcap 2>&1)"
+  echo "${out}" | grep -Fq "proto UDP (17)"
+  echo "${out}" | grep -Fq "ttl 64"
+
+  # ASCII payload dump.
+  out="$(td -A -r /test.pcap 2>&1)"
+  echo "${out}" | grep -Fq "chisel"
+
+  # BPF filters have to compile and select the right packets.
+  out="$(td -r /test.pcap 'udp port 4445' 2>&1)"
+  echo "${out}" | grep -Fq "10.0.0.2.4445"
+  ! echo "${out}" | grep -Fq "ARP"
+  out="$(td -r /test.pcap 'arp' 2>&1)"
+  echo "${out}" | grep -Fq "ARP"
+  ! echo "${out}" | grep -Fq "4445"
+
+  # -d dumps the compiled BPF program.
+  out="$(td -d -r /test.pcap 'udp port 4445' 2>&1)"
+  echo "${out}" | grep -Fq "ldh"
+  echo "${out}" | grep -Fq "jeq"
+
+  # Writing a savefile and reading it back has to round-trip.
+  td -w /out.pcap -r /test.pcap 'arp'
+  out="$(td -r /out.pcap 2>&1)"
+  echo "${out}" | grep -Fq "ARP, Request who-has 10.0.0.2 tell 10.0.0.1"
+  ! echo "${out}" | grep -Fq "4445"
+
+  # Interface enumeration goes through libpcap and needs no capture privileges.
+  chroot "${rootfs}" /usr/bin/tcpdump -Z root -D >/dev/null
+
+  # tcpdump_sysusers-config -- systemd-sysusers turns the shipped drop-in into
+  # the "tcpdump" user, after which tcpdump runs as root without -Z.
+  rootfs="$(install-slices tcpdump_bins tcpdump_sysusers-config \
+    base-passwd_data systemd_standard)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+  make_pcap "${rootfs}/test.pcap"
+
+  ! grep -q "^tcpdump:" "${rootfs}/etc/passwd"
+  chroot "${rootfs}" /usr/bin/systemd-sysusers tcpdump.conf
+  grep -q "^tcpdump:" "${rootfs}/etc/passwd"
+
+  out="$(chroot "${rootfs}" /usr/bin/tcpdump -nn -r /test.pcap 2>&1)"
+  echo "${out}" | grep -Fq "ARP, Request who-has 10.0.0.2 tell 10.0.0.1"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `tcpdump` and its dependency chain on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `libibverbs1` | `libs`, `copyright` | Leaf library; `DT_NEEDED` of `libpcap` |
| `libpcap0.8t64` | `libs`, `copyright` | Packet capture library |
| `tcpdump` | `bins`, `sysusers-config`, `copyright` | `tcpdump` + the `tcpdump` sysusers drop-in |

Debian's `tcpdump` relinquishes privileges to the `tcpdump` user whenever it runs
as root, so `sysusers-config` ships `/usr/lib/sysusers.d/tcpdump.conf` --
`systemd-sysusers` creates the user, otherwise `-Z <user>` is needed.

`libpcap0.8t64` is also a dependency of `arping` and is added identically in
#1167.

Left out: `/etc/apparmor.d/usr.bin.tcpdump` (needs `apparmor_parser` and an
AppArmor-enabled kernel; no other SDF here ships a per-package profile).

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
