### PR TITLE
fix(26.04): tomcat10 copyright ships nothing

### DIFF
--- a/slices/tomcat10.yaml
+++ b/slices/tomcat10.yaml
@@ -48,5 +48,5 @@ slices:
       tomcat10_standard:
 
   copyright:
-    content:
+    contents:
       /usr/share/doc/tomcat10/copyright:


### PR DESCRIPTION
# Proposed changes

Resolve issue noticed by @lczyk - mispelled `contents` key in tomcat10 copyright 

## Related issues/PRs


### Forward porting

https://github.com/canonical/chisel-releases/pull/1184


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)

<!-- Note that Chisel Releases, as well as Chisel itself, are both licensed under AGPLv3. See https://github.com/canonical/chisel-releases/blob/main/LICENSE -->

## Additional Context
<!-- If relevant -->