### PR TITLE
feat(26.04): add ipmitool slices

### DIFF
--- a/slices/freeipmi-common.yaml
+++ b/slices/freeipmi-common.yaml
@@ -1,0 +1,17 @@
+package: freeipmi-common
+
+essential:
+  freeipmi-common_copyright:
+
+slices:
+  config:
+    hint: FreeIPMI configuration files
+    contents:
+      /etc/freeipmi/freeipmi.conf: {mode: 0640}
+      /etc/freeipmi/freeipmi_interpret_sel.conf:
+      /etc/freeipmi/freeipmi_interpret_sensor.conf:
+      /etc/freeipmi/libipmiconsole.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/freeipmi-common/copyright:

--- a/slices/ipmitool.yaml
+++ b/slices/ipmitool.yaml
@@ -1,0 +1,38 @@
+package: ipmitool
+
+essential:
+  ipmitool_copyright:
+
+slices:
+  # /etc/init.d/ipmievd is left out: the systemd unit below supersedes it, and
+  # it also needs start-stop-daemon plus the runlevel links update-rc.d creates.
+  bins:
+    hint: IPMI baseboard management utility
+    essential:
+      ipmitool_data:
+      libc6_libs:
+      libfreeipmi17_libs:
+      libreadline8t64_libs:
+      libssl3t64_libs:
+    contents:
+      /usr/bin/ipmitool:
+      /usr/sbin/ipmievd:
+
+  data:
+    hint: IANA PEN and OEM SEL tables
+    contents:
+      # enterprise-numbers.txt is the IANA Private Enterprise Number registry,
+      # loaded from this path on every run. oem_ibm_sel_map is the IBM OEM SEL
+      # decode table, read via IPMI_OEM_IBM_DATAFILE with "-o ibm".
+      /usr/share/ipmitool/oem_ibm_sel_map:
+      /usr/share/misc/enterprise-numbers.txt:
+
+  services:
+    essential:
+      ipmitool_bins:
+    contents:
+      /usr/lib/systemd/system/ipmievd.service:
+
+  copyright:
+    contents:
+      /usr/share/doc/ipmitool/copyright:

--- a/slices/libfreeipmi17.yaml
+++ b/slices/libfreeipmi17.yaml
@@ -1,0 +1,18 @@
+package: libfreeipmi17
+
+essential:
+  libfreeipmi17_copyright:
+
+slices:
+  libs:
+    hint: IPMI protocol library
+    essential:
+      freeipmi-common_config:
+      libc6_libs:
+      libgcrypt20_libs:
+    contents:
+      /usr/lib/*-linux-*/libfreeipmi.so.17*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfreeipmi17/copyright:

