### PR TITLE
feat(ci): support releases with bin slices files

### DIFF
--- a/.github/scripts/forward-port-missing/forward_port_missing.py
+++ b/.github/scripts/forward-port-missing/forward_port_missing.py
@@ -13,27 +13,26 @@ Any slices for any discontinued packages are ignored.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import argparse
-import tempfile
 import datetime
 import gzip
 import io
 import logging
 import os
 import re
-from concurrent.futures import ThreadPoolExecutor
-from itertools import product
 import subprocess as sub
-from dataclasses import dataclass
-from contextlib import contextmanager
+import tempfile
 import time
-from typing import Iterator, Callable
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from itertools import product
+from pathlib import Path
+from typing import Callable, Iterator
 
-from diff_parser import Diff
 import requests
 import yaml
+from diff_parser import Diff
 
 # For dev you can use requests-cache to cache the
 # GitHub API responses and avoid hitting rate limits:
@@ -82,6 +81,29 @@ class PR:
         )
 
 
+# Regex matching a top-level "store: bin" key in the added lines of a diff
+# block. The key must be at the start of a line (no indentation), so that a
+# nested key of the same name does not match.
+_BIN_STORE_RE = re.compile(r"^\+store:\s*bin\s*$", re.MULTILINE)
+
+
+def _diff_adds_bin_store(diff_text: str, filepath: str) -> bool:
+    """Whether the given diff adds a top-level "store: bin" key to the given
+    file. Used to detect bin SDFs from a PR diff, where the file content itself
+    is not available."""
+    # Extract the block of the diff corresponding to the given file
+    block_start = diff_text.find(f"diff --git a/{filepath} b/{filepath}")
+    if block_start == -1:
+        return False
+    next_block = diff_text.find("\ndiff --git ", block_start + 1)
+    block = (
+        diff_text[block_start:]
+        if next_block == -1
+        else diff_text[block_start:next_block]
+    )
+    return _BIN_STORE_RE.search(block) is not None
+
+
 def fetch_prs(supported_branches: set[str] | None = None) -> set[PR]:
     """Fetch the list of open PRs into 'ubuntu-XX.XX' branches in chisel-releases which correspond to
     the supported Ubuntu releases. For each PR determine the set of new slices it introduces"""
@@ -128,8 +150,9 @@ def fetch_prs(supported_branches: set[str] | None = None) -> set[PR]:
 
     # fetch the diff for each PR in parallel and determine which slices they are modifying (i.e. which files in the /slices directory they are adding/modifying)
 
-    def _fetch_diff(pr: dict) -> tuple[int, Diff | None]:
-        """Fetch a PR's diff and return the PR number and the parsed Diff object."""
+    def _fetch_diff(pr: dict) -> tuple[int, Diff | None, str | None]:
+        """Fetch a PR's diff and return the PR number, the parsed Diff object
+        and the raw diff text (needed to inspect the added lines)."""
         with requests.Session() as s:
             response = s.get(pr["diff_url"], headers=headers)
             response.raise_for_status()
@@ -139,19 +162,21 @@ def fetch_prs(supported_branches: set[str] | None = None) -> set[PR]:
             warn(
                 f"Rate limit exceeded when fetching diff for PR #{pr_number}. Skipping."
             )
-            return pr_number, None
-        return pr_number, Diff(diff_text)
+            return pr_number, None, None
+        return pr_number, Diff(diff_text), diff_text
 
     with timing_context() as elapsed:
         with ThreadPoolExecutor(max_workers=5) as executor:
             _diffs = list(executor.map(_fetch_diff, results))
-    diffs: dict[int, Diff | None] = dict(_diffs)
+    diffs: dict[int, tuple[Diff | None, str | None]] = {
+        number: (diff, text) for number, diff, text in _diffs
+    }
 
     info(f"Fetched diffs for {len(results)} PRs in {elapsed():.2f} seconds.")
 
     # for each PR patch in a field "new_slices" based on the fetched diff
     for result in results:
-        diff = diffs.get(result["number"])
+        diff, diff_text = diffs.get(result["number"], (None, None))
         if not diff:
             warn(f"Could not fetch diff for PR #{result['number']}. Skipping.")
             continue
@@ -164,7 +189,15 @@ def fetch_prs(supported_branches: set[str] | None = None) -> set[PR]:
                     new_filepath.parent.name == "slices"
                     and new_filepath.suffix == ".yaml"
                 ):
