### PR TITLE
chore: add chisel 1.5 install-slices

### DIFF
--- a/.github/workflows/install-slices.yaml
+++ b/.github/workflows/install-slices.yaml
@@ -27,8 +27,8 @@ env:
       {"ref": "ubuntu-20.04", "chisel-versions": ["v1.1.0","v1.2.0"]},
       {"ref": "ubuntu-22.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
       {"ref": "ubuntu-24.04", "chisel-versions": ["v1.1.0","v1.2.0","main"]},
-      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.2","main"]},
-      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.4.2","main"]}
+      {"ref": "ubuntu-26.04", "chisel-versions": ["v1.4.2","v1.5.0","main"]},
+      {"ref": "ubuntu-26.10", "chisel-versions": ["v1.5.0","main"]}
     ]
 
 jobs:


### PR DESCRIPTION
# Proposed changes

add v1.5.0 to the 26.04 and 26.10 test matrix.

## Related issues/PRs

n/a

### Forward porting

n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)