### PR TITLE
feat(26.04): add python3-smbus slices

### DIFF
--- a/slices/libi2c0.yaml
+++ b/slices/libi2c0.yaml
@@ -1,0 +1,16 @@
+package: libi2c0
+
+essential:
+  libi2c0_copyright:
+
+slices:
+  libs:
+    hint: SMBus and I2C userspace library
+    essential:
+      libc6_libs:
+    contents:
+      /usr/lib/*-linux-*/libi2c.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libi2c0/copyright:

--- a/slices/python3-smbus.yaml
+++ b/slices/python3-smbus.yaml
@@ -1,0 +1,19 @@
+package: python3-smbus
+
+essential:
+  python3-smbus_copyright:
+
+slices:
+  libs:
+    hint: SMBus Python bindings
+    essential:
+      libc6_libs:
+      libi2c0_libs:
+      python3_core:
+    contents:
+      /usr/lib/python3/dist-packages/smbus-*.egg-info/**:
+      /usr/lib/python3/dist-packages/smbus.cpython-314-*-linux-*.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/python3-smbus/copyright:

--- a/tests/spread/integration/libi2c0/task.yaml
+++ b/tests/spread/integration/libi2c0/task.yaml
@@ -1,0 +1,33 @@
+summary: Integration tests for libi2c0
+
+execute: |
+  rootfs="$(install-slices libi2c0_libs)"
+
+  for lib in "${rootfs}"/usr/lib/*-linux-*/libi2c.so.0; do
+    rel="${lib#"${rootfs}"}"
+
+    # The soname symlink and the versioned object both have to land.
+    test -L "${lib}"
+    target="$(readlink -f "${lib}")"
+    test -f "${target}"
+    head -c4 "${target}" | grep -Fq "ELF"
+
+    # The dynamic linker has to resolve the whole closure from inside the
+    # rootfs: anything the slice forgot shows up as "not found".
+    ld="$(find "${rootfs}/usr/lib" -maxdepth 2 -name 'ld*.so.*' -print -quit)"
+    test -n "${ld}"
+    out="$(chroot "${rootfs}" "${ld#"${rootfs}"}" --list "${rel}")"
+    echo "${out}" | grep -Fq "libc.so.6 =>"
+    ! echo "${out}" | grep -Fq "not found"
+  done
+
+  # Prove the library loads and works by pairing it with its consumer in a fresh
+  # rootfs: the smbus extension module has libi2c.so.0 as a DT_NEEDED, so the
+  # import only succeeds once the linker resolves it.
+  rootfs="$(install-slices libi2c0_libs python3-smbus_libs)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  out="$(chroot "${rootfs}" /usr/bin/python3 -c \
+    'import smbus; print(sorted(a for a in dir(smbus.SMBus) if a[0] != "_"))')"
+  echo "${out}" | grep -Fq "read_i2c_block_data"
+  echo "${out}" | grep -Fq "write_i2c_block_data"

--- a/tests/spread/integration/python3-smbus/task.yaml
+++ b/tests/spread/integration/python3-smbus/task.yaml
@@ -1,0 +1,21 @@
+summary: Integration tests for python3-smbus
+
+execute: |
+  rootfs="$(install-slices python3-smbus_libs)"
+  mkdir -p "${rootfs}/dev" && touch "${rootfs}/dev/null"
+
+  # A plain file standing in for an i2c-dev node: open(2) succeeds so the module
+  # gets as far as issuing real ioctl(2) calls. Loading i2c-stub would need a
+  # kernel module, which is not available in every CI backend.
+  touch "${rootfs}/dev/i2c-9"
+  chmod 666 "${rootfs}/dev/i2c-9"
+
+  # The extension has libi2c.so.0 as a DT_NEEDED, so importing it at all proves
+  # libi2c0_libs came in and resolved.
+  chroot "${rootfs}" /usr/bin/python3 -c 'import smbus'
+
+  cp test_smbus.py "${rootfs}/test_smbus.py"
+  out="$(chroot "${rootfs}" /usr/bin/python3 /test_smbus.py)"
+  echo "${out}" | grep -Fq "ALL-SMBUS-CHECKS-PASSED"
+  echo "${out}" | grep -Fq "version 1.1"
+  echo "${out}" | grep -Fq "ioctl rejected as expected"

--- a/tests/spread/integration/python3-smbus/test_smbus.py
+++ b/tests/spread/integration/python3-smbus/test_smbus.py
@@ -1,0 +1,68 @@
+import errno
+from importlib.metadata import version
+
+import smbus
+
+# The extension module must be the one from the slice.
+assert smbus.__file__.startswith("/usr/lib/python3/dist-packages/smbus."), smbus.__file__
+print("module", smbus.__file__)
+
+# Distribution metadata from the shipped egg-info.
+print("version", version("smbus"))
+
+# The full SMBus API surface has to be there.
+expected = {
+    "block_process_call", "close", "open", "pec", "process_call",
+    "read_block_data", "read_byte", "read_byte_data", "read_i2c_block_data",
+    "read_word_data", "write_block_data", "write_byte", "write_byte_data",
+    "write_i2c_block_data", "write_quick", "write_word_data",
+}
+present = {a for a in dir(smbus.SMBus) if not a.startswith("_")}
+assert expected <= present, expected - present
+
+# Opening a bus that does not exist has to surface the open(2) error.
+try:
+    smbus.SMBus(999)
+except FileNotFoundError as e:
+    assert e.errno == errno.ENOENT, e
+    print("missing bus ->", e.errno)
+else:
+    raise AssertionError("SMBus(999) unexpectedly succeeded")
+
+# An unopened object has no descriptor to talk to.
+bus = smbus.SMBus()
+try:
+    bus.read_byte(0x50)
+except OSError as e:
+    assert e.errno == errno.EBADF, e
+    print("unopened ->", e.errno)
+else:
+    raise AssertionError("read_byte on an unopened bus unexpectedly succeeded")
+
+# /dev/i2c-9 is a plain file created by the task, so open(2) succeeds and every
+# transfer below reaches a real ioctl(2) that the kernel rejects because the
+# target is not an i2c-dev character device. That is enough to prove the module
+# drives the kernel interface rather than failing earlier.
+bus = smbus.SMBus(9)
+for call in (lambda: bus.read_byte(0x50),
+             lambda: bus.write_quick(0x50),
+             lambda: bus.read_byte_data(0x50, 0x00),
+             lambda: bus.read_i2c_block_data(0x50, 0x00, 4)):
+    try:
+        call()
+    except OSError as e:
+        assert e.errno == errno.ENOTTY, e
+    else:
+        raise AssertionError("transfer on a non-i2c device unexpectedly succeeded")
+print("ioctl rejected as expected")
+
+bus.close()
+try:
+    bus.read_byte(0x50)
+except OSError as e:
+    assert e.errno == errno.EBADF, e
+    print("after close ->", e.errno)
+else:
+    raise AssertionError("read_byte after close unexpectedly succeeded")
+
+print("ALL-SMBUS-CHECKS-PASSED")


### PR DESCRIPTION
# Proposed changes

Add slice definitions for `python3-smbus` and its dependency on `ubuntu-26.04`.

### Packages added

| Package | Slices | Notes |
|---------|--------|-------|
| `libi2c0` | `libs`, `copyright` | SMBus/I2C userspace library |
| `python3-smbus` | `libs`, `copyright` | `smbus` C extension module + `smbus-*.egg-info` |

Both come from the `i2c-tools` source. The `libi2c0` SDF matches the one proposed
in the closed #1004.

The extension has `libi2c.so.0` as a `DT_NEEDED`, so importing `smbus` at all
proves `libi2c0_libs` resolved. `python3_core` is enough -- the module pulls in no
stdlib beyond the interpreter.

## Checklist
* [x] I have read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](https://ubuntu.com/legal/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->
