### PR TITLE
chore(26.10): more libssl4

### DIFF
--- a/slices/apache2-bin.yaml
+++ b/slices/apache2-bin.yaml
@@ -23,7 +23,7 @@ slices:
       libldap2_libs:
       liblua5.4-0_libs:
       libnghttp2-14_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libxml2-16_libs:
       zlib1g_libs:
     contents:

--- a/slices/apt.yaml
+++ b/slices/apt.yaml
@@ -28,7 +28,7 @@ slices:
       libgcc-s1_libs:
       libgnutls30t64_libs:
       libseccomp2_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libstdc++6_libs:
       libsystemd0_libs:
     contents:

--- a/slices/bind9-libs.yaml
+++ b/slices/bind9-libs.yaml
@@ -14,7 +14,7 @@ slices:
       liblmdb0_libs:
       libmaxminddb0_libs:
       libnghttp2-14_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       liburcu8t64_libs:
       libuv1t64_libs:
       libxml2-16_libs:

--- a/slices/bind9-utils.yaml
+++ b/slices/bind9-utils.yaml
@@ -35,7 +35,7 @@ slices:
       bind9-libs_libs:
       libc6_libs:
       libjemalloc2_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       liburcu8t64_libs:
     contents:
       /usr/bin/dnssec-cds:

--- a/slices/bind9.yaml
+++ b/slices/bind9.yaml
@@ -55,7 +55,7 @@ slices:
       liblmdb0_libs:
       libmaxminddb0_libs:
       libnghttp2-14_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       liburcu8t64_libs:
       libuv1t64_libs:
       libxml2-16_libs:

--- a/slices/dotnet-apphost-pack-10.0.yaml
+++ b/slices/dotnet-apphost-pack-10.0.yaml
@@ -9,7 +9,7 @@ slices:
       libbrotli1_libs: {arch: [amd64, arm64]}
       libc6_libs:
       libgcc-s1_libs:
-      libssl3t64_libs: {arch: [amd64, arm64]}
+      libssl4_libs: {arch: [amd64, arm64]}
       libstdc++6_libs:
       libunwind8_libs: {arch: [amd64]}
       zlib1g_libs: {arch: [amd64, arm64]}

--- a/slices/dotnet-runtime-10.0.yaml
+++ b/slices/dotnet-runtime-10.0.yaml
@@ -39,7 +39,7 @@ slices:
       dotnet-runtime-10.0_minimal:
       libbrotli1_libs:
       liblttng-ust1t64_libs: {arch: [amd64, arm64]}
-      libssl3t64_libs:
+      libssl4_libs:
       zlib1g_libs:
     contents:
       /usr/lib/dotnet/shared/Microsoft.NETCore.App/10.0.*/**:

--- a/slices/dotnet-sdk-aot-10.0.yaml
+++ b/slices/dotnet-sdk-aot-10.0.yaml
@@ -10,7 +10,7 @@ slices:
       libbrotli1_libs:
       libc6_libs:
       libgcc-s1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libstdc++6_libs:
       libunwind8_libs: {arch: [amd64]}
       zlib1g_libs:

--- a/slices/gnu-coreutils.yaml
+++ b/slices/gnu-coreutils.yaml
@@ -88,7 +88,7 @@ slices:
   summarizing-files:
     essential:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/bin/gnub2sum:
       /usr/bin/gnucksum:
@@ -108,7 +108,7 @@ slices:
     essential:
       gnu-coreutils_sort:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/bin/gnucomm:
       /usr/bin/gnuptx:

--- a/slices/httping.yaml
+++ b/slices/httping.yaml
@@ -9,7 +9,7 @@ slices:
       libc6_libs:
       libfftw3-double3_libs:
       libncursesw6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libtinfo6_libs:
       openssl_bins:
     contents:

--- a/slices/libaprutil1t64.yaml
+++ b/slices/libaprutil1t64.yaml
@@ -12,7 +12,7 @@ slices:
       libdb5.3t64_libs:
       libexpat1_libs:
       libgdbm6t64_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/lib/*-linux-*/apr-util-1/apr_crypto_openssl*.so:
       /usr/lib/*-linux-*/apr-util-1/apr_dbm_db*.so:

--- a/slices/libapt-pkg7.0.yaml
+++ b/slices/libapt-pkg7.0.yaml
@@ -11,7 +11,7 @@ slices:
       libgcc-s1_libs:
       liblz4-1_libs:
       liblzma5_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libstdc++6_libs:
       libsystemd0_libs:
       libudev1_libs:

--- a/slices/libcryptsetup12.yaml
+++ b/slices/libcryptsetup12.yaml
@@ -10,7 +10,7 @@ slices:
       libc6_libs:
       libdevmapper1.02.1_libs:
       libjson-c5_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libuuid1_libs:
     contents:
       /usr/lib/*-linux-*/libcryptsetup.so.12*:

--- a/slices/libfido2-1.yaml
+++ b/slices/libfido2-1.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_libs:
       libcbor0.10_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libudev1_libs:
       zlib1g_libs:
     contents:

--- a/slices/libgit2-1.9.yaml
+++ b/slices/libgit2-1.9.yaml
@@ -10,7 +10,7 @@ slices:
       libgssapi-krb5-2_libs:
       libpcre2-8-0_libs:
       libssh2-1t64_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       zlib1g_libs:
     contents:
       /usr/lib/*-linux-*/libgit2.so.1.9*:

--- a/slices/libkmod2.yaml
+++ b/slices/libkmod2.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_libs:
       liblzma5_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libzstd1_libs:
     contents:
       /usr/lib/*-linux-*/libkmod.so.2*:

--- a/slices/libmosquitto1.yaml
+++ b/slices/libmosquitto1.yaml
@@ -7,7 +7,7 @@ slices:
   libs:
     essential:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/lib/*-linux-*/libmosquitto.so.1:
       /usr/lib/*-linux-*/libmosquitto.so.2.*:

--- a/slices/librabbitmq4.yaml
+++ b/slices/librabbitmq4.yaml
@@ -7,7 +7,7 @@ slices:
   libs:
     essential:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/lib/*-linux-*/librabbitmq.so.4*:
 

--- a/slices/librdkafka1.yaml
+++ b/slices/librdkafka1.yaml
@@ -10,7 +10,7 @@ slices:
       libcurl4t64_libs:
       liblz4-1_libs:
       libsasl2-2_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libzstd1_libs:
       zlib1g_libs:
     contents:

--- a/slices/libssh-4.yaml
+++ b/slices/libssh-4.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_libs:
       libgssapi-krb5-2_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       zlib1g_libs:
     contents:
       /usr/lib/*-linux-*/libssh.so.4*:

--- a/slices/libssh2-1t64.yaml
+++ b/slices/libssh2-1t64.yaml
@@ -7,7 +7,7 @@ slices:
   libs:
     essential:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       zlib1g_libs:
     contents:
       /usr/lib/*-linux-*/libssh2.so.1*:

--- a/slices/libsystemd-shared.yaml
+++ b/slices/libsystemd-shared.yaml
@@ -16,7 +16,7 @@ slices:
       libpam0g_libs:
       libseccomp2_libs:
       libselinux1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/lib/*-linux-*/systemd/libsystemd-core-*.so:
       /usr/lib/*-linux-*/systemd/libsystemd-shared-*.so:

--- a/slices/libsystemd-shared.yaml
+++ b/slices/libsystemd-shared.yaml
@@ -16,6 +16,7 @@ slices:
       libpam0g_libs:
       libseccomp2_libs:
       libselinux1_libs:
+      # dlopened, and the package accepts libssl3t64 | libssl4
       libssl4_libs:
     contents:
       /usr/lib/*-linux-*/systemd/libsystemd-core-*.so:

--- a/slices/libtcnative-2.yaml
+++ b/slices/libtcnative-2.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libapr1t64_libs:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/lib/*-linux-*/libtcnative-2.so*:
 

--- a/slices/libwebsockets19t64.yaml
+++ b/slices/libwebsockets19t64.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_libs:
       libcap2_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       zlib1g_libs:
     contents:
       /usr/lib/*-linux-*/libwebsockets.so.19*:

--- a/slices/memcached.yaml
+++ b/slices/memcached.yaml
@@ -10,7 +10,7 @@ slices:
       libevent-2.1-7t64_libs:
       liblua5.4-0_libs:
       libsasl2-2_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       memcached_config:
     contents:
       /usr/bin/memcached:

--- a/slices/mosquitto-clients.yaml
+++ b/slices/mosquitto-clients.yaml
@@ -9,6 +9,7 @@ slices:
       libc6_libs:
       libcjson1_libs:
       libmosquitto1_libs:
+      libssl4_libs:
     contents:
       /usr/bin/mosquitto_pub:
       /usr/bin/mosquitto_rr:

--- a/slices/mosquitto.yaml
+++ b/slices/mosquitto.yaml
@@ -10,7 +10,7 @@ slices:
       libcjson1_libs:
       libdlt3_libs:
       libmosquitto1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libsystemd0_libs:
       libwebsockets19t64_libs:
       libwrap0_libs:
@@ -20,7 +20,7 @@ slices:
       mosquitto_logs:
     contents:
       # For future reference, these binaries can also be put in their own "tools" slice,
-      # and depend on libc6_libs, libcjson1_libs. libmosquitto1_libs, libssl3t64_libs
+      # and depend on libc6_libs, libcjson1_libs. libmosquitto1_libs, libssl4_libs
       /usr/bin/mosquitto_ctrl:
       /usr/bin/mosquitto_passwd:
       /usr/sbin/mosquitto:
@@ -37,7 +37,7 @@ slices:
     essential:
       libc6_libs:
       libcjson1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
     contents:
       /usr/lib/*-linux-*/mosquitto_dynamic_security.so:
 

--- a/slices/openssh-client.yaml
+++ b/slices/openssh-client.yaml
@@ -16,7 +16,7 @@ slices:
       libfido2-1_libs:
       libgssapi-krb5-2_libs:
       libselinux1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       passwd_config:
       zlib1g_libs:
     contents:

--- a/slices/openssh-server.yaml
+++ b/slices/openssh-server.yaml
@@ -20,7 +20,7 @@ slices:
       libpam-runtime_config:
       libpam0g_libs:
       libselinux1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libwrap0_libs:
       openssh-client_bins:
       openssh-sftp-server_bins:

--- a/slices/openssl-provider-legacy.yaml
+++ b/slices/openssl-provider-legacy.yaml
@@ -7,7 +7,7 @@ slices:
   libs:
     essential:
       libc6_libs:
-      # libssl3t64_libs: # prevent circular dependency with libssl3t64
+      # libssl4_libs: # prevent circular dependency with libssl4
     contents:
       /usr/lib/*-linux-*/ossl-modules/legacy.so:
 

--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_config:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       openssl_config:
       openssl_data:
     contents:
@@ -36,6 +36,6 @@ slices:
 
   copyright:
     essential:
-      libssl3t64_copyright:
+      libssl4_copyright:
     contents:
       /usr/share/doc/openssl/copyright:

--- a/slices/php8.5-cli.yaml
+++ b/slices/php8.5-cli.yaml
@@ -13,7 +13,7 @@ slices:
         arch: [amd64]
       libpcre2-8-0_libs:
       libsodium23_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libxml2-16_libs:
       media-types_data:
       php-common_session:

--- a/slices/php8.5-common.yaml
+++ b/slices/php8.5-common.yaml
@@ -8,7 +8,7 @@ slices:
     essential:
       libc6_libs:
       libffi8_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       php8.5-common_module-config:
     contents:
       /usr/lib/php/*/calendar.so:

--- a/slices/redis-tools.yaml
+++ b/slices/redis-tools.yaml
@@ -13,7 +13,7 @@ slices:
       libc6_libs:
       libjemalloc2_libs:
       liblzf1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libsystemd0_libs:
     contents:
       /usr/bin/redis-benchmark:

--- a/slices/sbsigntool.yaml
+++ b/slices/sbsigntool.yaml
@@ -7,7 +7,7 @@ slices:
   bins:
     essential:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libuuid1_libs:
     contents:
       /usr/bin/kmodsign:

--- a/slices/sudo.yaml
+++ b/slices/sudo.yaml
@@ -12,7 +12,7 @@ slices:
       libpam-modules_libs:
       libpam0g_libs:
       libselinux1_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       sudo_config:
       sudo_libs:
       zlib1g_libs:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -191,7 +191,7 @@ slices:
     hint: Manage network configuration
     essential:
       libc6_libs:
-      libssl3t64_libs:
+      libssl4_libs:
       libsystemd-shared_libs:
       systemd_config:
       systemd_network-config:

--- a/slices/systemd.yaml
+++ b/slices/systemd.yaml
@@ -191,6 +191,7 @@ slices:
     hint: Manage network configuration
     essential:
       libc6_libs:
+      # dlopened, and the package accepts libssl3t64 | libssl4
       libssl4_libs:
       libsystemd-shared_libs:
       systemd_config:


### PR DESCRIPTION
# Proposed changes

26.10 has ossl4 alongside ossl3 and most of the archive has been rebuilt against 4. This PR updates more slices to use ossl4.

A bunch were still deliberately open on ossl4 since the transition is in progress: https://transitions.ubuntu.com/html/openssl4.html#good,bad,partial,unknown,!notintesting

## Related issues/PRs

### Forward porting

n/a

## Checklist

* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)
