### PR TITLE
feat(26.04): add arping slices

### DIFF
--- a/slices/arping.yaml
+++ b/slices/arping.yaml
@@ -1,0 +1,23 @@
+package: arping
+
+essential:
+  arping_copyright:
+
+slices:
+  # /usr/include/arping.h ships in the runtime deb (there is no -dev package)
+  # but there is no library to build against, so it is left out.
+  bins:
+    hint: ARP level ping utility
+    essential:
+      libc6_libs:
+      libnet9_libs:
+      libpcap0.8t64_libs:
+      libseccomp2_libs:
+    contents:
+      # arping drops privileges to "nobody" and chroots before sending, so a
+      # rootfs also needs base-passwd_data for the passwd entry.
+      /usr/sbin/arping:
+
+  copyright:
+    contents:
+      /usr/share/doc/arping/copyright:

--- a/slices/libibverbs1.yaml
+++ b/slices/libibverbs1.yaml
@@ -1,0 +1,20 @@
+package: libibverbs1
+
+essential:
+  libibverbs1_copyright:
+
+slices:
+  # The adduser dependency is only used by the postinst, to create the "rdma"
+  # group; maintainer scripts are handled differently in Chisel.
+  libs:
+    hint: InfiniBand and RDMA userspace library
+    essential:
+      libc6_libs:
+      libnl-3-200_libs:
+      libnl-route-3-200_libs:
+    contents:
+      /usr/lib/*-linux-*/libibverbs.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libibverbs1/copyright:

--- a/slices/libnet9.yaml
+++ b/slices/libnet9.yaml
@@ -1,0 +1,16 @@
+package: libnet9
+
+essential:
+  libnet9_copyright:
+
+slices:
+  libs:
+    hint: Low level packet construction library
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libnet.so.9*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libnet9/copyright:

--- a/slices/libpcap0.8t64.yaml
+++ b/slices/libpcap0.8t64.yaml
@@ -1,0 +1,19 @@
+package: libpcap0.8t64
+
+essential:
+  libpcap0.8t64_copyright:
+
+slices:
+  libs:
+    hint: Packet capture library
+    essential:
+      libc6_libs:
+      libdbus-1-3_libs:
+      libibverbs1_libs:
+    contents:
+      /usr/lib/*-linux-*/libpcap.so.0.8:  # Symlink to libpcap.so.1.10.x
+      /usr/lib/*-linux-*/libpcap.so.1.10*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpcap0.8t64/copyright:

--- a/tests/spread/integration/arping/task.yaml
+++ b/tests/spread/integration/arping/task.yaml
@@ -1,0 +1,45 @@
+summary: Integration tests for arping
+
+execute: |
+  # arping drops privileges to "nobody" and chroots before it sends, so the
+  # rootfs needs the passwd entry from base-passwd.
+  rootfs="$(install-slices arping_bins base-passwd_data)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  out="$(chroot "${rootfs}" /usr/sbin/arping -h 2>&1)"
+  echo "${out}" | grep -Fiq "arping 2."
+  echo "${out}" | grep -Fq "usage: arping"
+
+  # Send real ARP requests to the default gateway: it is on the local link, so
+  # no external network is involved, and it always answers ARP.
+  gw="$(ip -4 route show default | awk '{print $3; exit}')"
+  iface="$(ip -4 route show default | awk '{print $5; exit}')"
+  test -n "${gw}"
+  test -n "${iface}"
+
+  arp() { chroot "${rootfs}" /usr/sbin/arping -i "${iface}" "$@"; }
+
+  out="$(arp -c 2 -w 5 "${gw}" 2>&1)"
+  echo "${out}" | grep -Fq "ARPING ${gw}"
+  echo "${out}" | grep -Eq "2 packets transmitted, [12] packets received"
+
+  # -r prints only the resolved MAC address.
+  mac="$(arp -r -c 1 -w 5 "${gw}")"
+  echo "${mac}" | grep -Eq '^([0-9a-f]{2}:){5}[0-9a-f]{2}$'
+
+  # -q stays silent on success (stdout only: spread runs the task with -x).
+  out="$(arp -q -c 1 -w 5 "${gw}")"
+  test -z "${out}"
+
+  # -0 sends with 0.0.0.0 as the sender address.
+  out="$(arp -0 -c 1 -w 5 "${gw}" 2>&1)"
+  echo "${out}" | grep -Eq "1 packets transmitted, 1 packets received"
+
+  # -v reports the sender's own interface details before pinging.
+  out="$(arp -v -c 1 -w 5 "${gw}" 2>&1)"
+  echo "${out}" | grep -Fq "Interface: ${iface}"
+
+  # An unused link-local address must not answer, and that is an error exit.
+  rc=0
+  arp -c 1 -w 2 169.254.111.222 >/dev/null 2>&1 || rc=$?
+  test "${rc}" -eq 1