-                    new_slices.add(new_filepath.stem)
+                    # Skip bin SDFs ("store: bin"), which are
+                    # release-specific. The key is looked up in the added
+                    # lines of the diff, as the file content itself is not
+                    # available here.
+                    # NOTE: diff_parser prefixes new_filepath with "/".
+                    if not _diff_adds_bin_store(
+                        diff_text, block.new_filepath.lstrip("/")
+                    ):
+                        new_slices.add(new_filepath.stem)
         result["new_slices"] = sorted(new_slices)
 
     return set(PR.from_github_json(r) for r in results if r.get("new_slices"))
@@ -286,8 +319,12 @@ def checkout_chisel_releases_info(
                 )
                 continue
 
+            # Skip bin SDFs ("store: bin"), which are release-specific.
+            # bin-slices/ is not scanned at all, for the same reason.
             slices_per_branch[branch] = set(
-                sdf.stem for sdf in (tmpdir / "slices").glob("*.yaml")
+                sdf.stem
+                for sdf in (tmpdir / "slices").glob("*.yaml")
+                if yaml.safe_load(sdf.read_text()).get("store") != "bin"
             )
             codenames[branch] = _codenames.pop()
 

--- a/.github/scripts/forward-port-missing/test_forward_port_missing.py
+++ b/.github/scripts/forward-port-missing/test_forward_port_missing.py
@@ -3,15 +3,15 @@
 Unit tests for forward_port_missing.py
 """
 
-import pytest
-
-import sys
-import os
 import gzip
-from unittest.mock import patch, MagicMock
-from textwrap import dedent
-from dataclasses import replace
+import os
+import sys
 from copy import deepcopy
+from dataclasses import replace
+from textwrap import dedent
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -306,3 +306,101 @@ class TestDetermineForwardPortingStatus:
 
         assert to_add == (set() if labels else {1})
         assert to_remove == set()
+
+
+class TestBinSlices:
+    """Bin SDFs ("store: bin") are excluded from forward port tracking;
+    regular SDFs are not."""
+
+    @staticmethod
+    def _make_diff(filepath: str, content: str) -> str:
+        return dedent(f"""
+        diff --git a/{filepath} b/{filepath}
+        new file mode 100644
+        index 0000000..1111111
+        --- /dev/null
+        +++ b/{filepath}
+        @@ -0,0 +1,2 @@
+        {content}
+        """).strip()
+
+    json_response = [
+        {
+            "number": 1,
+            "base": {"ref": "ubuntu-26.04"},
+            "labels": [{"name": "bug"}],
+            "diff_url": "http://example.com/diff1",
+            "draft": False,
+        }
+    ]
+
+    @patch("forward_port_missing.requests.Session")
+    def test_bin_sdf_in_slices_ignored(self, mock_session: MagicMock) -> None:
+        """PRs adding bin SDFs (store: bin) in slices/ must not be tracked"""
+        diff_text = self._make_diff("slices/foo.yaml", "+package: foo\n+store: bin")
+
+        get = _mock_session_get(mock_session)
+        get.side_effect = TestFetchPRs.make_side_effects(self.json_response, diff_text)
+        prs = forward_port_missing.fetch_prs()
+
+        assert len(prs) == 0, "bin SDFs in slices/ should be ignored"
+
+    @patch("forward_port_missing.requests.Session")
+    def test_bin_sdf_in_bin_slices_dir_ignored(self, mock_session: MagicMock) -> None:
+        """PRs adding SDFs under bin-slices/ must not be tracked"""
+        diff_text = self._make_diff("bin-slices/foo.yaml", "+package: foo\n+store: bin")
+
+        get = _mock_session_get(mock_session)
+        get.side_effect = TestFetchPRs.make_side_effects(self.json_response, diff_text)
+        prs = forward_port_missing.fetch_prs()
+
+        assert len(prs) == 0, "bin-slices/ SDFs should be ignored"
+
+    @patch("forward_port_missing.requests.Session")
+    def test_deb_sdf_in_slices_tracked(self, mock_session: MagicMock) -> None:
+        """PRs adding regular deb SDFs under slices/ must still be tracked"""
+        diff_text = self._make_diff("slices/foo.yaml", "+package: foo")
+
+        get = _mock_session_get(mock_session)
+        get.side_effect = TestFetchPRs.make_side_effects(self.json_response, diff_text)
+        prs = forward_port_missing.fetch_prs()
+
+        assert len(prs) == 1
+        pr = next(iter(prs))
+        assert pr.new_slices == frozenset(["foo"])
+
+    @patch("forward_port_missing.requests.Session")
+    def test_deb_sdf_misplaced_in_bin_slices_not_tracked(
+        self, mock_session: MagicMock
+    ) -> None:
+        """A deb SDF under bin-slices/ is not tracked (the directory is not
+        scanned for forward porting)."""
+        diff_text = self._make_diff("bin-slices/foo.yaml", "+package: foo")
+
+        get = _mock_session_get(mock_session)
+        get.side_effect = TestFetchPRs.make_side_effects(self.json_response, diff_text)
+        prs = forward_port_missing.fetch_prs()
+
+        assert len(prs) == 0, "bin-slices/ is not scanned for forward porting"
+
+    def test_diff_adds_bin_store(self) -> None:
+        """Test the _diff_adds_bin_store() helper directly"""
+        diff_text = self._make_diff("slices/foo.yaml", "+package: foo\n+store: bin")
+        assert forward_port_missing._diff_adds_bin_store(diff_text, "slices/foo.yaml")
+
+        # deb SDF (no store key)
+        diff_text = self._make_diff("slices/foo.yaml", "+package: foo")
+        assert not forward_port_missing._diff_adds_bin_store(
+            diff_text, "slices/foo.yaml"
+        )
+
+        # nested "store" key must not match (only top-level counts)
+        diff_text = self._make_diff("slices/foo.yaml", "+package: foo\n+  store: bin")
+        assert not forward_port_missing._diff_adds_bin_store(
+            diff_text, "slices/foo.yaml"
+        )
+
+        # file not in the diff
+        assert not forward_port_missing._diff_adds_bin_store(
+            diff_text, "slices/bar.yaml"
+        )

--- a/.github/scripts/install-slices/install_slices.py
+++ b/.github/scripts/install-slices/install_slices.py
@@ -28,16 +28,13 @@ import pathlib
 import subprocess
 import sys
 import tempfile
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
 
 import magic
 import requests
 import yaml
-
 from apt.debfile import DebPackage
-from concurrent.futures import ProcessPoolExecutor, as_completed
-from dataclasses import dataclass
-
-
 
 CHISEL_PKG_CACHE = pathlib.Path.home() / ".cache/chisel/sha256"
 
@@ -181,6 +178,33 @@ class Package:
 
     package: str
     slices: list[str]
+    store: str | None = None
+
+    @property
+    def is_bin(self) -> bool:
+        """
+        Whether the package comes from the "bin" store instead of the
+        Ubuntu archive. Bin packages are distributed from the Chisel store,
+        not from the Ubuntu archive, so they never take part in the
+        archive-based checks of this script (rmadison queries, deb copyright
+        check); they are installed by Chisel versions with bin store
+        support (>= 1.6.0).
+        """
+        return self.store == "bin"
+
+
+def is_bin_sdf(filepath: str | os.PathLike) -> bool:
+    """
+    Whether the given slice definition file describes a package of the "bin"
+    store, i.e. whether it carries a top-level "store: bin" key.
+    """
+    filepath = os.fspath(filepath)
+    try:
+        with open(filepath, "r", encoding="utf-8") as stream:
+            data = yaml.safe_load(stream)
+    except (OSError, yaml.YAMLError):
+        return False
+    return isinstance(data, dict) and data.get("store") == "bin"
 
 
 def full_slice_name(pkg: str, slice: str) -> str:
@@ -188,6 +212,22 @@ def full_slice_name(pkg: str, slice: str) -> str:
     Return the full slice name in "pkg_slice" format.
     """
     return f"{pkg}_{slice}"
