### PR TITLE
feat(26.04): add Xvfb and xvfb-run slices

### DIFF
--- a/slices/libgl1-mesa-dri.yaml
+++ b/slices/libgl1-mesa-dri.yaml
@@ -112,6 +112,7 @@ slices:
           - arm64
           - armhf
           - riscv64
+      /usr/lib/*-linux-*/dri/libdril_dri.so:
       /usr/lib/*-linux-*/dri/lima_dri.so:
         arch:
           - arm64

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -7,6 +7,7 @@ slices:
   libs:
     essential:
       libc6_libs:
+      libgcc-s1_libs:
       liblzma5_libs:
     contents:
       /usr/lib/*-linux-*/libunwind-*.so.*:

--- a/slices/libxfont2.yaml
+++ b/slices/libxfont2.yaml
@@ -1,0 +1,19 @@
+package: libxfont2
+
+essential:
+  libxfont2_copyright:
+
+slices:
+  libs:
+    essential:
+      libbz2-1.0_libs:
+      libc6_libs:
+      libfontenc1_libs:
+      libfreetype6_libs:
+      zlib1g_libs:
+    contents:
+      /usr/lib/*-linux-*/libXfont2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxfont2/copyright:

--- a/slices/libxkbfile1.yaml
+++ b/slices/libxkbfile1.yaml
@@ -1,0 +1,16 @@
+package: libxkbfile1
+
+essential:
+  libxkbfile1_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libx11-6_libs:
+    contents:
+      /usr/lib/*-linux-*/libxkbfile.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxkbfile1/copyright:

--- a/slices/libxmuu1.yaml
+++ b/slices/libxmuu1.yaml
@@ -1,0 +1,15 @@
+package: libxmuu1
+
+essential:
+  libxmuu1_copyright:
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libx11-6_libs:
+    contents:
+      /usr/lib/*-linux-*/libXmuu.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxmuu1/copyright:

--- a/slices/mesa-libgallium.yaml
+++ b/slices/mesa-libgallium.yaml
@@ -8,15 +8,12 @@ slices:
     essential:
       libc6_libs:
       libdrm-amdgpu1_libs:
-      # The libdrm-intel1_libs dependency is currently ommited, it can be
-      # added again once chisel supports per-arch package dependencies,
-      # see https://github.com/canonical/chisel/issues/93
-      # needed for: amd64 and i386
+      libdrm-intel1_libs: {arch: [amd64, i386]}
       libdrm2_libs:
       libelf1t64_libs:
       libexpat1_libs:
       libgcc-s1_libs:
-      libllvm19_libs:
+      libllvm21_libs:
       libsensors5_libs:
       libstdc++6_libs:
       libx11-xcb1_libs:

--- a/slices/x11-xkb-utils.yaml
+++ b/slices/x11-xkb-utils.yaml
@@ -1,0 +1,17 @@
+package: x11-xkb-utils
+
+essential:
+  x11-xkb-utils_copyright:
+
+slices:
+  xkbcomp:
+    essential:
+      libc6_libs:
+      libx11-6_libs:
+      libxkbfile1_libs:
+    contents:
+      /usr/bin/xkbcomp:
+
+  copyright:
+    contents:
+      /usr/share/doc/x11-xkb-utils/copyright:

--- a/slices/xauth.yaml
+++ b/slices/xauth.yaml
@@ -1,0 +1,18 @@
+package: xauth
+
+essential:
+  xauth_copyright:
+slices:
+  bins:
+    essential:
+      libc6_libs:
+      libx11-6_libs:
+      libxau6_libs:
+      libxext6_libs:
+      libxmuu1_libs:
+    contents:
+      /usr/bin/xauth:
+
+  copyright:
+    contents:
+      /usr/share/doc/xauth/copyright:

--- a/slices/xkb-data.yaml
+++ b/slices/xkb-data.yaml
@@ -1,0 +1,14 @@
+package: xkb-data
+
+essential:
+  xkb-data_copyright:
+
+slices:
+  data:
+    contents:
+      /usr/share/X11/xkb:
+      /usr/share/xkeyboard-config-2/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/xkb-data/copyright:

--- a/slices/xserver-common.yaml
+++ b/slices/xserver-common.yaml
@@ -1,0 +1,14 @@
+package: xserver-common
+
+essential:
+  xserver-common_copyright:
+
+slices:
+  data:
+    contents:
+      /usr/lib/xorg/protocol.txt:
+      /var/lib/xkb/: {make: true}
+
+  copyright:
+    contents:
+      /usr/share/doc/xserver-common/copyright:

--- a/slices/xvfb.yaml
+++ b/slices/xvfb.yaml
@@ -1,0 +1,32 @@
+package: xvfb
+
+essential:
+  xvfb_copyright:
+
+slices:
+  server:
+    essential:
+      base-files_bin:
+      base-files_tmp:
+      # Xvfb invokes xkbcomp through /bin/sh when initializing the keyboard.
+      dash_bins:
+      libaudit1_libs:
+      libc6_libs:
+      libgl1_libs:
+      libnettle8t64_libs:
+      libpixman-1-0_libs:
+      libselinux1_libs:
+      libsystemd0_libs:
+      libunwind8_libs: {arch: [amd64, arm64, i386, ppc64el]}
+      libxau6_libs:
+      libxdmcp6_libs:
+      libxfont2_libs:
+      x11-xkb-utils_xkbcomp:
+      xkb-data_data:
+      xserver-common_data:
+    contents:
+      /usr/bin/Xvfb:
+
+  copyright:
+    contents:
+      /usr/share/doc/xvfb/copyright:

--- a/slices/xvfb.yaml
+++ b/slices/xvfb.yaml
@@ -4,6 +4,17 @@ essential:
   xvfb_copyright:
 
 slices:
+  bins:
+    essential:
+      coreutils_bins:
+      gawk_bins:
+      util-linux_getopt:
+      util-linux_mcookie:
+      xauth_bins:
+      xvfb_server:
+    contents:
+      /usr/bin/xvfb-run:
+
   server:
     essential:
       base-files_bin:

--- a/tests/spread/integration/x11-xkb-utils/keymap.xkb
+++ b/tests/spread/integration/x11-xkb-utils/keymap.xkb
@@ -1,0 +1,7 @@
+xkb_keymap {
+    xkb_keycodes { include "evdev+aliases(qwerty)" };
+    xkb_types { include "complete" };
+    xkb_compatibility { include "complete" };
+    xkb_symbols { include "pc+us+inet(evdev)" };
+    xkb_geometry { include "pc(pc105)" };
+};

--- a/tests/spread/integration/x11-xkb-utils/task.yaml
+++ b/tests/spread/integration/x11-xkb-utils/task.yaml
@@ -1,0 +1,12 @@
+summary: Integration tests for x11-xkb-utils
+
+execute: |
+  set -eu
+
+  rootfs="$(install-slices x11-xkb-utils_xkbcomp xkb-data_data)"
+
+  chroot "$rootfs" /usr/bin/xkbcomp -w 0 -xkm - /keymap.xkm < keymap.xkb
+  test -s "$rootfs/keymap.xkm"
+
+  chroot "$rootfs" /usr/bin/xkbcomp -w 0 -xkb /keymap.xkm - > "$rootfs/keymap.xkb"
+  grep -A3 'key <AD01>' "$rootfs/keymap.xkb" | grep -Eq 'q, +Q'

--- a/tests/spread/integration/xvfb/task.yaml
+++ b/tests/spread/integration/xvfb/task.yaml
@@ -1,0 +1,47 @@
+summary: Integration tests for xvfb
+
+prepare: |
+  apt-get install -y mesa-utils x11-utils
+
+execute: |
+  set -eu
+
+  rootfs="$(install-slices xvfb_server)"
+
+  cleanup() {
+    status=$?
+    trap - EXIT
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" || true
+    if [ "$status" -ne 0 ]; then
+      tail -n 80 "$rootfs/xvfb.log"
+    fi
+    exit "$status"
+  }
+
+  # Let Xvfb choose a free display and report it only when ready.
+  chroot "$rootfs" /usr/bin/Xvfb \
+    -displayfd 3 -screen 0 640x480x24 -nolisten tcp \
+    3>"$rootfs/display" >"$rootfs/xvfb.log" 2>&1 &
+  server_pid=$!
+  trap cleanup EXIT
+
+  for attempt in $(seq 1 100); do
+    test ! -s "$rootfs/display" || break
+    kill -0 "$server_pid"
+    sleep 0.1
+  done
+  test -s "$rootfs/display"
+
+  # Query the display without adding any server dependencies to the rootfs.
+  display=":$(cat "$rootfs/display")"
+  xdpyinfo -display "$display" >"$rootfs/xdpyinfo"
+  grep -Eq 'dimensions: +640x480 pixels' "$rootfs/xdpyinfo"
+  grep -Eq 'depth of root window: +24 planes' "$rootfs/xdpyinfo"
+
+  # Copy only the test executable; all GL libraries must come from the slices.
+  install -m 755 "$(command -v glxinfo)" "$rootfs/glxinfo-test"
+  XDG_CACHE_HOME=/tmp LIBGL_ALWAYS_SOFTWARE=1 \
+    chroot "$rootfs" /glxinfo-test \
+    -display "$display" -B >"$rootfs/glxinfo"
+  grep -q 'OpenGL renderer string:' "$rootfs/glxinfo"