--- a/tests/spread/integration/libibverbs1/task.yaml
+++ b/tests/spread/integration/libibverbs1/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for libibverbs1
+
+execute: |
+  rootfs="$(install-slices libibverbs1_libs)"
+
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libibverbs.so.1; do
+    rel="${lib#"${rootfs}"}"
+
+    # The soname symlink and the versioned object both have to land.
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+
+    # The dynamic linker has to resolve the whole closure from inside the
+    # rootfs: anything the slice forgot shows up as "not found".
+    ld="$(find "${rootfs}/usr/lib" -maxdepth 2 -name 'ld*.so.*' -print -quit)"
+    test -n "${ld}"
+    out="$(chroot "${rootfs}" "${ld#"${rootfs}"}" --list "${rel}")"
+    echo "${out}" | grep -Fq "libc.so.6 =>"
+    echo "${out}" | grep -Fq "libnl-3.so.200 =>"
+    echo "${out}" | grep -Fq "libnl-route-3.so.200 =>"
+    ! echo "${out}" | grep -Fq "not found"
+  done

--- a/tests/spread/integration/libnet9/task.yaml
+++ b/tests/spread/integration/libnet9/task.yaml
@@ -1,0 +1,25 @@
+summary: Integration tests for libnet9
+
+execute: |
+  rootfs="$(install-slices libnet9_libs)"
+
+  # Both the soname symlink and the versioned object have to land.
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libnet.so.9; do
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+  done
+
+  # Prove the library loads and works by pairing it with its consumer in a fresh
+  # rootfs: libnet builds every ARP frame arping puts on the wire below.
+  rootfs="$(install-slices libnet9_libs arping_bins base-passwd_data)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  gw="$(ip -4 route show default | awk '{print $3; exit}')"
+  iface="$(ip -4 route show default | awk '{print $5; exit}')"
+  test -n "${gw}"
+  test -n "${iface}"
+
+  out="$(chroot "${rootfs}" /usr/sbin/arping -i "${iface}" -c 1 -w 5 "${gw}" 2>&1)"
+  echo "${out}" | grep -Eq "1 packets transmitted, 1 packets received"

--- a/tests/spread/integration/libpcap0.8t64/task.yaml
+++ b/tests/spread/integration/libpcap0.8t64/task.yaml
@@ -1,0 +1,24 @@
+summary: Integration tests for libpcap0.8t64
+
+execute: |
+  rootfs="$(install-slices libpcap0.8t64_libs)"
+
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libpcap.so.0.8; do
+    rel="${lib#"${rootfs}"}"
+
+    # The soname symlink and the versioned object both have to land.
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+
+    # The dynamic linker has to resolve the whole closure from inside the
+    # rootfs: anything the slice forgot shows up as "not found".
+    ld="$(find "${rootfs}/usr/lib" -maxdepth 2 -name 'ld*.so.*' -print -quit)"
+    test -n "${ld}"
+    out="$(chroot "${rootfs}" "${ld#"${rootfs}"}" --list "${rel}")"
+    echo "${out}" | grep -Fq "libc.so.6 =>"
+    echo "${out}" | grep -Fq "libibverbs.so.1 =>"
+    echo "${out}" | grep -Fq "libdbus-1.so.3 =>"
+    ! echo "${out}" | grep -Fq "not found"
+  done


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `arping` and its dependency chain on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `libibverbs1` | `libs`, `copyright` | Leaf library; `DT_NEEDED` of `libpcap` |
| `libnet9` | `libs`, `copyright` | Packet construction library; carried over from `libnet1` on 24.04/25.10 |
| `libpcap0.8t64` | `libs`, `copyright` | Packet capture library |
| `arping` | `bins`, `copyright` | ARP level ping utility |

`libpcap0.8t64` and `libibverbs1` are also dependencies of `tcpdump` and are
added byte-identically in #1166, so whichever lands first the other still merges.

`arping` drops privileges to `nobody` before sending, so a rootfs also needs
`base-passwd_data`. `/usr/include/arping.h` is left out: it ships in the runtime
deb, but there is no library to build against.

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
