### PR TITLE
chore(26.10): disable manifest cuts in spread

### DIFF
--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -15,8 +15,10 @@ trap 'rm -f "$_OUTPUT"' EXIT
 
 function main() {
     local slices="$*"
+    # manifest generation is broken on sha512-only archives, see
+    # https://github.com/canonical/chisel/issues/305. restore once chisel 1.5.1 lands.
     # add base-files_chisel slice to ensure we generate the manifest
-    slices="${slices} base-files_chisel"
+    # slices="${slices} base-files_chisel"
 
     # chrooted daemons that drop privileges need the path to stay traversable
     #shellcheck disable=SC2174 # the parent always exists, only the leaf is created
@@ -25,7 +27,7 @@ function main() {
     local rootfs
     rootfs="$(mktemp -d -p "$ROOTFS_DIR")"
     chisel_cut "$rootfs" "$slices"
-    if [ -n "$MANIFESTS_EXPORT_DIR" ]; then
+    if [ -n "$MANIFESTS_EXPORT_DIR" ] && [ -f "$rootfs/var/lib/chisel/manifest.wall" ]; then
         export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"
     fi
 

--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -15,8 +15,9 @@ trap 'rm -f "$_OUTPUT"' EXIT
 
 function main() {
     local slices="$*"
-    # manifest generation is broken on sha512-only archives, see
-    # https://github.com/canonical/chisel/issues/305. restore once chisel 1.5.1 lands.
+    # TODO: manifest generation is broken on sha512-only archives. restore the
+    # line below once https://github.com/canonical/chisel/issues/305 is fixed.
+
     # add base-files_chisel slice to ensure we generate the manifest
     # slices="${slices} base-files_chisel"
 


### PR DESCRIPTION
# Proposed changes

manifest generation is broken in chisel 1.5.0. to unblock chisel-releases work on 26.10, this PR temporarily disables manifest generation. the upshot is that we dont get the coverage report.

## Related issues/PRs

- revert this once https://github.com/canonical/chisel/issues/305 is fixed

### Forward porting

n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)