### PR TITLE
feat(26.04): add python3-protobuf slices

### DIFF
--- a/slices/python3-protobuf.yaml
+++ b/slices/python3-protobuf.yaml
@@ -1,0 +1,17 @@
+package: python3-protobuf
+
+essential:
+  python3-protobuf_copyright:
+
+slices:
+  libs:
+    hint: Protocol Buffers Python bindings
+    essential:
+      python3_standard:
+    contents:
+      /usr/lib/python3/dist-packages/google/protobuf/**:
+      /usr/lib/python3/dist-packages/protobuf-*.egg-info/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-protobuf/copyright:

--- a/tests/spread/integration/python3-protobuf/task.yaml
+++ b/tests/spread/integration/python3-protobuf/task.yaml
@@ -1,0 +1,27 @@
+summary: Integration tests for python3-protobuf
+
+execute: |
+  rootfs="$(install-slices python3-protobuf_libs)"
+
+  # The module is a PEP 420 namespace package: the deb ships no
+  # google/__init__.py, so "google" only resolves if the directory itself lands.
+  test -d "${rootfs}/usr/lib/python3/dist-packages/google/protobuf"
+  ! test -e "${rootfs}/usr/lib/python3/dist-packages/google/__init__.py"
+
+  # Importing the package and every generated well-known type module has to work
+  # from the sliced tree alone.
+  chroot "${rootfs}" /usr/bin/python3 -c \
+    'import google.protobuf; print(google.protobuf.__version__)' | grep -Fq "4.21"
+
+  # Distribution metadata has to be discoverable, so consumers can version-check.
+  out="$(chroot "${rootfs}" /usr/bin/python3 -c \
+    'from importlib.metadata import version; print(version("protobuf"))')"
+  echo "${out}" | grep -Fq "4.21"
+
+  # The functional suite: serialisation, JSON and text formats, runtime message
+  # construction and descriptor handling.
+  cp test_protobuf.py "${rootfs}/test_protobuf.py"
+  out="$(chroot "${rootfs}" /usr/bin/python3 /test_protobuf.py)"
+  echo "${out}" | grep -Fq "ALL-PROTOBUF-CHECKS-PASSED"
+  # Debian ships the pure-Python implementation only -- no _message extension.
+  echo "${out}" | grep -Fq "implementation python"

--- a/tests/spread/integration/python3-protobuf/test_protobuf.py
+++ b/tests/spread/integration/python3-protobuf/test_protobuf.py
@@ -1,0 +1,75 @@
+import json
+
+from google.protobuf import __version__ as pb_version
+from google.protobuf import json_format, proto_builder, text_format
+from google.protobuf.internal import api_implementation
+from google.protobuf import descriptor_pb2, duration_pb2, struct_pb2, timestamp_pb2
+
+print("version", pb_version)
+print("implementation", api_implementation.Type())
+
+# --- well-known types: build, serialise, parse back -----------------------
+ts = timestamp_pb2.Timestamp()
+ts.FromJsonString("2026-04-23T17:07:15Z")
+wire = ts.SerializeToString()
+again = timestamp_pb2.Timestamp()
+again.ParseFromString(wire)
+assert again == ts, (again, ts)
+assert again.ToJsonString() == "2026-04-23T17:07:15Z", again.ToJsonString()
+print("timestamp seconds", again.seconds)
+
+d = duration_pb2.Duration()
+d.FromSeconds(90)
+assert d.ToJsonString() == "90s", d.ToJsonString()
+
+# --- Struct + json_format round trip -------------------------------------
+s = struct_pb2.Struct()
+s.update({"name": "chisel", "count": 3, "ok": True, "items": [1, 2]})
+as_json = json.loads(json_format.MessageToJson(s))
+assert as_json == {"name": "chisel", "count": 3, "ok": True, "items": [1, 2]}, as_json
+back = json_format.Parse(json.dumps(as_json), struct_pb2.Struct())
+assert back == s
+
+# --- text_format round trip ----------------------------------------------
+text = text_format.MessageToString(ts)
+assert "seconds:" in text, text
+parsed = text_format.Parse(text, timestamp_pb2.Timestamp())
+assert parsed == ts
+
+# --- runtime message construction (no protoc, no .proto file) ------------
+Cls = proto_builder.MakeSimpleProtoClass(
+    {"host": descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+     "port": descriptor_pb2.FieldDescriptorProto.TYPE_INT32},
+    full_name="chisel.Endpoint",
+)
+msg = Cls(host="example.invalid", port=8080)
+rt = Cls()
+rt.ParseFromString(msg.SerializeToString())
+assert rt.host == "example.invalid" and rt.port == 8080, rt
+print("built message", rt.host, rt.port)
+
+# --- descriptors -----------------------------------------------------------
+fields = [f.name for f in timestamp_pb2.Timestamp.DESCRIPTOR.fields]
+assert fields == ["seconds", "nanos"], fields
+
+fdp = descriptor_pb2.FileDescriptorProto()
+fdp.name = "chisel.proto"
+fdp.package = "chisel"
+m = fdp.message_type.add()
+m.name = "Thing"
+f = m.field.add()
+f.name = "label"
+f.number = 1
+f.type = descriptor_pb2.FieldDescriptorProto.TYPE_STRING
+f.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+rt = descriptor_pb2.FileDescriptorProto()
+rt.ParseFromString(fdp.SerializeToString())
+assert rt.message_type[0].field[0].name == "label", rt
+
+# --- unknown field preservation -------------------------------------------
+raw = Cls(host="a", port=1).SerializeToString()
+other = timestamp_pb2.Timestamp()
+other.ParseFromString(raw)
+assert len(other.SerializeToString()) == len(raw), "unknown fields not preserved"
+
+print("ALL-PROTOBUF-CHECKS-PASSED")


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `python3-protobuf` on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `python3-protobuf` | `libs`, `copyright` | Pure-Python Protocol Buffers runtime (`google.protobuf`) |

`Depends: python3:any` only, so `python3_standard` is the single essential.
The `libs` slice ships the module tree plus the `protobuf-*.egg-info` metadata so
`importlib.metadata.version("protobuf")` keeps working, following the pattern of
`python3-setuptools` and `python3-wheel`.

`google` is a PEP 420 namespace package -- the deb ships no
`google/__init__.py` -- which the test asserts explicitly.

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