+
+
+def chisel_supports_bin_store(chisel_version: str) -> bool:
+    """
+    Whether the given Chisel version supports the "bin" store, i.e. whether
+    it can install slices of packages distributed from the store. Support was
+    introduced in Chisel 1.6.0; "main" (development) also has it.
+    """
+    version = chisel_version.lstrip("v").split("+", 1)[0]
+    if version == "main" or version == "unknown":
+        return True
+    try:
+        return tuple(int(part) for part in version.split(".")) >= (1, 6, 0)
+    except ValueError:
+        # Unrecognized version string: assume support.
+        return True
 
 
 def parse_package(filepath: str) -> Package:
@@ -208,7 +248,7 @@ def parse_package(filepath: str) -> Package:
     except KeyError as e:
         logging.error("%s: key %s not found", filepath, e)
         sys.exit(1)
-    pkg = Package(package, slices)
+    pkg = Package(package, slices, store=data.get("store"))
     return pkg
 
 
@@ -270,11 +310,18 @@ def query_package_existence(
     found, missing = set(), set()
     for i in range(n_batches):
         batch = packages[i * batch_size : (i + 1) * batch_size]
-        logging.info("Querying packages batch %d/%d (%s ... %s)...", i + 1, n_batches, batch[0], batch[-1])
+        logging.info(
+            "Querying packages batch %d/%d (%s ... %s)...",
+            i + 1,
+            n_batches,
+            batch[0],
+            batch[-1],
+        )
         f, m = _query_package_existence(batch, archive, arch)
         found.update(f)
         missing.update(m)
     return sorted(found), sorted(missing)
+
 
 def ensure_package_existence(packages: list[str], archive: Archive) -> None:
     """
@@ -313,6 +360,7 @@ def ignore_missing_packages(
             ignored.append(p)
     return filtered, ignored
 
+
 _patterns_to_retry: list[str] = [
     # https://github.com/canonical/chisel-releases/issues/765
     "cannot fetch from archive",
@@ -321,6 +369,7 @@ _patterns_to_retry: list[str] = [
     # https://github.com/canonical/chisel-releases/issues/768
     "cannot find archive data",
 ]
+
 
 def chisel_cut(
     *,
@@ -363,7 +412,7 @@ def chisel_cut(
             if pattern in err:
                 matched = pattern
                 break
-        
+
         if attempt < n_retries and matched is not None:
             logging.warning(
                 "Error while installing %s (attempt %d/%d): %s. Retrying...",
@@ -377,12 +426,17 @@ def chisel_cut(
 
 
 def install_slices(
-    chunk: list[tuple[str, str]], dry_run: bool, arch: str, release: str, worker: int, chisel_version: str
+    chunk: list[tuple[str, str, bool]],
+    dry_run: bool,
+    arch: str,
+    release: str,
+    worker: int,
+    chisel_version: str,
 ) -> None:
     """
     Install the slice by running "chisel cut".
     """
-    for i, (pkg, slice) in enumerate(chunk):
+    for i, (pkg, slice, is_bin) in enumerate(chunk):
         slice_name = full_slice_name(pkg, slice)
         logging.info(
             "Worker %d (%d/%d): Installing %s on %s...",
@@ -394,7 +448,10 @@ def install_slices(
         )
         if dry_run:
             continue
-        with tempfile.TemporaryDirectory() as tmpfs, tempfile.TemporaryDirectory() as cache_dir:
+        with (
+            tempfile.TemporaryDirectory() as tmpfs,
+            tempfile.TemporaryDirectory() as cache_dir,
+        ):
             err = chisel_cut(
                 arch=arch,
                 release=release,
@@ -407,7 +464,10 @@ def install_slices(
                 logging.error("==============================================\n%s", err)
                 return
 
-            # Check if the copyright file has been installed with this slice
+            # Check if the copyright file has been installed with this slice.
+            # Only meaningful for deb packages: bin packages are not debs.
+            if is_bin:
+                continue
             copyright_file = pathlib.Path(f"{tmpfs}/usr/share/doc/{pkg}/copyright")
             if not copyright_file.is_file() and not copyright_file.is_symlink():
                 # Does the copyright file exist in the deb?
@@ -456,21 +516,53 @@ def main() -> None:
     cli_args = parse_args()
     # Parse slice definition files.
     packages = []
+    bin_packages = []
     for file in cli_args.files:
         pkg = parse_package(file)
-        packages.append(pkg)
+        if pkg.is_bin:
+            bin_packages.append(pkg)
+        else:
+            packages.append(pkg)
+    # Bin packages are distributed from the Chisel store, not from the
+    # Ubuntu archive, so they never take part in the archive-based checks
+    # below (rmadison queries). They can only be installed by Chisel versions
+    # with bin store support (>= 1.6.0); with older versions they are
+    # skipped, as those versions ignore the bin-slices/ directory entirely.
+    if len(bin_packages) > 0:
+        if chisel_supports_bin_store(cli_args.chisel_version):
+            logging.info(
+                "The following %s bin packages will be INSTALLED from the store:",
+                len(bin_packages),
+            )
+            for pkg in bin_packages:
+                logging.info("  - %s", pkg.package)
+            packages.extend(bin_packages)
+        else:
+            logging.info(
+                "The following %s bin packages will be SKIPPED "
+                "(Chisel %s does not support the bin store):",
+                len(bin_packages),
+                cli_args.chisel_version,
+            )
+            for pkg in bin_packages:
+                logging.info("  - %s", pkg.package)
     # Ensure package existence for at least one architecture. This means that
     # each package must be present in the archive for at least one of the
-    # architectures.
+    # architectures. Bin packages are not in the archive, so they are
+    # excluded from this check.
     if cli_args.ensure_existence:
         archive = parse_archive(cli_args.release)
-        ensure_package_existence([p.package for p in packages], archive)
+        ensure_package_existence([p.package for p in packages if not p.is_bin], archive)
     # Ignore packages who do not exist in the archive for this particular
-    # architecture.
+    # architecture. Bin packages are not in the archive, so they are kept
+    # regardless of the rmadison query result.
     if cli_args.ignore_missing:
-        packages, ignored = ignore_missing_packages(
-            packages, cli_args.arch, cli_args.release
+        deb_packages = [p for p in packages if not p.is_bin]
+        bin_packages = [p for p in packages if p.is_bin]
+        deb_packages, ignored = ignore_missing_packages(
+            deb_packages, cli_args.arch, cli_args.release
         )
+        packages = deb_packages + bin_packages
         if len(ignored) > 0:
             logging.info("The following packages will be IGNORED:")
             for pkg in ignored:
@@ -494,10 +586,14 @@ def main() -> None:
     # are going to get installed anyway). The problem here is accounting: I'd like
     # to ensure that all slices are still installed nonetheless, even if indirectly,
     # but that means `install_slices` will have to be aware of the nested essentials.
-    all_slices = [(pkg.package, slice) for pkg in packages for slice in pkg.slices]
+    all_slices = [
+        (pkg.package, slice, pkg.is_bin) for pkg in packages for slice in pkg.slices
+    ]
 
     chunk_size = math.ceil(len(all_slices) / cli_args.workers)
-    chunks_of_slices: list[tuple[list[tuple[str, str]], bool, str, str, int, str]] = [
+    chunks_of_slices: list[
+        tuple[list[tuple[str, str, bool]], bool, str, str, int, str]
+    ] = [
         (
             all_slices[i : i + chunk_size],
             cli_args.dry_run,

--- a/.github/scripts/install-slices/test_install_slices.py
+++ b/.github/scripts/install-slices/test_install_slices.py
@@ -12,19 +12,19 @@ import unittest.mock
 
 from install_slices import (
     CHISEL_PKG_CACHE,
-    Package,
     Archive,
-    parse_archive,
+    Package,
+    chisel_supports_bin_store,
+    deb_has_copyright_file,
+    ensure_package_existence,
     full_slice_name,
+    ignore_missing_packages,
+    is_bin_sdf,
+    main,
+    parse_archive,
     parse_package,
     query_package_existence,
-    ensure_package_existence,
-    ignore_missing_packages,
-    install_slice,
-    deb_has_copyright_file,
-    main,
 )
-
 
 # Default archive for testing. Copied from the ubuntu-22.04 release.
 DEFAULT_CHISEL_YAML = """
@@ -92,6 +92,21 @@ DEFAULT_PACKAGE = Package(
     slices=["bins"],
 )
 
+# Default bin package for testing ("v4" style, with the store key).
+DEFAULT_BIN_PACKAGE_YAML = """
+package: hello-bin
+store: bin
+slices:
+    bins:
+        contents:
+            /usr/bin/hello:
+"""
+DEFAULT_BIN_PACKAGE = Package(
+    package="hello-bin",
+    slices=["bins"],
+    store="bin",
+)
+
 
 class TestScriptMethods(unittest.TestCase):
     """
@@ -134,6 +149,137 @@ class TestScriptMethods(unittest.TestCase):
                     suites=["mantic", "mantic-security", "mantic-updates"],
                 ),
             )
+
+    def test_parse_bin_package(self):
+        """
+        Test parse_package() on a bin SDF ("v4" style, store key)
+        """
+        with tempfile.TemporaryDirectory() as tmpfs:
+            filepath = os.path.join(tmpfs, "hello-bin.yaml")
+            with open(filepath, "w", encoding="utf-8") as file:
+                file.write(DEFAULT_BIN_PACKAGE_YAML)
+            pkg = parse_package(filepath)
+            self.assertEqual(pkg, DEFAULT_BIN_PACKAGE)
+            self.assertTrue(pkg.is_bin)
+
+    def test_is_bin_sdf(self):
+        """
+        Test is_bin_sdf() on deb and bin SDFs, by content only
+        """
+        with tempfile.TemporaryDirectory() as tmpfs:
+            # deb SDF (no store key, not in bin-slices/)
+            deb_sdf = os.path.join(tmpfs, "hello.yaml")
+            with open(deb_sdf, "w", encoding="utf-8") as file:
+                file.write(DEFAULT_PACKAGE_YAML)
+            self.assertFalse(is_bin_sdf(deb_sdf))
+
+            # bin SDF by content ("v4" style: store key in slices/)
+            bin_sdf = os.path.join(tmpfs, "hello-bin.yaml")
+            with open(bin_sdf, "w", encoding="utf-8") as file:
+                file.write(DEFAULT_BIN_PACKAGE_YAML)
+            self.assertTrue(is_bin_sdf(bin_sdf))
+
+            # bin SDF by content ("v3" style: store key in bin-slices/)
+            bin_dir = os.path.join(tmpfs, "bin-slices")
+            os.mkdir(bin_dir)
+            bin_sdf_v3 = os.path.join(bin_dir, "hello.yaml")
+            with open(bin_sdf_v3, "w", encoding="utf-8") as file:
+                file.write(DEFAULT_BIN_PACKAGE_YAML)
+            self.assertTrue(is_bin_sdf(bin_sdf_v3))
+
+            # deb SDF under bin-slices/ is not a bin SDF (content-based
+            # detection, not location-based)
+            misplaced_deb_sdf = os.path.join(bin_dir, "oops.yaml")
+            with open(misplaced_deb_sdf, "w", encoding="utf-8") as file:
+                file.write(DEFAULT_PACKAGE_YAML)
+            self.assertFalse(is_bin_sdf(misplaced_deb_sdf))
+
+    def test_main_installs_bin_packages_with_store_support(self):
+        """
+        Test that main() installs bin packages when the Chisel version
+        supports the bin store (>= 1.6.0)
+        """
+        with tempfile.TemporaryDirectory() as tmpfs:
+            with open(os.path.join(tmpfs, "chisel.yaml"), "w", encoding="utf-8") as f:
+                f.write(DEFAULT_CHISEL_YAML)
+            slices_dir = os.path.join(tmpfs, "slices")
+            os.mkdir(slices_dir)
+            slice_path = os.path.join(slices_dir, "hello-bin.yaml")
+            with open(slice_path, "w", encoding="utf-8") as f:
+                f.write(DEFAULT_BIN_PACKAGE_YAML)
+            args = [
+                "",
+                "--arch",
+                "amd64",
+                "--release",
+                tmpfs,
+                "--chisel-version",
+                "v1.6.0",
+                slice_path,
+            ]
+            with unittest.mock.patch("sys.argv", args):
+                with (
+                    unittest.mock.patch(
+                        "install_slices.ProcessPoolExecutor"
+                    ) as mock_executor_cls,
+                    unittest.mock.patch("install_slices.as_completed", return_value=[]),
+                ):
+                    try:
+                        main()
+                    except SystemExit as e:
+                        self.assertEqual(e.code, 0)
+                    mock_executor = mock_executor_cls.return_value.__enter__()
+                    submit = mock_executor.submit
+                    submit.assert_called_once()
+                    # The bin package's slices must be in the installed chunk
+                    chunk = submit.call_args[0][1]
+                    self.assertIn(("hello-bin", "bins", True), chunk)
+
+    def test_main_skips_bin_packages_without_store_support(self):
+        """
+        Test that main() skips bin packages when the Chisel version does
+        not support the bin store (< 1.6.0)
+        """
+        with tempfile.TemporaryDirectory() as tmpfs:
+            with open(os.path.join(tmpfs, "chisel.yaml"), "w", encoding="utf-8") as f:
+                f.write(DEFAULT_CHISEL_YAML)
+            slices_dir = os.path.join(tmpfs, "slices")
+            os.mkdir(slices_dir)
+            slice_path = os.path.join(slices_dir, "hello-bin.yaml")
+            with open(slice_path, "w", encoding="utf-8") as f:
+                f.write(DEFAULT_BIN_PACKAGE_YAML)
+            args = [
+                "",
+                "--arch",
+                "amd64",
+                "--release",
+                tmpfs,
+                "--chisel-version",
+                "v1.4.2",
+                slice_path,
+            ]
+            with unittest.mock.patch("sys.argv", args):
+                with unittest.mock.patch(
+                    "install_slices.ProcessPoolExecutor"
+                ) as mock_executor_cls:
+                    try:
+                        main()
+                    except SystemExit as e:
+                        self.assertEqual(e.code, 0)
+                    mock_executor = mock_executor_cls.return_value.__enter__()
+                    mock_executor.submit.assert_not_called()
+
+    def test_chisel_supports_bin_store(self):
+        """
+        Test chisel_supports_bin_store()
+        """
+        self.assertTrue(chisel_supports_bin_store("v1.6.0"))
+        self.assertTrue(chisel_supports_bin_store("v1.6.1"))
+        self.assertTrue(chisel_supports_bin_store("main"))
+        self.assertTrue(chisel_supports_bin_store("unknown"))
+        self.assertFalse(chisel_supports_bin_store("v1.4.2"))
+        self.assertFalse(chisel_supports_bin_store("v1.2.0"))
+        self.assertFalse(chisel_supports_bin_store("1.4.2"))
 
     def test_full_slice_name(self):
         """
@@ -211,22 +357,6 @@ class TestScriptMethods(unittest.TestCase):
                 Package("foo123", []),
             ],
         )