--- a/tests/spread/integration/freeipmi-common/task.yaml
+++ b/tests/spread/integration/freeipmi-common/task.yaml
@@ -1,0 +1,36 @@
+summary: Integration tests for freeipmi-common
+
+execute: |
+  # freeipmi-common ships configuration only, so install it together with the
+  # library that reads it and prove both land in a usable state.
+  rootfs="$(install-slices freeipmi-common_config libfreeipmi17_libs)"
+
+  # Each file has to be the real thing, identified by its own header, not an
+  # empty placeholder.
+  conf="${rootfs}/etc/freeipmi"
+  grep -Fq "FreeIPMI configuration" "${conf}/freeipmi.conf"
+  grep -Fq "FreeIPMI Interpret SEL" "${conf}/freeipmi_interpret_sel.conf"
+  grep -Fq "FreeIPMI Interpret Sensor" "${conf}/freeipmi_interpret_sensor.conf"
+  grep -Fq "Libipmiconsole defaults" "${conf}/libipmiconsole.conf"
+
+  # freeipmi.conf can hold BMC credentials, so it must stay unreadable to
+  # group and other. The other three are ordinary 0644.
+  test "$(stat -c '%a' "${conf}/freeipmi.conf")" = "640"
+  for c in freeipmi_interpret_sel freeipmi_interpret_sensor libipmiconsole; do
+    test "$(stat -c '%a' "${conf}/${c}.conf")" = "644"
+  done
+
+  # All four are shipped as templates with every directive commented out, so
+  # installing them cannot change library or tool defaults. Assert that: no
+  # line outside a comment carries anything.
+  for c in "${conf}"/*.conf; do
+    ! grep -qvE '^[[:space:]]*(#|$)' "${c}"
+  done
+
+  # Pair with the consumer: ipmitool links libfreeipmi, and libfreeipmi resolves
+  # its /etc/freeipmi lookups at runtime, so the two have to co-install and run.
+  rootfs="$(install-slices freeipmi-common_config ipmitool_bins)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -V)"
+  echo "${out}" | grep -Fq "ipmitool version 1.8"

--- a/tests/spread/integration/ipmitool/task.yaml
+++ b/tests/spread/integration/ipmitool/task.yaml
@@ -1,0 +1,72 @@
+summary: Integration tests for ipmitool
+
+execute: |
+  rootfs="$(install-slices ipmitool_bins)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -V)"
+  echo "${out}" | grep -Fq "ipmitool version 1.8"
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -h 2>&1)"
+  echo "${out}" | grep -Fq "usage: ipmitool"
+
+  # The command and OEM tables are built in, so they list without a BMC.
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool help 2>&1)"
+  echo "${out}" | grep -Fq "Send a RAW IPMI request"
+  echo "${out}" | grep -Fq "Print System Event Log"
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -o list 2>&1)"
+  echo "${out}" | grep -Fq "OEM Support:"
+  echo "${out}" | grep -Fq "supermicro"
+
+  # The "open" interface talks to the kernel IPMI driver, which a chroot has no
+  # access to; reaching that error proves the interface plugin was selected and
+  # initialised.
+  rc=0
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -I open mc info 2>&1)" || rc=$?
+  echo "${out}" | grep -Fiq "could not open device at /dev/ipmi0"
+
+  # The lanplus interface sets up an RMCP+ session, which is where the OpenSSL
+  # dependency is exercised. 127.0.0.1:623 has no BMC, so the handshake fails
+  # after one bounded retry -- but only after the crypto path has run.
+  rc=0
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -I lanplus -H 127.0.0.1 \
+    -U chisel -P chisel -R 1 -N 1 mc info 2>&1)" || rc=$?
+  test "${rc}" -ne 0
+  echo "${out}" | grep -Fiq "rmcp+"
+
+  # The IANA Private Enterprise Number registry is loaded from
+  # /usr/share/misc/enterprise-numbers.txt on every run. -v -v reports the load,
+  # and reports "registry open failed" when the file is not there, so the
+  # absence of that line proves the data slice landed at the expected path.
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -I lanplus -H 127.0.0.1 \
+    -U chisel -P chisel -R 1 -N 1 -v -v mc info 2>&1 || true)"
+  echo "${out}" | grep -Fq "Loading IANA PEN Registry"
+  ! echo "${out}" | grep -Fiq "IANA PEN registry open failed"
+
+  # The IBM OEM SEL decode table is read from IPMI_OEM_IBM_DATAFILE. "nrecs="
+  # counts the records parsed out of that file, so a non-zero count proves
+  # oem_ibm_sel_map landed and parses.
+  out="$(IPMI_OEM_IBM_DATAFILE=/usr/share/ipmitool/oem_ibm_sel_map \
+    chroot "${rootfs}" /usr/bin/ipmitool -o ibm -I open sel list 2>&1 || true)"
+  echo "${out}" | grep -Eq "nrecs=[1-9][0-9]*"
+
+  # ... and it really is read from that file: a missing one is reported.
+  out="$(IPMI_OEM_IBM_DATAFILE=/nonexistent \
+    chroot "${rootfs}" /usr/bin/ipmitool -o ibm -I open sel list 2>&1 || true)"
+  echo "${out}" | grep -Fq "Could not open /nonexistent file"
+
+  # ipmievd is the event daemon. Its command table lists without a BMC; running
+  # it for real needs the kernel IPMI driver, so it stops at the same device
+  # error as ipmitool above.
+  out="$(chroot "${rootfs}" /usr/sbin/ipmievd -V)"
+  echo "${out}" | grep -Fq "ipmievd version 1.8"
+  out="$(chroot "${rootfs}" /usr/sbin/ipmievd help 2>&1)"
+  echo "${out}" | grep -Fq "Poll SEL for notification of events"
+  rc=0
+  out="$(chroot "${rootfs}" /usr/sbin/ipmievd -I open open 2>&1)" || rc=$?
+  echo "${out}" | grep -Fiq "could not open device at /dev/ipmi0"
+
+  # ipmitool_services -- the unit and the binary it starts.
+  rootfs="$(install-slices ipmitool_services)"
+  unit="${rootfs}/usr/lib/systemd/system/ipmievd.service"
+  grep -Fq "ExecStart=/usr/sbin/ipmievd open daemon" "${unit}"
+  test -x "${rootfs}/usr/sbin/ipmievd"

--- a/tests/spread/integration/libfreeipmi17/task.yaml
+++ b/tests/spread/integration/libfreeipmi17/task.yaml
@@ -1,0 +1,39 @@
+summary: Integration tests for libfreeipmi17
+
+execute: |
+  rootfs="$(install-slices libfreeipmi17_libs)"
+
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libfreeipmi.so.17; do
+    rel="${lib#"${rootfs}"}"
+
+    # The soname symlink and the versioned object both have to land.
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+
+    # The dynamic linker has to resolve the whole closure from inside the
+    # rootfs: anything the slice forgot shows up as "not found".
+    ld="$(find "${rootfs}/usr/lib" -maxdepth 2 -name 'ld*.so.*' -print -quit)"
+    test -n "${ld}"
+    out="$(chroot "${rootfs}" "${ld#"${rootfs}"}" --list "${rel}")"
+    echo "${out}" | grep -Fq "libc.so.6 =>"
+    echo "${out}" | grep -Fq "libgcrypt.so.20 =>"
+    ! echo "${out}" | grep -Fq "not found"
+  done
+
+  # freeipmi-common comes in through the libs slice's essential, because the
+  # library reads its interpretation rules from /etc/freeipmi.
+  grep -Fq "FreeIPMI Interpret SEL" \
+    "${rootfs}/etc/freeipmi/freeipmi_interpret_sel.conf"
+  grep -Fq "FreeIPMI Interpret Sensor" \
+    "${rootfs}/etc/freeipmi/freeipmi_interpret_sensor.conf"
+
+  # Prove the library loads and works by pairing it with its consumer in a fresh
+  # rootfs: libfreeipmi is a DT_NEEDED of ipmitool, so ipmitool cannot even
+  # print its version unless the library resolves.
+  rootfs="$(install-slices libfreeipmi17_libs ipmitool_bins)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  out="$(chroot "${rootfs}" /usr/bin/ipmitool -V)"
+  echo "${out}" | grep -Fq "ipmitool version 1.8"


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `ipmitool` and its dependency chain on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `freeipmi-common` | `config`, `copyright` | `/etc/freeipmi` defaults; `Architecture: all` |
| `libfreeipmi17` | `libs`, `copyright` | IPMI protocol library |
| `ipmitool` | `bins`, `data`, `services`, `copyright` | `ipmitool` + `ipmievd`, IANA PEN / IBM OEM SEL tables, systemd unit |

`data` carries `/usr/share/misc/enterprise-numbers.txt` (the IANA Private
Enterprise Number registry, loaded on every run) and
`/usr/share/ipmitool/oem_ibm_sel_map` (read via `IPMI_OEM_IBM_DATAFILE` with
`-o ibm`).

`/etc/init.d/ipmievd` is left out: the shipped systemd unit supersedes it, and it
also needs `start-stop-daemon` plus the runlevel links `update-rc.d` creates.

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
