### PR TITLE
feat(26.10): add `libpulse0` and `libsndfile1` slices

### DIFF
--- a/slices/libpulse0.yaml
+++ b/slices/libpulse0.yaml
@@ -1,0 +1,29 @@
+package: libpulse0
+
+essential:
+  libpulse0_copyright:
+
+slices:
+  config:
+    contents:
+      /etc/pulse/client.conf:
+
+  libs:
+    essential:
+      libapparmor1_libs:
+      libasyncns0_libs:
+      libc6_libs:
+      libdbus-1-3_libs:
+      libsndfile1_libs:
+      libsystemd0_libs:
+      libx11-6_libs:
+      libx11-xcb1_libs:
+      libxcb1_libs:
+    contents:
+      /usr/lib/*-linux-*/libpulse-simple.so.0*:
+      /usr/lib/*-linux-*/libpulse.so.0*:
+      /usr/lib/*-linux-*/pulseaudio/libpulsecommon-*.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/libpulse0/copyright:

--- a/slices/libsndfile1.yaml
+++ b/slices/libsndfile1.yaml
@@ -1,0 +1,22 @@
+package: libsndfile1
+
+essential:
+  libsndfile1_copyright:
+
+slices:
+  libs:
+    essential:
+      libc6_libs:
+      libflac14_libs:
+      libmp3lame0_libs:
+      libmpg123-0t64_libs:
+      libogg0_libs:
+      libopus0_libs:
+      libvorbis0a_libs:
+      libvorbisenc2_libs:
+    contents:
+      /usr/lib/*-linux-*/libsndfile.so.1*:
+
+  copyright:
+    contents:
+      /usr/share/doc/libsndfile1/copyright:

--- a/tests/spread/integration/libpulse0/task.yaml
+++ b/tests/spread/integration/libpulse0/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for libpulse0
+
+execute: |
+  rootfs="$(install-slices libpulse0_libs)"
+  libdir="$(find "$rootfs/usr/lib" -maxdepth 1 -type d -name '*-linux-*')"
+  loader="$(find "$libdir" -maxdepth 1 -name 'ld*.so.*')"
+  chroot "$rootfs" "${loader#"$rootfs"}" --list "${libdir#"$rootfs"}/libpulse.so.0"

--- a/tests/spread/integration/libsndfile1/task.yaml
+++ b/tests/spread/integration/libsndfile1/task.yaml
@@ -1,0 +1,7 @@
+summary: Integration tests for libsndfile1
+
+execute: |
+  rootfs="$(install-slices libsndfile1_libs)"
+  libdir="$(find "$rootfs/usr/lib" -maxdepth 1 -type d -name '*-linux-*')"
+  loader="$(find "$libdir" -maxdepth 1 -name 'ld*.so.*')"
+  chroot "$rootfs" "${loader#"$rootfs"}" --list "${libdir#"$rootfs"}/libsndfile.so.1"


### PR DESCRIPTION
# Proposed changes

forward port of https://github.com/canonical/chisel-releases/pull/1178

## Related issues/PRs

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1178
- https://github.com/canonical/chisel-releases/pull/1179 **(this PR)**

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)