-
-    def test_install_slice(self):
-        """
-        Test install_slice()
-        """
-        mock_missing_copyright = set()
-        install_slice("libc6", "libs", "amd64", "ubuntu-22.04", mock_missing_copyright)
-        assert mock_missing_copyright == set()
-        #
-        try:
-            install_slice(
-                "foo123", "bar", "amd64", "ubuntu-22.04", mock_missing_copyright
-            )
-            assert False
-        except SystemExit as e:
-            self.assertEqual(e.code, 1)
 
     @unittest.mock.patch("os.popen")
     @unittest.mock.patch("pathlib.Path.rglob")

--- a/.github/scripts/pkg-deps/pkg-deps
+++ b/.github/scripts/pkg-deps/pkg-deps
@@ -28,6 +28,12 @@ fi
 echo -e "Diff of dependencies:" > "$msg_file"
 for f in $@; do
   echo "Processing $f.." >&2
+  # Bin packages are distributed from the store, not from the Ubuntu
+  # archive, so their dependencies cannot be compared with apt depends.
+  if [ "$(yq -r '.store // ""' "$f")" = "bin" ]; then
+    echo "Skipping $f (bin store package, not from the archive).." >&2
+    continue
+  fi
   pkg=$(yq '.package' "$f")
 
   fupstream="$(mktemp)"

