### PR TITLE
chore(26.10): reenable manifest cuts in spread

### DIFF
--- a/tests/spread/lib/install-slices
+++ b/tests/spread/lib/install-slices
@@ -15,11 +15,8 @@ trap 'rm -f "$_OUTPUT"' EXIT
 
 function main() {
     local slices="$*"
-    # TODO: manifest generation is broken on sha512-only archives. restore the
-    # line below once https://github.com/canonical/chisel/issues/305 is fixed.
-
     # add base-files_chisel slice to ensure we generate the manifest
-    # slices="${slices} base-files_chisel"
+    slices="${slices} base-files_chisel"
 
     # chrooted daemons that drop privileges need the path to stay traversable
     #shellcheck disable=SC2174 # the parent always exists, only the leaf is created
@@ -28,7 +25,7 @@ function main() {
     local rootfs
     rootfs="$(mktemp -d -p "$ROOTFS_DIR")"
     chisel_cut "$rootfs" "$slices"
-    if [ -n "$MANIFESTS_EXPORT_DIR" ] && [ -f "$rootfs/var/lib/chisel/manifest.wall" ]; then
+    if [ -n "$MANIFESTS_EXPORT_DIR" ]; then
         export_manifests "$rootfs" "$MANIFESTS_EXPORT_DIR"
     fi
 


### PR DESCRIPTION
# Proposed changes

reenable manifest cuts. reverts https://github.com/canonical/chisel-releases/pull/1180

> I really don't want to forget about this :sweat_smile: 
> 
> **pls create the "Revert" PR already, leaving it as blocked**

_Originally posted by @cjdcordeiro in https://github.com/canonical/chisel-releases/pull/1180#pullrequestreview-5129514832_

blocked on https://github.com/canonical/chisel/issues/305

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)