### PR TITLE
feat(22.04): add Xvfb and xvfb-run slices

### DIFF
--- a/slices/libdrm-amdgpu1.yaml
+++ b/slices/libdrm-amdgpu1.yaml
@@ -1,0 +1,17 @@
+package: libdrm-amdgpu1
+
+essential:
+  - libdrm-amdgpu1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm-common_data
+      - libdrm2_libs
+    contents:
+      /usr/lib/*-linux-*/libdrm_amdgpu.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdrm-amdgpu1/copyright:

--- a/slices/libdrm-amdgpu1.yaml
+++ b/slices/libdrm-amdgpu1.yaml
@@ -7,7 +7,6 @@ slices:
   libs:
     essential:
       - libc6_libs
-      - libdrm-common_data
       - libdrm2_libs
     contents:
       /usr/lib/*-linux-*/libdrm_amdgpu.so.1*:

--- a/slices/libdrm-common.yaml
+++ b/slices/libdrm-common.yaml
@@ -1,0 +1,13 @@
+package: libdrm-common
+
+essential:
+  - libdrm-common_copyright
+
+slices:
+  data:
+    contents:
+      /usr/share/libdrm/amdgpu.ids:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdrm-common/copyright:

--- a/slices/libdrm-intel1.yaml
+++ b/slices/libdrm-intel1.yaml
@@ -1,0 +1,17 @@
+package: libdrm-intel1
+
+essential:
+  - libdrm-intel1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libpciaccess0_libs
+    contents:
+      /usr/lib/*-linux-*/libdrm_intel.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdrm-intel1/copyright:

--- a/slices/libdrm-nouveau2.yaml
+++ b/slices/libdrm-nouveau2.yaml
@@ -1,0 +1,16 @@
+package: libdrm-nouveau2
+
+essential:
+  - libdrm-nouveau2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+    contents:
+      /usr/lib/*-linux-*/libdrm_nouveau.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdrm-nouveau2/copyright:

--- a/slices/libdrm-radeon1.yaml
+++ b/slices/libdrm-radeon1.yaml
@@ -1,0 +1,16 @@
+package: libdrm-radeon1
+
+essential:
+  - libdrm-radeon1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+    contents:
+      /usr/lib/*-linux-*/libdrm_radeon.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdrm-radeon1/copyright:

--- a/slices/libdrm2.yaml
+++ b/slices/libdrm2.yaml
@@ -7,6 +7,7 @@ slices:
   libs:
     essential:
       - libc6_libs
+      - libdrm-common_data
     contents:
       /usr/lib/*-linux-*/libdrm.so.2*:
 

--- a/slices/libdrm2.yaml
+++ b/slices/libdrm2.yaml
@@ -1,0 +1,15 @@
+package: libdrm2
+
+essential:
+  - libdrm2_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libdrm.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libdrm2/copyright:

--- a/slices/libedit2.yaml
+++ b/slices/libedit2.yaml
@@ -1,0 +1,17 @@
+package: libedit2
+
+essential:
+  - libedit2_copyright
+
+slices:
+  libs:
+    essential:
+      - libbsd0_libs
+      - libc6_libs
+      - libtinfo6_libs
+    contents:
+      /usr/lib/*-linux-*/libedit.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libedit2/copyright:

--- a/slices/libelf1.yaml
+++ b/slices/libelf1.yaml
@@ -1,0 +1,17 @@
+package: libelf1
+
+essential:
+  - libelf1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libelf-0.186.so*:
+      /usr/lib/*-linux-*/libelf.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libelf1/copyright:

--- a/slices/libelf1.yaml
+++ b/slices/libelf1.yaml
@@ -9,7 +9,7 @@ slices:
       - libc6_libs
       - zlib1g_libs
     contents:
-      /usr/lib/*-linux-*/libelf-0.186.so*:
+      /usr/lib/*-linux-*/libelf-*.so:
       /usr/lib/*-linux-*/libelf.so.1*:
 
   copyright:

--- a/slices/libfontenc1.yaml
+++ b/slices/libfontenc1.yaml
@@ -1,0 +1,16 @@
+package: libfontenc1
+
+essential:
+  - libfontenc1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libfontenc.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libfontenc1/copyright:

--- a/slices/libgl1-mesa-dri.yaml
+++ b/slices/libgl1-mesa-dri.yaml
@@ -4,7 +4,8 @@ essential:
   - libgl1-mesa-dri_copyright
 
 slices:
-  swrast:
+  # Backported from Noble; Jammy embeds Gallium in the hardlinked drivers.
+  libs:
     essential:
       - libc6_libs
       - libdrm-amdgpu1_libs
@@ -14,6 +15,7 @@ slices:
       - libelf1_libs
       - libexpat1_libs
       - libgcc-s1_libs
+      - libgl1-mesa-dri_config
       - libglapi-mesa_libs
       - libllvm15_libs
       - libsensors5_libs
@@ -21,11 +23,61 @@ slices:
       - libxcb-dri3-0_libs
       - libzstd1_libs
       - zlib1g_libs
-    # Architecture-specific essentials require Chisel >= 1.3.0.
+    # Chisel < 1.3 silently ignores this block and produces broken x86 DRI
+    # drivers (missing libdrm_intel.so.1). Use Chisel >= 1.3.
     v3-essential:
       libdrm-intel1_libs: {arch: [amd64, i386]}
     contents:
+      /usr/lib/*-linux-*/dri/armada-drm_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/crocus_dri.so: {arch: [amd64, i386]}
+      /usr/lib/*-linux-*/dri/d3d12_dri.so: {arch: [amd64, arm64]}
+      /usr/lib/*-linux-*/dri/etnaviv_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/exynos_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/hx8357d_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/i915_dri.so: {arch: [amd64, i386]}
+      /usr/lib/*-linux-*/dri/ili9225_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/ili9341_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/imx-dcss_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/imx-drm_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/imx-lcdif_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/ingenic-drm_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/iris_dri.so: {arch: [amd64, i386]}
+      /usr/lib/*-linux-*/dri/kgsl_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/kirin_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/kms_swrast_dri.so:
+      /usr/lib/*-linux-*/dri/komeda_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/lima_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/mali-dp_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/mcde_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/mediatek_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/meson_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/mi0283qt_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/msm_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/mxsfb-drm_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/nouveau_dri.so:
+      /usr/lib/*-linux-*/dri/panfrost_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/pl111_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/r300_dri.so:
+      /usr/lib/*-linux-*/dri/r600_dri.so:
+      /usr/lib/*-linux-*/dri/radeonsi_dri.so:
+      /usr/lib/*-linux-*/dri/rcar-du_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/repaper_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/rockchip_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/st7586_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/st7735r_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/stm_dri.so: {arch: [arm64, armhf, riscv64]}
+      /usr/lib/*-linux-*/dri/sun4i-drm_dri.so: {arch: [arm64, armhf, riscv64]}
       /usr/lib/*-linux-*/dri/swrast_dri.so:
+      /usr/lib/*-linux-*/dri/tegra_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/v3d_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/vc4_dri.so: {arch: [arm64, armhf]}
+      /usr/lib/*-linux-*/dri/virtio_gpu_dri.so:
+      /usr/lib/*-linux-*/dri/vmwgfx_dri.so: {arch: [amd64, arm64, armhf, i386]}
+      /usr/lib/*-linux-*/dri/zink_dri.so:
+
+  config:
+    contents:
+      /usr/share/drirc.d/00-mesa-defaults.conf:
 
   copyright:
     contents:

--- a/slices/libgl1-mesa-dri.yaml
+++ b/slices/libgl1-mesa-dri.yaml
@@ -1,0 +1,32 @@
+package: libgl1-mesa-dri
+
+essential:
+  - libgl1-mesa-dri_copyright
+
+slices:
+  swrast:
+    essential:
+      - libc6_libs
+      - libdrm-amdgpu1_libs
+      - libdrm-nouveau2_libs
+      - libdrm-radeon1_libs
+      - libdrm2_libs
+      - libelf1_libs
+      - libexpat1_libs
+      - libgcc-s1_libs
+      - libglapi-mesa_libs
+      - libllvm15_libs
+      - libsensors5_libs
+      - libstdc++6_libs
+      - libxcb-dri3-0_libs
+      - libzstd1_libs
+      - zlib1g_libs
+    # Architecture-specific essentials require Chisel >= 1.3.0.
+    v3-essential:
+      libdrm-intel1_libs: {arch: [amd64, i386]}
+    contents:
+      /usr/lib/*-linux-*/dri/swrast_dri.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgl1-mesa-dri/copyright:

--- a/slices/libgl1.yaml
+++ b/slices/libgl1.yaml
@@ -1,0 +1,17 @@
+package: libgl1
+
+essential:
+  - libgl1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libglvnd0_libs
+      - libglx0_libs
+    contents:
+      /usr/lib/*-linux-*/libGL.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libgl1/copyright:

--- a/slices/libglapi-mesa.yaml
+++ b/slices/libglapi-mesa.yaml
@@ -1,0 +1,15 @@
+package: libglapi-mesa
+
+essential:
+  - libglapi-mesa_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libglapi.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglapi-mesa/copyright:

--- a/slices/libglvnd0.yaml
+++ b/slices/libglvnd0.yaml
@@ -1,0 +1,15 @@
+package: libglvnd0
+
+essential:
+  - libglvnd0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libGLdispatch.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglvnd0/copyright:

--- a/slices/libglx-mesa0.yaml
+++ b/slices/libglx-mesa0.yaml
@@ -1,0 +1,34 @@
+package: libglx-mesa0
+
+essential:
+  - libglx-mesa0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libdrm2_libs
+      - libexpat1_libs
+      - libgl1-mesa-dri_swrast
+      - libglapi-mesa_libs
+      - libx11-6_libs
+      - libx11-xcb1_libs
+      - libxcb-dri2-0_libs
+      - libxcb-dri3-0_libs
+      - libxcb-glx0_libs
+      - libxcb-present0_libs
+      - libxcb-randr0_libs
+      - libxcb-shm0_libs
+      - libxcb-sync1_libs
+      - libxcb-xfixes0_libs
+      - libxcb1_libs
+      - libxext6_libs
+      - libxfixes3_libs
+      - libxshmfence1_libs
+      - libxxf86vm1_libs
+    contents:
+      /usr/lib/*-linux-*/libGLX_mesa.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglx-mesa0/copyright:

--- a/slices/libglx-mesa0.yaml
+++ b/slices/libglx-mesa0.yaml
@@ -9,7 +9,8 @@ slices:
       - libc6_libs
       - libdrm2_libs
       - libexpat1_libs
-      - libgl1-mesa-dri_swrast
+      # Jammy embeds Gallium in DRI drivers; mesa-libgallium is not packaged.
+      - libgl1-mesa-dri_libs
       - libglapi-mesa_libs
       - libx11-6_libs
       - libx11-xcb1_libs
@@ -27,6 +28,7 @@ slices:
       - libxshmfence1_libs
       - libxxf86vm1_libs
     contents:
+      /usr/lib/*-linux-*/libGLX_indirect.so.0*:
       /usr/lib/*-linux-*/libGLX_mesa.so.0*:
 
   copyright:

--- a/slices/libglx0.yaml
+++ b/slices/libglx0.yaml
@@ -1,0 +1,18 @@
+package: libglx0
+
+essential:
+  - libglx0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libglvnd0_libs
+      - libglx-mesa0_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libGLX.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libglx0/copyright:

--- a/slices/libllvm15.yaml
+++ b/slices/libllvm15.yaml
@@ -1,0 +1,25 @@
+package: libllvm15
+
+essential:
+  - libllvm15_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libedit2_libs
+      - libffi8_libs
+      - libgcc-s1_libs
+      - libstdc++6_libs
+      - libtinfo6_libs
+      - libxml2_libs
+      - zlib1g_libs
+    # Architecture-specific essentials require Chisel >= 1.3.0.
+    v3-essential:
+      libatomic1_libs: {arch: [i386, riscv64]}
+    contents:
+      /usr/lib/*-linux-*/libLLVM-15.so.1:
+
+  copyright:
+    contents:
+      /usr/share/doc/libllvm15/copyright:

--- a/slices/libllvm15.yaml
+++ b/slices/libllvm15.yaml
@@ -14,7 +14,8 @@ slices:
       - libtinfo6_libs
       - libxml2_libs
       - zlib1g_libs
-    # Architecture-specific essentials require Chisel >= 1.3.0.
+    # Chisel < 1.3 silently ignores this block and omits the atomic runtime
+    # required by LLVM on these architectures. Use Chisel >= 1.3.
     v3-essential:
       libatomic1_libs: {arch: [i386, riscv64]}
     contents:

--- a/slices/libpciaccess0.yaml
+++ b/slices/libpciaccess0.yaml
@@ -1,0 +1,16 @@
+package: libpciaccess0
+
+essential:
+  - libpciaccess0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libpciaccess.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpciaccess0/copyright:

--- a/slices/libsensors-config.yaml
+++ b/slices/libsensors-config.yaml
@@ -1,0 +1,14 @@
+package: libsensors-config
+
+essential:
+  - libsensors-config_copyright
+
+slices:
+  config:
+    contents:
+      /etc/sensors.d/:
+      /etc/sensors3.conf:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsensors-config/copyright:

--- a/slices/libsensors5.yaml
+++ b/slices/libsensors5.yaml
@@ -1,0 +1,15 @@
+package: libsensors5
+
+essential:
+  - libsensors5_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libsensors.so.5*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsensors5/copyright:

--- a/slices/libsensors5.yaml
+++ b/slices/libsensors5.yaml
@@ -7,6 +7,7 @@ slices:
   libs:
     essential:
       - libc6_libs
+      - libsensors-config_config
     contents:
       /usr/lib/*-linux-*/libsensors.so.5*:
 

--- a/slices/libunwind8.yaml
+++ b/slices/libunwind8.yaml
@@ -7,6 +7,7 @@ slices:
   libs:
     essential:
       - libc6_libs
+      - libgcc-s1_libs
       - liblzma5_libs
     contents:
       /usr/lib/*-linux-*/libunwind-*.so.*:

--- a/slices/libx11-xcb1.yaml
+++ b/slices/libx11-xcb1.yaml
@@ -1,0 +1,13 @@
+package: libx11-xcb1
+
+essential:
+  - libx11-xcb1_copyright
+
+slices:
+  libs:
+    contents:
+      /usr/lib/*-linux-*/libX11-xcb.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libx11-xcb1/copyright:

--- a/slices/libx11-xcb1.yaml
+++ b/slices/libx11-xcb1.yaml
@@ -5,6 +5,8 @@ essential:
 
 slices:
   libs:
+    essential:
+      - libx11-6_libs
     contents:
       /usr/lib/*-linux-*/libX11-xcb.so.1*:
 

--- a/slices/libxcb-dri2-0.yaml
+++ b/slices/libxcb-dri2-0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-dri2-0
+
+essential:
+  - libxcb-dri2-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-dri2.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-dri2-0/copyright:

--- a/slices/libxcb-dri3-0.yaml
+++ b/slices/libxcb-dri3-0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-dri3-0
+
+essential:
+  - libxcb-dri3-0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-dri3.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-dri3-0/copyright:

--- a/slices/libxcb-glx0.yaml
+++ b/slices/libxcb-glx0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-glx0
+
+essential:
+  - libxcb-glx0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-glx.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-glx0/copyright:

--- a/slices/libxcb-present0.yaml
+++ b/slices/libxcb-present0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-present0
+
+essential:
+  - libxcb-present0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-present.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-present0/copyright:

--- a/slices/libxcb-randr0.yaml
+++ b/slices/libxcb-randr0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-randr0
+
+essential:
+  - libxcb-randr0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-randr.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-randr0/copyright:

--- a/slices/libxcb-sync1.yaml
+++ b/slices/libxcb-sync1.yaml
@@ -1,0 +1,16 @@
+package: libxcb-sync1
+
+essential:
+  - libxcb-sync1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-sync.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-sync1/copyright:

--- a/slices/libxcb-xfixes0.yaml
+++ b/slices/libxcb-xfixes0.yaml
@@ -1,0 +1,16 @@
+package: libxcb-xfixes0
+
+essential:
+  - libxcb-xfixes0_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libxcb1_libs
+    contents:
+      /usr/lib/*-linux-*/libxcb-xfixes.so.0*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxcb-xfixes0/copyright:

--- a/slices/libxfixes3.yaml
+++ b/slices/libxfixes3.yaml
@@ -1,0 +1,16 @@
+package: libxfixes3
+
+essential:
+  - libxfixes3_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libXfixes.so.3*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxfixes3/copyright:

--- a/slices/libxfont2.yaml
+++ b/slices/libxfont2.yaml
@@ -1,0 +1,19 @@
+package: libxfont2
+
+essential:
+  - libxfont2_copyright
+
+slices:
+  libs:
+    essential:
+      - libbz2-1.0_libs
+      - libc6_libs
+      - libfontenc1_libs
+      - libfreetype6_libs
+      - zlib1g_libs
+    contents:
+      /usr/lib/*-linux-*/libXfont2.so.2*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxfont2/copyright:

--- a/slices/libxkbfile1.yaml
+++ b/slices/libxkbfile1.yaml
@@ -1,0 +1,16 @@
+package: libxkbfile1
+
+essential:
+  - libxkbfile1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libxkbfile.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxkbfile1/copyright:

--- a/slices/libxmuu1.yaml
+++ b/slices/libxmuu1.yaml
@@ -1,0 +1,16 @@
+package: libxmuu1
+
+essential:
+  - libxmuu1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+    contents:
+      /usr/lib/*-linux-*/libXmuu.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxmuu1/copyright:

--- a/slices/libxshmfence1.yaml
+++ b/slices/libxshmfence1.yaml
@@ -1,0 +1,15 @@
+package: libxshmfence1
+
+essential:
+  - libxshmfence1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+    contents:
+      /usr/lib/*-linux-*/libxshmfence.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxshmfence1/copyright:

--- a/slices/libxxf86vm1.yaml
+++ b/slices/libxxf86vm1.yaml
@@ -1,0 +1,17 @@
+package: libxxf86vm1
+
+essential:
+  - libxxf86vm1_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+      - libxext6_libs
+    contents:
+      /usr/lib/*-linux-*/libXxf86vm.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libxxf86vm1/copyright:

--- a/slices/x11-xkb-utils.yaml
+++ b/slices/x11-xkb-utils.yaml
@@ -1,0 +1,17 @@
+package: x11-xkb-utils
+
+essential:
+  - x11-xkb-utils_copyright
+
+slices:
+  xkbcomp:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+      - libxkbfile1_libs
+    contents:
+      /usr/bin/xkbcomp:
+
+  copyright:
+    contents:
+      /usr/share/doc/x11-xkb-utils/copyright:

--- a/slices/xauth.yaml
+++ b/slices/xauth.yaml
@@ -1,0 +1,19 @@
+package: xauth
+
+essential:
+  - xauth_copyright
+
+slices:
+  bins:
+    essential:
+      - libc6_libs
+      - libx11-6_libs
+      - libxau6_libs
+      - libxext6_libs
+      - libxmuu1_libs
+    contents:
+      /usr/bin/xauth:
+
+  copyright:
+    contents:
+      /usr/share/doc/xauth/copyright:

--- a/slices/xkb-data.yaml
+++ b/slices/xkb-data.yaml
@@ -1,0 +1,13 @@
+package: xkb-data
+
+essential:
+  - xkb-data_copyright
+
+slices:
+  data:
+    contents:
+      /usr/share/X11/xkb/**:
+
+  copyright:
+    contents:
+      /usr/share/doc/xkb-data/copyright:

--- a/slices/xserver-common.yaml
+++ b/slices/xserver-common.yaml
@@ -1,0 +1,14 @@
+package: xserver-common
+
+essential:
+  - xserver-common_copyright
+
+slices:
+  data:
+    contents:
+      /usr/lib/xorg/protocol.txt:
+      /var/lib/xkb/: {make: true}
+
+  copyright:
+    contents:
+      /usr/share/doc/xserver-common/copyright:

--- a/slices/xvfb.yaml
+++ b/slices/xvfb.yaml
@@ -1,0 +1,34 @@
+package: xvfb
+
+essential:
+  - xvfb_copyright
+
+slices:
+  server:
+    essential:
+      - base-files_tmp
+      # Xvfb invokes xkbcomp through /bin/sh when initializing the keyboard.
+      - dash_bins
+      - libaudit1_libs
+      - libbsd0_libs
+      - libc6_libs
+      - libgcrypt20_libs
+      - libgl1_libs
+      - libpixman-1-0_libs
+      - libselinux1_libs
+      - libsystemd0_libs
+      - libxau6_libs
+      - libxdmcp6_libs
+      - libxfont2_libs
+      - x11-xkb-utils_xkbcomp
+      - xkb-data_data
+      - xserver-common_data
+    # Architecture-specific essentials require Chisel >= 1.3.0.
+    v3-essential:
+      libunwind8_libs: {arch: [amd64, arm64, armhf, i386, ppc64el]}
+    contents:
+      /usr/bin/Xvfb:
+
+  copyright:
+    contents:
+      /usr/share/doc/xvfb/copyright:

--- a/slices/xvfb.yaml
+++ b/slices/xvfb.yaml
@@ -4,6 +4,17 @@ essential:
   - xvfb_copyright
 
 slices:
+  bins:
+    essential:
+      - coreutils_bins
+      - gawk_bins
+      - util-linux_cli-helpers
+      - util-linux_mcookie
+      - xauth_bins
+      - xvfb_server
+    contents:
+      /usr/bin/xvfb-run:
+
   server:
     essential:
       - base-files_tmp
@@ -23,7 +34,8 @@ slices:
       - x11-xkb-utils_xkbcomp
       - xkb-data_data
       - xserver-common_data
-    # Architecture-specific essentials require Chisel >= 1.3.0.
+    # Chisel < 1.3 silently ignores this block, leaving Xvfb unable to start
+    # on the listed architectures because libunwind.so.8 is missing.
     v3-essential:
       libunwind8_libs: {arch: [amd64, arm64, armhf, i386, ppc64el]}
     contents:

--- a/tests/spread/integration/x11-xkb-utils/keymap.xkb
+++ b/tests/spread/integration/x11-xkb-utils/keymap.xkb
@@ -1,0 +1,7 @@
+xkb_keymap {
+    xkb_keycodes { include "evdev+aliases(qwerty)" };
+    xkb_types { include "complete" };
+    xkb_compatibility { include "complete" };
+    xkb_symbols { include "pc+us+inet(evdev)" };
+    xkb_geometry { include "pc(pc105)" };
+};

--- a/tests/spread/integration/x11-xkb-utils/task.yaml
+++ b/tests/spread/integration/x11-xkb-utils/task.yaml
@@ -1,0 +1,12 @@
+summary: Integration tests for x11-xkb-utils
+
+execute: |
+  set -eu
+
+  rootfs="$(install-slices x11-xkb-utils_xkbcomp xkb-data_data)"
+
+  chroot "$rootfs" /usr/bin/xkbcomp -w 0 -xkm - /keymap.xkm < keymap.xkb
+  test -s "$rootfs/keymap.xkm"
+
+  chroot "$rootfs" /usr/bin/xkbcomp -w 0 -xkb /keymap.xkm - > "$rootfs/keymap.xkb"
+  grep -A3 'key <AD01>' "$rootfs/keymap.xkb" | grep -Eq 'q, +Q'

--- a/tests/spread/integration/xvfb/task.yaml
+++ b/tests/spread/integration/xvfb/task.yaml
@@ -1,0 +1,47 @@
+summary: Integration tests for xvfb
+
+prepare: |
+  apt-get install -y mesa-utils x11-utils
+
+execute: |
+  set -eu
+
+  rootfs="$(install-slices xvfb_server)"
+
+  cleanup() {
+    status=$?
+    trap - EXIT
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" || true
+    if [ "$status" -ne 0 ]; then
+      tail -n 80 "$rootfs/xvfb.log"
+    fi
+    exit "$status"
+  }
+
+  # Let Xvfb choose a free display and report it only when ready.
+  chroot "$rootfs" /usr/bin/Xvfb \
+    -displayfd 3 -screen 0 640x480x24 -nolisten tcp \
+    3>"$rootfs/display" >"$rootfs/xvfb.log" 2>&1 &
+  server_pid=$!
+  trap cleanup EXIT
+
+  for attempt in $(seq 1 100); do
+    test ! -s "$rootfs/display" || break
+    kill -0 "$server_pid"
+    sleep 0.1
+  done
+  test -s "$rootfs/display"
+
+  # Query the display without adding any server dependencies to the rootfs.
+  display=":$(cat "$rootfs/display")"
+  xdpyinfo -display "$display" >"$rootfs/xdpyinfo"
+  grep -Eq 'dimensions: +640x480 pixels' "$rootfs/xdpyinfo"
+  grep -Eq 'depth of root window: +24 planes' "$rootfs/xdpyinfo"
+
+  # Copy only the test executable; all GL libraries must come from the slices.
+  install -m 755 "$(command -v glxinfo)" "$rootfs/glxinfo-test"
+  XDG_CACHE_HOME=/tmp LIBGL_ALWAYS_SOFTWARE=1 \
+    chroot "$rootfs" /glxinfo-test \
+    -display "$display" -B >"$rootfs/glxinfo"
+  grep -q 'OpenGL renderer string:' "$rootfs/glxinfo"

--- a/tests/spread/integration/xvfb/task.yaml
+++ b/tests/spread/integration/xvfb/task.yaml
@@ -1,6 +1,7 @@
 summary: Integration tests for xvfb
 
 prepare: |
+  # The matching Ubuntu test system supplies ABI-compatible client binaries.
   apt-get install -y mesa-utils x11-utils
 
 execute: |
@@ -26,14 +27,18 @@ execute: |
   server_pid=$!
   trap cleanup EXIT
 
-  for attempt in $(seq 1 100); do
+  for _ in $(seq 1 300); do
     test ! -s "$rootfs/display" || break
-    kill -0 "$server_pid"
+    if ! jobs -pr | grep -qx "$server_pid"; then
+      wait "$server_pid"
+      exit 1
+    fi
     sleep 0.1
   done
   test -s "$rootfs/display"
 
   # Query the display without adding any server dependencies to the rootfs.
+  # Linux abstract Unix sockets are shared across this chroot boundary.
   display=":$(cat "$rootfs/display")"
   xdpyinfo -display "$display" >"$rootfs/xdpyinfo"
   grep -Eq 'dimensions: +640x480 pixels' "$rootfs/xdpyinfo"
@@ -44,4 +49,20 @@ execute: |
   XDG_CACHE_HOME=/tmp LIBGL_ALWAYS_SOFTWARE=1 \
     chroot "$rootfs" /glxinfo-test \
     -display "$display" -B >"$rootfs/glxinfo"
-  grep -q 'OpenGL renderer string:' "$rootfs/glxinfo"
+  grep -q 'OpenGL renderer string: llvmpipe' "$rootfs/glxinfo"
+
+  wrapper_root="$(install-slices xvfb_bins)"
+  install -m 755 "$(command -v glxinfo)" "$wrapper_root/glxinfo-test"
+  # Supply a writable sink for /dev/null redirects in the test chroot.
+  # Real containers provide the device; this also works on rootless runners.
+  install -d "$wrapper_root/dev"
+  touch "$wrapper_root/dev/null"
+  XDG_CACHE_HOME=/tmp LIBGL_ALWAYS_SOFTWARE=1 \
+    chroot "$wrapper_root" /usr/bin/xvfb-run -a /glxinfo-test -B \
+    >"$wrapper_root/wrapper-glxinfo"
+  grep -q 'OpenGL renderer string: llvmpipe' "$wrapper_root/wrapper-glxinfo"
+
+  status=0
+  chroot "$wrapper_root" /usr/bin/xvfb-run -a /bin/sh -c 'exit 42' || status=$?
+  test "$status" -eq 42
+  test -z "$(find "$wrapper_root/tmp" -maxdepth 1 -name 'xvfb-run.*' -print)"


### PR DESCRIPTION
## Proposed changes

Add `xvfb_server` and the authenticated `xvfb_bins` (`xvfb-run`) wrapper, including XKB compilation/data, xauth, shell utilities and software GLX.

The graphics closure is largely backported from official Noble definitions, preserving libs/config defaults. Jammy uses LLVM15 and embeds Gallium in hardlinked DRI drivers. Driver names/architecture filters were checked against all seven Jammy package architectures; full driver names share storage (13 links on amd64). Also fix libunwind8's missing GCC runtime dependency.

### Compatibility decision required

**Chisel >=1.3 is required** for the existing `v3-essential` backport syntax. **Chisel 1.1/1.2 silently omit architecture-specific dependencies and can produce unusable filesystems.** Old-client cut-only CI is not runtime compatibility. Unconditional Intel DRM/unwind dependencies are not portable because Ubuntu does not publish them on every architecture.

Please approve the minimum client version or determine the release/CI policy before merging. Affected definitions contain explicit warnings.

Software GLX remains enabled, matching official libGL/libGLX policy. This is not a minimal X11-only image; changing shared vendor selection is separate work.

### Validation

On Ubuntu 22.04 amd64, task execute bodies passed with Chisel 1.4.2 and the unchanged repository helper, including manifests:

- Separate server/wrapper roots: 640x480, depth 24 and llvmpipe using only sliced libraries.
- Authenticated xvfb-run client, exit-status 42 propagation and auth-directory cleanup.
- Standalone US keyboard compilation/decompilation.
- Repository YAML lint, changed-slice ordering and whitespace checks.

Server/wrapper roots measured 210/220 MiB, including copied test executables. Earlier non-amd64 cut/static audits and package checks are **not native runtime validation**. Full Spread and native non-amd64 runtime were not run locally.

```sh
spread -v docker:ubuntu-22.04-amd64:tests/spread/integration/xvfb
spread -v docker:ubuntu-22.04-amd64:tests/spread/integration/x11-xkb-utils
```

### AI usage

Codex agents did most implementation, testing and PR writing. Claude Opus independently reviewed the Jammy work; Codex addressed findings and forward-ported the changes. The contributor directed the work and approved submission.

### Related release PRs

22.04: #1177 · 24.04: #1175 · 26.04: #1174 · 26.10: #1176 (manifest blocker; keep draft). No merge-order dependency.

### Checklist

- [x] Read the [contributing guidelines](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md).
- [x] Tested changes (scope and limitations above).
- [x] Submitted the [Canonical CLA](https://ubuntu.com/legal/contributors/agreement).