--- a/tests/spread/integration/xvfb/task.yaml
+++ b/tests/spread/integration/xvfb/task.yaml
@@ -1,6 +1,7 @@
 summary: Integration tests for xvfb
 
 prepare: |
+  # The matching Ubuntu test system supplies ABI-compatible client binaries.
   apt-get install -y mesa-utils x11-utils
 
 execute: |
@@ -26,14 +27,18 @@ execute: |
   server_pid=$!
   trap cleanup EXIT
 
-  for attempt in $(seq 1 100); do
+  for _ in $(seq 1 300); do
     test ! -s "$rootfs/display" || break
-    kill -0 "$server_pid"
+    if ! jobs -pr | grep -qx "$server_pid"; then
+      wait "$server_pid"
+      exit 1
+    fi
     sleep 0.1
   done
   test -s "$rootfs/display"
 
   # Query the display without adding any server dependencies to the rootfs.
+  # Linux abstract Unix sockets are shared across this chroot boundary.
   display=":$(cat "$rootfs/display")"
   xdpyinfo -display "$display" >"$rootfs/xdpyinfo"
   grep -Eq 'dimensions: +640x480 pixels' "$rootfs/xdpyinfo"
@@ -44,4 +49,20 @@ execute: |
   XDG_CACHE_HOME=/tmp LIBGL_ALWAYS_SOFTWARE=1 \
     chroot "$rootfs" /glxinfo-test \
     -display "$display" -B >"$rootfs/glxinfo"
-  grep -q 'OpenGL renderer string:' "$rootfs/glxinfo"
+  grep -q 'OpenGL renderer string: llvmpipe' "$rootfs/glxinfo"
+
+  wrapper_root="$(install-slices xvfb_bins)"
+  install -m 755 "$(command -v glxinfo)" "$wrapper_root/glxinfo-test"
+  # Supply a writable sink for /dev/null redirects in the test chroot.
+  # Real containers provide the device; this also works on rootless runners.
+  install -d "$wrapper_root/dev"
+  touch "$wrapper_root/dev/null"
+  XDG_CACHE_HOME=/tmp LIBGL_ALWAYS_SOFTWARE=1 \
+    chroot "$wrapper_root" /usr/bin/xvfb-run -a /glxinfo-test -B \
+    >"$wrapper_root/wrapper-glxinfo"
+  grep -q 'OpenGL renderer string: llvmpipe' "$wrapper_root/wrapper-glxinfo"
+
+  status=0
+  chroot "$wrapper_root" /usr/bin/xvfb-run -a /bin/sh -c 'exit 42' || status=$?
+  test "$status" -eq 42
+  test -z "$(find "$wrapper_root/tmp" -maxdepth 1 -name 'xvfb-run.*' -print)"


### PR DESCRIPTION
## Proposed changes

Forward-port Xvfb support to Ubuntu 26.04 in native format v3: `xvfb_server`, authenticated `xvfb_bins` (`xvfb-run`), X server/XKB support and xauth/libXmuu.

Use current nettle, architecture-specific unwind/Intel DRM, LLVM21 and libdril dependencies. Include `/bin/sh` and libunwind8's GCC runtime; use `/usr/share/xkeyboard-config-2` with its `/usr/share/X11` compatibility symlink.

### Validation

Ubuntu 26.04 amd64 server and separate wrapper execute bodies passed with Chisel 1.5.0 and the repository helper: geometry/depth, contained llvmpipe, authenticated client execution, exit 42 and auth-directory cleanup. Standalone keyboard compilation passed with 1.4.2.

Temporary logs were lost on restart. Recovered files pass repository YAML lint, ordering and whitespace checks. Full Spread and native non-amd64 runtime were not run locally.

```sh
spread -v docker:ubuntu-26.04-amd64:tests/spread/integration/xvfb
spread -v docker:ubuntu-26.04-amd64:tests/spread/integration/x11-xkb-utils
```

### AI usage

Codex agents did most implementation, testing and PR writing. Claude Opus independently reviewed the Jammy work; Codex addressed findings and forward-ported the changes. The contributor directed the work and approved submission.

### Related release PRs

22.04: #1177 · 24.04: #1175 · 26.04: #1174 · 26.10: #1176 (manifest blocker; keep draft). No merge-order dependency.

### Checklist

- [x] Read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md).
- [x] Tested changes (scope and limitations above).
- [x] Submitted the [Canonical CLA](https://ubuntu.com/legal/contributors/agreement).