--- a/.github/scripts/removed-slices/removed-slices
+++ b/.github/scripts/removed-slices/removed-slices
@@ -25,10 +25,12 @@ curref="$(git rev-parse --short HEAD)"
 exitcode=0
 
 # Check for deleted or renamed slice definition files.
+# NOTE: the bin-slices/ directory only exists in releases using the "v3"
+# format (e.g. ubuntu-26.04); git diff ignores it when it does not exist.
 deleted_files=()
 while IFS= read -r f; do
   deleted_files+=( "$f" )
-done < <(git diff --name-only --diff-filter=DR "$oldref" "$curref" -- slices/)
+done < <(git diff --name-only --diff-filter=DR "$oldref" "$curref" -- slices/ bin-slices/)
 if (( ${#deleted_files[@]} )); then
   echo "The following slice definition files have been deleted or renamed:"
   for f in "${deleted_files[@]}"; do
@@ -43,7 +45,7 @@ fi
 modified=()
 while IFS= read -r f; do
   modified+=( "$f" )
-done < <(git diff --name-only --diff-filter=adr "$oldref" "$curref" -- slices/)
+done < <(git diff --name-only --diff-filter=adr "$oldref" "$curref" -- slices/ bin-slices/)
 
 # Lists all slices in the [modified] files.
 list() {

--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -27,8 +27,8 @@ env:
       {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
-      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.2","main"]},
-      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.4.2","main"]}
+      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.2","v1.6.0","main"]},
+      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.6.0","main"]}
     ]
 
 jobs:
@@ -159,9 +159,11 @@ jobs:
             install-all:
               - 'chisel.yaml'
               - deleted: 'slices/**/*.yaml'
+              - deleted: 'bin-slices/**/*.yaml'
               - '.github/**'
             slices:
               - added|modified: 'slices/**/*.yaml'
+              - added|modified: 'bin-slices/**/*.yaml'
           # Space delimited list usable as command-line argument list in
           # Linux shell. If needed, it uses single or double quotes to
           # wrap filename with unsafe characters.
@@ -216,15 +218,20 @@ jobs:
             "${{ env.install-all }}" == "true" ||
             "${{ steps.changed-paths.outputs.install-all }}" == "true"
           ]]; then
-            # Install all slices in slices/ dir.
-            # We need to enable globstar to use the ** patterns below.
-            shopt -s globstar
+            # Install all slices in slices/ and bin-slices/ dirs.
+            # With Chisel >= 1.6.0, bin SDFs ("store: bin" files) are
+            # installed from the store; with older versions they are
+            # skipped by install-slices itself.
+            # We need to enable globstar to use the ** patterns below, and
+            # nullglob so that the bin-slices/ pattern (absent in releases
+            # before ubuntu-26.04) expands to nothing.
+            shopt -s globstar nullglob
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \
               --ensure-existence \
               --ignore-missing \
               --chisel-version "${{ matrix.chisel-version }}" \
               --workers "${WORKERS}" \
-              slices/**/*.yaml
+              slices/**/*.yaml bin-slices/**/*.yaml
           elif [[ "${{ steps.changed-paths.outputs.slices }}" == "true" ]]; then
             # Install slices from changed files.
             ./install-slices --arch "${{ matrix.arch }}" --release ./ \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,9 +81,11 @@ jobs:
           config-path: "${{ env.main-branch-path }}/.github/yamllint.yaml"
         run: |
           set -e
-          yamllint -c "${{ env.config-path }}" \
-            chisel.yaml \
-            slices/
+          targets=(chisel.yaml slices/)
+          if [ -d bin-slices ]; then
+            targets+=(bin-slices/)
+          fi
+          yamllint -c "${{ env.config-path }}" "${targets[@]}"
 
       - name: Lint with SDF-specific rules
         run: |
@@ -97,7 +99,12 @@ jobs:
             EXIT_CODE=1
           }
 
-          for filename in $(find slices/ | grep "\.yaml$" | sort); do
+          sdf_files="$(find slices/ | grep "\.yaml$" | sort)"
+          if [ -d bin-slices ]; then
+            sdf_files="${sdf_files} $(find bin-slices/ | grep "\.yaml$" | sort)"
+          fi
+
+          for filename in $sdf_files; do
             for slice in $(yq '.slices | keys | .[]' "$filename"); do
               # Because of chisel format "v3", essential can either be a map or an array
               # so the following "essential" check needs to cope with that and verify the type of essential

--- a/.github/workflows/removed-slices.yaml
+++ b/.github/workflows/removed-slices.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "slices/**"
+      - "bin-slices/**"
   workflow_call:
 
 jobs:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -41,6 +41,7 @@ jobs:
           filters: |
             slices:
               - added|modified: 'slices/**/*.yaml'
+              - added|modified: 'bin-slices/**/*.yaml'
           list-files: shell
 
       - name: Check changed test directories

--- a/.github/workflows/validate-hints.yaml
+++ b/.github/workflows/validate-hints.yaml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             slices:
               - added|modified: 'slices/**/*.yaml'
+              - added|modified: 'bin-slices/**/*.yaml'
           # Space delimited list usable as command-line argument list in
           # Linux shell. If needed, it uses single or double quotes to
           # wrap filename with unsafe characters.


### PR DESCRIPTION
# Proposed changes

Prepare the CI for releases carrying package slices files (PSF) for `bin` store packages (ubuntu-26.04 with `bin-slices/`, ubuntu-26.10 with `v4` format), so the workflows keep working unchanged once such files start landing.

Bin PSFs are detected by their top-level `store: bin` key, never by location, so a deb PSF mistakenly placed under `bin-slices/` is not misinterpreted. In `install-slices`, bin packages are installed from the store with Chisel >= 1.6.0 and skipped with older versions (which ignore `bin-slices/` anyway), while remaining excluded from the archive-based checks (rmadison, deb copyright) that do not apply to them. `pkg-deps` and forward-port tracking skip bin PSFs, as `apt depends` comparisons and forward-porting do not apply to release-specific store packages. Lint, hints validation, removal detection and spread triggers now also cover `bin-slices/`; spread coverage deliberately includes bin slices so the missing tests stay visible. `chisel debug check-release-archives` needs no change as it covers store packages from 1.6.0 on.

### Forward porting

N/A


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
