### PR TITLE
fix(24.04): tomcat10 copyright ships nothing

### DIFF
--- a/slices/tomcat10.yaml
+++ b/slices/tomcat10.yaml
@@ -48,5 +48,5 @@ slices:
       - tomcat10_standard
 
   copyright:
-    content:
+    contents:
       /usr/share/doc/tomcat10/copyright:


### PR DESCRIPTION
# Proposed changes

rename to the correct key name ( chisel ignores unknown key names ) so the copyright slice ships copyright.

## Related issues/PRs

### Forward porting

- https://github.com/canonical/chisel-releases/pull/1183
- https://github.com/canonical/chisel-releases/pull/1141

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
